### PR TITLE
ci: surface real crates.io publish failures (engine pypi.yml)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -108,6 +108,27 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # Idempotent crates.io publish.  Replaces a blanket
+      # `continue-on-error: true` that previously swallowed real publish
+      # failures (mirrors the yantrikos/yantrikdb-server v0.7.3 silent-failure
+      # incident).  exit 0 on success OR if the version is already published;
+      # exit non-zero on any other failure so the workflow status surfaces it.
       - name: Publish to crates.io
-        continue-on-error: true
-        run: cargo publish -p yantrikdb --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set +e
+          out="$(cargo publish -p yantrikdb 2>&1)"
+          rc=$?
+          set -e
+          echo "$out"
+          if [[ $rc -eq 0 ]]; then
+            echo "::notice::yantrikdb: published to crates.io"
+            exit 0
+          fi
+          if echo "$out" | grep -qE "already exists on crates\.io"; then
+            echo "::notice::yantrikdb: already published at this version (idempotent re-run)"
+            exit 0
+          fi
+          echo "::error::yantrikdb: crates.io publish failed for a non-idempotent reason"
+          exit "$rc"


### PR DESCRIPTION
Same fix as yantrikos/yantrikdb-server#15, applied to the engine's pypi.yml.

## Why

The `publish-crates` job had `continue-on-error: true` on its `cargo publish` step. That swallowed any real publish failure — manifest invalid, auth, network, registry rejection — exactly the same way it did on yantrikdb-server v0.7.3 (where a missing dependency-version-spec silently kept crates.io at v0.7.2 despite the workflow reporting success).

## Fix

Idempotent semantics inline:

```bash
out=$(cargo publish -p yantrikdb 2>&1)
if rc=0: success → exit 0
if "already exists on crates.io" in stderr: idempotent re-run → exit 0
else: real failure → exit non-zero, ::error:: annotation
```

## Compatibility

- **Healthy releases**: identical behaviour.
- **Re-running against an already-published tag**: identical behaviour (idempotent).
- **Genuine failures**: NOW correctly fails the workflow status. Before, hidden.

The PyPI step (line 96, uses `PyO3/maturin-action@v1` with `--skip-existing`) already had proper idempotent semantics. This brings the crates.io step to parity.

## No release tag required

Workflow-only change. Takes effect on the next `v*` tag push.