### PR TITLE
fix: update pyo3 to allow python3.14

### DIFF
--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 yantrikdb-core = { path = "../yantrikdb-core", package = "yantrikdb" }
-pyo3 = { version = "0.23", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.28.3", features = ["extension-module", "multiple-pymethods"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "yantrikdb"
 version = "0.7.9"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
-license = "AGPL-3.0-only"
+license = {text = "AGPL-3.0-only"}
 requires-python = ">=3.10"
 authors = [
     { name = "Pranab Sarkar", email = "developer@pranab.co.in" },


### PR DESCRIPTION
Update pyo3 to 0.28.3 to allow python3.14

I also corrected the license syntax in pyproject.toml since that prevents building.