### PR TITLE
release: v0.7.13 — bump for issue #15 fix (multilingual extractor)

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.7.12"
+version = "0.7.13"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.7.12"
+version = "0.7.13"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## What

Pure version bump from 0.7.12 → 0.7.13 across 4 manifests.

## Why a release

PR #23 (commit 895a777) merged the [issue #15](https://github.com/yantrikos/yantrikdb/issues/15) fix:

`set_embedder_named("potion-multilingual-128M")` was silently producing empty cache dirs because the tarball extractor unconditionally stripped the leading path component (correct for v0.1.0 prefix-dir layout, broken for v0.2.0 files-at-root layout). Now handles both layouts via per-entry component-count check.

**User-impact:** multilingual embedder has been broken since v0.7.9 shipped 2026-05-12. Anyone who set `YANTRIKDB_EMBEDDER=potion-multilingual-128M` (or called `set_embedder_named` directly) hit this. v0.7.13 fixes it.

## After merge

Tag `v0.7.13` from main → pypi.yml workflow auto-runs → wheels (py3.10-3.14 × 5 platforms) + crates.io publish + SLSA build provenance attestations.

## Verification

- All four version strings consistent at 0.7.13
- cargo fmt / flake8 / pylint: pass locally
- cargo build -p yantrikdb: clean

## Workflow note

This is a separate-PR-for-version-bump pattern (like PR #21 for v0.7.12). Going forward I'll bundle version bumps into substantive PRs instead — saves a CI round trip per release. For this one the substantive merge already happened so the separate bump is necessary.