### PR TITLE
release: v0.7.15 — restore missing extract call (closes #26) + fix sdist LICENSE path

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.7.14"
+version = "0.7.15"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-core/src/embedder/downloaded.rs
+++ b/crates/yantrikdb-core/src/embedder/downloaded.rs
@@ -252,6 +252,21 @@ fn fetch_and_extract(model: &DownloadableModel, name: &str) -> Result<PathBuf> {
         YantrikDbError::InvalidInput(format!("mkdir tmp {}: {e}", tmp_dir.display()))
     })?;
 
+    // **Closes #26.** Restored the call to extract_tarball_to that PR #23's
+    // refactor accidentally swallowed. The helper was correctly defined +
+    // unit-tested for both v0.1.0-prefix and v0.2.0-files-at-root layouts,
+    // but never invoked from fetch_and_extract — so cache_is_populated()
+    // always failed and set_embedder_named() returned "expected files
+    // missing" for ALL named models in v0.7.13/v0.7.14, not just the
+    // multilingual one. Same class of gap as v0.7.9's user-side-smoke
+    // failure that filed #15 in the first place. The cleanup-on-error
+    // arm leaves no half-written tmp_dir lying around if extraction
+    // fails partway.
+    extract_tarball_to(&bytes, &tmp_dir).map_err(|e| {
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+        e
+    })?;
+
     // Final move: rename tmp_dir → final_dir. If a concurrent process
     // beat us to it, both renames may run; the second one fails and we
     // accept whatever's already there.

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.7.14"
+version = "0.7.15"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.7.14"
+version = "0.7.15"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,19 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.7.14"
+version = "0.7.15"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"
+# Explicitly declare the LICENSE file for PEP 639 compliance. Without
+# this, maturin's sdist auto-detection found the duplicate copy at
+# crates/yantrikdb-python/LICENSE and packaged it at that nested path
+# (yantrikdb-0.7.14/crates/yantrikdb-python/LICENSE inside the sdist).
+# PyPI's metadata validator expects the License-File at the sdist root
+# (yantrikdb-0.7.14/LICENSE), and rejected v0.7.12/v0.7.13/v0.7.14
+# sdists with "License-File LICENSE does not exist in distribution
+# file." Closes #(this PR fixes the v0.7.14 sdist publish failure).
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 authors = [
     { name = "Pranab Sarkar", email = "developer@pranab.co.in" },


### PR DESCRIPTION
## Two regressions I introduced in recent releases. Both verified locally before push (this time).

### #26 — set_embedder_named never extracts (v0.7.13 regression)

PR #23's refactor accidentally swallowed the `extract_tarball_to(&bytes, &tmp_dir)?;` call site when deleting an adjacent comment block. The helper is defined + unit-tested but never invoked from `fetch_and_extract`. **Effect: every set_embedder_named() download in v0.7.13 and v0.7.14 created the tmp_dir but never extracted anything into it.** Worse than the original #15 (which only affected multilingual) — breaks ALL named-embedder downloads.

Fix: restore the call, with a cleanup-on-error arm that removes the half-written tmp_dir on extract failure.

### Sdist LICENSE-File path (v0.7.12/v0.7.13/v0.7.14 publish failure)

v0.7.14 attempted a fix by copying LICENSE into crates/yantrikdb-python/, but local sdist verification (which I didn't run before claiming v0.7.14 fixed it) shows the duplicate ended up at `yantrikdb-X.Y.Z/crates/yantrikdb-python/LICENSE` inside the sdist, NOT at the sdist root.

Fix: declare `license-files = ["LICENSE"]` in `[project]` of root pyproject.toml. PEP 639-compliant approach tells maturin to package the listed file at the sdist root.

**Locally verified:**
```
$ tar -tzf yantrikdb-0.7.15.tar.gz | grep -i license
yantrikdb-0.7.15/LICENSE                          ← at sdist root ✓
yantrikdb-0.7.15/crates/yantrikdb-python/LICENSE  ← duplicate (harmless)
```

## Verification (full local CI sweep, all green before push)

- `maturin sdist` → `tar -tzf | grep LICENSE`: at `yantrikdb-0.7.15/LICENSE` (the actual PyPI rejection surface)
- cargo fmt: PASS
- flake8 + pylint: clean
- cargo clippy --all-targets: clean warnings
- cargo test (default 1422 / slim 1411)
- pytest tests/: 220 passed
- maturin develop --release: clean

## Discipline note

Both regressions had the **same root cause**: I claimed a fix was in place without running the actual verification that catches the failure. For #26 the unit tests covered the helper but not integration. For LICENSE the v0.7.14 cargo build/test were green but I never ran `maturin sdist` + tar inspection — which is the literal thing PyPI does.

Closes #26.