### PR TITLE
release: v0.7.12 — version bump for PR #14 contents

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.7.11"
+version = "0.7.12"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.7.11"
+version = "0.7.12"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## What

Pure version bump from 0.7.11 → 0.7.12 across 4 manifests:
- crates/yantrikdb-core/Cargo.toml
- crates/yantrikdb-python/Cargo.toml
- crates/yantrikdb-python/pyproject.toml
- pyproject.toml

## Why a release

PR #14 (commit 139dc1a) landed substantive user-impact and engine fixes that warrant a tag:

1. **`yantrikdb import <export.json>` was broken for edges** since V16→V17 migration ~2026-04. CLI tried `INSERT INTO edges` but edges is a backward-compat VIEW; SQLite rejects. Now writes to `claims` table directly. Caught only because pytest started running in CI for the first time today.

2. **Engine recall.rs E0502 borrow check error** in a feature-gated code path. Failed `cargo clippy --all-features`. Fixed via HashSet<String> instead of HashSet<&str>.

3. **`[mcp]` optional extra added** so `pip install yantrikdb[all]` includes the mcp package for MCP integration users (previously they had to install separately).

Plus stale-test fixes, compactor flake fix, CI workflow softening, CONTRIBUTORS.md, .pylintrc, .gitignore for build artifacts.

## After merge

Tag `v0.7.12` from main, which triggers `pypi.yml` workflow (wheels for py3.10-3.14 × 5 platforms + crates.io publish + SLSA provenance attestation).

## Verification

- cargo build -p yantrikdb: clean
- pylint src/yantrikdb tests/ --disable=C,R,W --enable=E,F: exit 0
- (PR #14's full CI ran green on 139dc1a for required checks; this PR adds 4 lines of version bumps)