### PR TITLE
release: v0.7.16 — v26 schema migration foundation (closes #29)

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.7.15"
+version = "0.7.16"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.7.15"
+version = "0.7.16"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.7.15"
+version = "0.7.16"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.7.15"
+version = "0.7.16"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
**Foundation-only release.** Cuts a stable tag for the v26 schema migration shipped in #35, so downstream consumers (yantrikdb-server, anyone pinned to the engine via tag) can pick it up without floating their pin against `main`.

## What ships in v0.7.16

- **v26 schema migration** (closes #29 via PR #35). Adds 4 additive columns on `memories` for conflict-aware-write provenance metadata — `prior_rid`, `resolution_kind`, `dismissal_reason`, `confidence_at_write` — plus 2 partial indexes for the resolution/supersession query patterns + source-enum normalization. Pure foundation: columns are NULL on every existing row, not yet populated by any write path. The WriteResolution API (#30) lands in a future release and will start populating them.

## What is **not** in this release

- No new public engine API. Byte-equivalent at the runtime surface to v0.7.15 from the agent caller's perspective; only the schema layout is extended.
- No yantrikdb-server changes (that ships separately; latest is v0.8.15 which addressed issue #37, unrelated to this release).

## Why a release just for schema?

The v0.7.x cadence is "every shipped change → tag" (see v0.7.13, v0.7.14 — both small/foundation releases bumping for a single PR). Floating yantrikdb-server's engine pin against engine `main` is risky; tagging v0.7.16 gives the next server release a stable point to depend on when #30 lands.

## Migration impact

**Zero.** Migration is purely additive (`ALTER TABLE ADD COLUMN` x4 + `CREATE INDEX IF NOT EXISTS` x2 + idempotent `UPDATE` on non-enum source values). Replay-safe per the v0.7.3 idempotent runner contract.

Three behavioral tests pin the contract:
- `schema_v26_fresh_install_has_provenance_columns_and_indexes`
- `schema_v26_migration_from_v25_adds_columns_and_normalizes_source`
- `schema_v26_migration_replay_is_idempotent`

## Pre-push verification

- `cargo fmt --check`: clean
- `cargo test --workspace --exclude yantrikdb-python --no-default-features`: 1414 passed, 0 failed (slim)
- `cargo test --workspace --exclude yantrikdb-python` (default features): 1425 passed, 0 failed
- Cargo.lock auto-regenerated to 0.7.16 (not committed — gitignored per repo convention)

## Files changed

| File | Change |
|---|---|
| `crates/yantrikdb-core/Cargo.toml` | `0.7.15` → `0.7.16` |
| `crates/yantrikdb-python/Cargo.toml` | `0.7.15` → `0.7.16` |
| `crates/yantrikdb-python/pyproject.toml` | `0.7.15` → `0.7.16` |
| `pyproject.toml` | `0.7.15` → `0.7.16` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)