### PR TITLE
feat(reembed): db.reembed() — engine-side embedder migration with atomic swap (closes #41)

### DIFF
--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -35,6 +35,52 @@ pub enum YantrikDbError {
     #[error("session conflict: {0}")]
     SessionConflict(String),
 
+    /// **Issue #41 / brainstorm-3.** `set_embedder*` was called with a
+    /// candidate embedder whose dimensionality differs from the active
+    /// index. On a populated DB this would produce silent corruption
+    /// (next insert mismatches HNSW's expected dim) so the engine
+    /// rejects. Caller's correct path is `db.reembed(new_embedder_name)`
+    /// which rebuilds the index under the new dim.
+    #[error(
+        "embedder dimensionality change requires db.reembed(): \
+         active index dim is {active_dim} ({memory_count} memories already indexed); \
+         candidate embedder dim is {candidate_dim}. \
+         Call db.reembed(new_embedder_name) to rebuild the index under the new dim."
+    )]
+    ChangeEmbedderDimensionRequiresReembed {
+        active_dim: usize,
+        candidate_dim: usize,
+        memory_count: u64,
+    },
+
+    /// **Issue #41 / brainstorm-3.** `set_embedder*` was called with a
+    /// candidate embedder whose fingerprint differs from the active
+    /// index's embedder, even though dim matches. Same-dim-different-
+    /// embedder is the silent-corruption case: queries encode under E1,
+    /// stored vectors are in E0's space, no panic but bad results.
+    /// Caller's correct path is `db.reembed(new_embedder_name)` to
+    /// re-encode existing memories under the new embedder.
+    ///
+    /// Returned only when the active index has `Known`-provenance. For
+    /// `ExternalOrUnknown` provenance (legacy DBs / external vector
+    /// imports) the same dim is accepted as a compat-attach without
+    /// claiming new provenance.
+    #[error(
+        "embedder change requires db.reembed(): \
+         active index built with embedder digest {active_digest:?}, \
+         candidate digest is {candidate_digest:?} (dim {dim} matches but model differs); \
+         {memory_count} memories already indexed in old embedder's vector space. \
+         Call db.reembed(new_embedder_name) to re-encode safely; \
+         a plain set_embedder() with a different model on a populated index \
+         would silently corrupt search results."
+    )]
+    ChangeEmbedderDigestRequiresReembed {
+        active_digest: Option<String>,
+        candidate_digest: Option<String>,
+        dim: usize,
+        memory_count: u64,
+    },
+
     /// **Decoupled write path RFC, Phase 1.**
     ///
     /// The bounded global ingest queue is full. Foreground writers receive

--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -128,6 +128,34 @@ pub enum YantrikDbError {
     #[error("embedding dimension mismatch: expected {expected}, got {got}")]
     EmbeddingDimensionMismatch { expected: usize, got: usize },
 
+    /// **Issue #41 brainstorm-4 §3 — monotonic-generation CAS.**
+    ///
+    /// `try_publish_search_state` rejects publish attempts whose
+    /// `new_state.generation` is strictly less than the
+    /// currently-active SearchState generation. This is the
+    /// brainstorm-4 §3 defense against compactor / reembed /
+    /// long-running write paths publishing stale work that would
+    /// ABA-rollback the active generation (durable data omission
+    /// when a generation regresses from N back to N-1 — the
+    /// post-swap materializer reapplies queued ops that were
+    /// already covered by generation N).
+    ///
+    /// Caller policy: re-load `search_state`, rebuild the proposed
+    /// state under the new active generation, retry. Reembed loops
+    /// abort the entire reembed (clear meta.reembed_state) and
+    /// require a fresh `db.reembed(...)` call from the operator —
+    /// silent retry inside reembed would mask a deeper concurrency
+    /// bug.
+    #[error(
+        "search state publish stale generation: current_generation={current_generation}, \
+         attempted_generation={attempted_generation}. Caller must re-read \
+         search_state and rebuild before retrying."
+    )]
+    SearchStatePublishStaleGeneration {
+        current_generation: u64,
+        attempted_generation: u64,
+    },
+
     #[error("invalid input: {0}")]
     InvalidInput(String),
 }

--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -1,4 +1,4 @@
-pub const SCHEMA_VERSION: i32 = 26;
+pub const SCHEMA_VERSION: i32 = 27;
 
 pub const SCHEMA_SQL: &str = "
 -- Memory records: the source of truth
@@ -56,7 +56,20 @@ CREATE TABLE IF NOT EXISTS memories (
     prior_rid TEXT,                            -- supersedes/updates/merges target rid; NULL for append_as_new
     resolution_kind TEXT,                      -- 'append' | 'update' | 'merge' | 'supersede' | 'dismiss'
     dismissal_reason TEXT,                     -- non-empty when resolution_kind='dismiss'; audit trail
-    confidence_at_write REAL                   -- substrate's conflict-confidence at write time, [0.0, 1.0]
+    confidence_at_write REAL,                  -- substrate's conflict-confidence at write time, [0.0, 1.0]
+
+    -- v27 (issue #41): staging columns for db.reembed() operation.
+    -- During Encoding phase, new embeddings are written here under the new
+    -- embedder. During Swap phase, an atomic transaction moves these into
+    -- the active `embedding` + `embedding_model` columns. Verifying phase
+    -- nulls them out. On non-reembed rows, both are NULL and cost is zero.
+    -- Pre-existing recall paths NEVER read these columns; only the reembed
+    -- machinery does. See the brainstorm comment chain on #41 for why a
+    -- two-column staging approach is required (recall re-reads active
+    -- `embedding` post-HNSW; in-place mutation would dim-mismatch concurrent
+    -- recalls).
+    embedding_new BLOB,                        -- pending new embedding bytes; NULL except during active reembed
+    embedding_new_model TEXT                   -- name of embedder that produced embedding_new; NULL when no pending reembed
 );
 -- v26 partial indexes for the resolution/supersession query patterns the
 -- WriteResolution API will exercise. Partial so they cost nothing on the
@@ -620,14 +633,52 @@ CREATE TABLE IF NOT EXISTS oplog (
     embedding_hash BLOB,                -- BLAKE3 hash of embedding (if applicable)
     origin_actor TEXT NOT NULL DEFAULT 'local', -- which device originally created this op
     applied INTEGER NOT NULL DEFAULT 1, -- 1 = materialized locally, 0 = pending
-    embedding BLOB                      -- v24: full embedding bytes for ingest replay (NULL for non-record ops)
+    embedding BLOB,                     -- v24: full embedding bytes for ingest replay (NULL for non-record ops)
+
+    -- v27 (issue #41): name of the embedder that produced the embedding
+    -- bytes above. Used by the materializer drain post-reembed-swap to
+    -- detect ops queued under the old embedder and re-encode them from
+    -- text. Pre-v27 ops have NULL here; materializer treats NULL as the
+    -- trust-embedding-as-is fallback for back-compat. Reembed Queue-mode
+    -- writes set this column on log_op_pending.
+    embedding_model TEXT,
+
+    -- v27 (issue #41, brainstorm-2 correction): per-generation application
+    -- tracking. Boolean `applied` above is ambiguous during reembed
+    -- (applied to OLD generation index? new? logical DB only?), so the
+    -- post-swap materializer cannot trust it. This column carries the
+    -- index generation the op was applied to. NULL means
+    -- never-applied-to-any-generation; the v27 materializer treats
+    -- NULL OR (applied_generation < current_generation) as needs-replay.
+    -- Boolean `applied` is kept as a derived hint for back-compat but is
+    -- no longer the truth.
+    applied_generation INTEGER
 );
+-- v27 index for the post-swap materializer query. Without this index,
+-- post-swap drain is a full oplog scan on every materializer wakeup.
+CREATE INDEX IF NOT EXISTS idx_oplog_applied_generation
+    ON oplog(applied_generation, op_id);
 
 -- Schema version tracking
 CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+-- v27 (issue #41): durable audit log of db.reembed() phase transitions.
+-- Authoritative source for crash recovery and observability. The
+-- in-memory on_phase_complete callback in ReembedOptions is best-effort
+-- only; this table is what the engine reads on open() to decide
+-- whether/how to resume an interrupted reembed. One row per (generation,
+-- phase) pair; phase strings are 'Probing' | 'Encoding' | 'Rebuilding'
+-- | 'Swapping' | 'Verifying' | 'Aborted' | 'Completed'.
+CREATE TABLE IF NOT EXISTS reembed_events (
+    generation   INTEGER NOT NULL,
+    phase        TEXT NOT NULL,
+    timestamp    REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_reembed_events_generation ON reembed_events(generation);
 
 -- Peer tracking for delta sync
 CREATE TABLE IF NOT EXISTS sync_peers (
@@ -1940,4 +1991,84 @@ UPDATE memories SET source = 'user'
     WHERE source NOT IN ('user', 'inference', 'document', 'system');
 CREATE INDEX IF NOT EXISTS idx_memories_prior_rid ON memories(prior_rid) WHERE prior_rid IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_memories_resolution_kind ON memories(resolution_kind) WHERE resolution_kind IS NOT NULL;
+";
+
+/// v26 → v27: foundation for `db.reembed()` operation (issue #41).
+///
+/// Three additive columns + one new audit-log table, all purely additive
+/// and replay-safe per the v0.7.3 idempotent runner contract.
+///
+/// ## On `memories`
+///
+/// - `embedding_new BLOB NULL` — staging column for new-embedder bytes
+///   written during the Encoding phase of `db.reembed()`. The active
+///   `embedding` column stays untouched throughout Encoding/Rebuilding,
+///   so concurrent recall traffic continues to score consistently against
+///   old-dim vectors. At the Swap phase, an atomic SQL transaction copies
+///   `embedding_new` → `embedding` (and clears the staging column) inside
+///   the same critical section as the `ArcSwap<SearchState>::store`. The
+///   Verifying phase ensures any remaining non-NULL staging values are
+///   cleaned up (defensive against partial failures).
+///
+///   Why two columns and not in-place mutation: the recall path
+///   (`fetch_embeddings_by_rids` in engine/recall.rs and ~13 sibling
+///   call-sites) re-reads `memories.embedding` AFTER HNSW returns
+///   candidate rids, to rescore via `serde_helpers::deserialize_f32`.
+///   In-place `UPDATE memories.embedding = <new-dim bytes>` during
+///   Encoding would cause concurrent recalls to deserialize new-dim
+///   bytes and compare them against old-dim query vectors. Garbage
+///   scores or panic on dim_mismatch. Verified by grep prior to
+///   shipping this migration; see the brainstorm comment chain on #41.
+///
+/// - `embedding_new_model TEXT NULL` — name of the embedder that
+///   produced `embedding_new`. Used by the Swap phase to populate
+///   `embedding_model` correctly, and by the reembed crash-recovery
+///   path on open() to verify the staged work matches the persisted
+///   `meta.reembed_state` target embedder.
+///
+/// ## On `oplog`
+///
+/// - `embedding_model TEXT NULL` — name of the embedder active when
+///   this oplog row's `embedding` BLOB (v24-added column) was produced.
+///   Necessary for Queue-mode reembed: when concurrent record() calls
+///   during reembed go through `log_op_pending`, they record the
+///   embedder name in this column. After the SearchState swap, the
+///   materializer drain compares each pending op's `embedding_model`
+///   against the active SearchState's embedder name. If they differ,
+///   the materializer re-encodes the op's text under the new embedder
+///   (ignoring the now-stale `oplog.embedding` bytes). If they match,
+///   the existing `oplog.embedding` is applied directly. Pre-v27 ops
+///   have NULL `embedding_model`; the materializer treats NULL as
+///   "trust embedding as-is" for backwards compatibility.
+///
+/// ## New table: `reembed_events`
+///
+/// Durable audit log of every phase transition during a `db.reembed()`
+/// call. Authoritative source of truth for crash recovery — on open(),
+/// the engine reads the latest non-Completed/non-Aborted event for the
+/// current generation in `meta.reembed_state` and resumes from there.
+///
+/// The in-memory `on_phase_complete` callback in `ReembedOptions` is
+/// best-effort notification only. If the process dies between callback
+/// invocation and the next phase transition, the callback's side
+/// effects might be lost — but `reembed_events` has the durable record.
+///
+/// One row per `(generation, phase)` pair. Phase strings match the
+/// `ReembedPhase` enum string repr: 'Probing' | 'Encoding' |
+/// 'Rebuilding' | 'Swapping' | 'Verifying' | 'Aborted' | 'Completed'.
+/// `payload_json` carries phase-specific detail (memories_total,
+/// memories_encoded, last_error, etc.).
+pub const MIGRATE_V26_TO_V27: &str = "
+ALTER TABLE memories ADD COLUMN embedding_new BLOB;
+ALTER TABLE memories ADD COLUMN embedding_new_model TEXT;
+ALTER TABLE oplog ADD COLUMN embedding_model TEXT;
+ALTER TABLE oplog ADD COLUMN applied_generation INTEGER;
+CREATE TABLE IF NOT EXISTS reembed_events (
+    generation   INTEGER NOT NULL,
+    phase        TEXT NOT NULL,
+    timestamp    REAL NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_reembed_events_generation ON reembed_events(generation);
+CREATE INDEX IF NOT EXISTS idx_oplog_applied_generation ON oplog(applied_generation, op_id);
 ";

--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -1,4 +1,4 @@
-pub const SCHEMA_VERSION: i32 = 27;
+pub const SCHEMA_VERSION: i32 = 28;
 
 pub const SCHEMA_SQL: &str = "
 -- Memory records: the source of truth
@@ -69,8 +69,20 @@ CREATE TABLE IF NOT EXISTS memories (
     -- `embedding` post-HNSW; in-place mutation would dim-mismatch concurrent
     -- recalls).
     embedding_new BLOB,                        -- pending new embedding bytes; NULL except during active reembed
-    embedding_new_model TEXT                   -- name of embedder that produced embedding_new; NULL when no pending reembed
+    embedding_new_model TEXT,                  -- name of embedder that produced embedding_new; NULL when no pending reembed
+
+    -- v28 (issue #41 brainstorm-4 section 6): durable per-row generation stamp.
+    -- Records which SearchState generation this row embedding column
+    -- was encoded under. NULL on pre-v28 rows (treated as generation 0 by
+    -- the post-swap materializer). Reembed Phase-2 swap transaction
+    -- writes the new generation here atomically with promoting
+    -- embedding_new into embedding. The materializer scan for rows under
+    -- a stale generation uses idx_memories_embedding_generation.
+    embedding_generation INTEGER
 );
+-- v28 index for the post-swap materializer scan of stale-generation rows.
+CREATE INDEX IF NOT EXISTS idx_memories_embedding_generation
+    ON memories(embedding_generation);
 -- v26 partial indexes for the resolution/supersession query patterns the
 -- WriteResolution API will exercise. Partial so they cost nothing on the
 -- (initially) overwhelming majority of rows that are append-with-no-conflict.
@@ -2071,4 +2083,49 @@ CREATE TABLE IF NOT EXISTS reembed_events (
 );
 CREATE INDEX IF NOT EXISTS idx_reembed_events_generation ON reembed_events(generation);
 CREATE INDEX IF NOT EXISTS idx_oplog_applied_generation ON oplog(applied_generation, op_id);
+";
+
+/// **Issue #41 brainstorm-4 §6 — durable linearization point for
+/// reembed crash recovery.**
+///
+/// Two surfaces locked together:
+///
+/// 1. `memories.embedding_generation INTEGER` — per-row stamp of
+///    which SearchState generation the row's `embedding` column was
+///    encoded under. NULL on pre-v28 rows (treated by the post-swap
+///    materializer as "covered by generation 0 — the initial
+///    pre-reembed generation"). Reembed Phase-2's swap transaction
+///    writes the new generation here atomically with promoting
+///    `embedding_new` into `embedding`.
+///
+/// 2. `meta.active_generation` row — durable record of the current
+///    active SearchState generation. Initialized to '0' on v28
+///    install / migration. Phase-2 swap atomically increments this
+///    AND swaps the in-memory SearchState; if the engine crashes
+///    after the SQL transaction commits but before the ArcSwap
+///    store, `open()` reads `meta.active_generation` and rebuilds
+///    the SearchState at the new generation from the v28 column —
+///    no replay logic, just "the durable record says what it is."
+///
+/// 3. Index on `(embedding_generation)` — the post-swap materializer
+///    scans for "rows under generation < active" to apply queued
+///    re-encode ops; this needs index support to be O(N_changed)
+///    not O(N_total) for large DBs.
+///
+/// Brainstorm-4 §6 motivation: without a single durable linearization
+/// point, crash recovery needed multi-step replay logic that
+/// re-derived the active generation from oplog scans + reembed_events
+/// table joins. That logic is itself the bug surface (the
+/// reembed_events table is best-effort; oplog scans miss tail writes
+/// during the SQL transaction window). One column + one row + one
+/// transaction is the clean answer.
+///
+/// Additive-only migration. Idempotent (the runner in engine/mod.rs
+/// swallows "duplicate column name" / "already exists" / "duplicate
+/// key" per the v0.7.3 replay-resilience fix). Safe to re-run.
+pub const MIGRATE_V27_TO_V28: &str = "
+ALTER TABLE memories ADD COLUMN embedding_generation INTEGER;
+CREATE INDEX IF NOT EXISTS idx_memories_embedding_generation
+    ON memories(embedding_generation);
+INSERT OR IGNORE INTO meta (key, value) VALUES ('active_generation', '0');
 ";

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -22,6 +22,39 @@ pub trait Embedder: Send + Sync {
 
     /// The dimensionality of produced embeddings.
     fn dim(&self) -> usize;
+
+    /// Stable identity of this embedder. SHA-256 of model weights, or
+    /// equivalent fingerprint that distinguishes one model from another
+    /// even when they share dim. Default `None` for back-compat with
+    /// existing third-party Embedder impls.
+    ///
+    /// Used by `db.set_embedder*` (issue #41) to distinguish:
+    /// - same-model-replacement (matching fingerprint, matching dim) — safe Arc swap
+    /// - different-model-same-dim (different fingerprint, same dim) —
+    ///   silent-corruption risk, rejected on populated `Known`-provenance
+    ///   DBs with `ChangeEmbedderDigestRequiresReembed`
+    ///
+    /// Embedders returning `None` are treated as `ExternalOrUnknown`
+    /// provenance — they may attach to empty or unknown-provenance DBs
+    /// but cannot attach to a `Known`-provenance populated DB without
+    /// going through `db.reembed()`. Conservative-correct: a custom
+    /// embedder without identity cannot prove compatibility with
+    /// previously-indexed vectors.
+    ///
+    /// Bundled embedders + the `set_embedder_named` named-download path
+    /// override this with real fingerprints (SHA-256 from the embedder-
+    /// download registry).
+    fn fingerprint(&self) -> Option<String> {
+        None
+    }
+
+    /// Human-readable name of this embedder (e.g. "potion-base-2M").
+    /// Independent of fingerprint identity; used for observability and
+    /// status reporting. Default `None` for back-compat. Named-download
+    /// embedders override with the registry name.
+    fn name(&self) -> Option<String> {
+        None
+    }
 }
 
 /// A memory record returned by get() and recall().

--- a/crates/yantrikdb-core/src/cognition/benchmark_ck4.rs
+++ b/crates/yantrikdb-core/src/cognition/benchmark_ck4.rs
@@ -453,7 +453,11 @@ pub fn run_coherence_tests(run: &mut BenchRun, scenario: &PersonaScenario) {
     // Test 2: Enforcement plan generation.
     let start = Instant::now();
     let enforcement = plan_enforcement(&report, &ws, &config);
-    let valid_enforcement = enforcement.items_affected >= 0;
+    // `items_affected: u64` so the prior `>= 0` check was always
+    // true (clippy: absurd_extreme_comparisons). The intent was
+    // "enforcement produced some plan we can record"; the
+    // BenchResult below records items_affected as the metric_value
+    // regardless of count, so the no-op check was vestigial.
     run.add(BenchResult {
         category: "coherence".into(),
         test_name: "enforcement_plan".into(),

--- a/crates/yantrikdb-core/src/cognition/patterns.rs
+++ b/crates/yantrikdb-core/src/cognition/patterns.rs
@@ -537,8 +537,12 @@ fn mine_cross_domain_patterns(db: &YantrikDB, config: &PatternConfig) -> Result<
     // Also need domain for neighbors not in candidates
     // We'll query from DB as needed
 
+    // **Issue #41 brainstorm-4 §1.** Snapshot SearchState once for the
+    // pattern-detection scan so every neighbor query within this scan
+    // hits the same generation-anchored index.
+    let state = db.search_state.load_full();
     for (rid_a, domain_a, embedding) in &candidates {
-        let neighbors = match db.vec_index.search(embedding, 10) {
+        let neighbors = match state.vec_index.search(embedding, 10) {
             Ok(n) => n,
             Err(_) => continue,
         };

--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -314,7 +314,10 @@ fn materialize_op(db: &YantrikDB, op: &OplogEntry) -> Result<()> {
                     .vec_seq
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                     + 1;
-                db.vec_index.tombstone(rid, _seq);
+                // **Issue #41 brainstorm-4 §1.** Replication-applied
+                // tombstones land on the active SearchState's
+                // DeltaIndex.
+                db.search_state.load().vec_index.tombstone(rid, _seq);
                 db.graph_index.write().unlink_memory(rid);
             }
         }
@@ -368,7 +371,9 @@ fn materialize_op(db: &YantrikDB, op: &OplogEntry) -> Result<()> {
                         .vec_seq
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                         + 1;
-                    db.vec_index.tombstone(loser, _seq);
+                    // **Issue #41 brainstorm-4 §1.** Active-generation
+                    // SearchState tombstone.
+                    db.search_state.load().vec_index.tombstone(loser, _seq);
                 }
             }
         }
@@ -414,7 +419,12 @@ fn materialize_op(db: &YantrikDB, op: &OplogEntry) -> Result<()> {
                     .vec_seq
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                     + 1;
-                db.vec_index.tombstone(original_rid, _seq);
+                // **Issue #41 brainstorm-4 §1.** Active-generation
+                // SearchState tombstone for correct's "original_rid".
+                db.search_state
+                    .load()
+                    .vec_index
+                    .tombstone(original_rid, _seq);
             }
         }
         "trigger_fire" => {

--- a/crates/yantrikdb-core/src/engine/durable_embeddings.rs
+++ b/crates/yantrikdb-core/src/engine/durable_embeddings.rs
@@ -135,7 +135,11 @@ impl<'a> DurableEmbeddingStore<'a> {
         let mut stmt = conn.prepare(&sql)?;
         let rows: Vec<(String, Vec<u8>, i64)> = stmt
             .query_map(params_ref.as_slice(), |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, i64>(2)?))
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         drop(stmt);
@@ -255,10 +259,7 @@ mod tests {
         assert_eq!(map.len(), 1, "exact match");
         let entry = map.get(&rid).unwrap();
         assert!(!entry.bytes.is_empty(), "bytes returned");
-        assert_eq!(
-            entry.generation, 0,
-            "fresh engine writes rows at gen 0"
-        );
+        assert_eq!(entry.generation, 0, "fresh engine writes rows at gen 0");
     }
 
     #[test]

--- a/crates/yantrikdb-core/src/engine/durable_embeddings.rs
+++ b/crates/yantrikdb-core/src/engine/durable_embeddings.rs
@@ -1,0 +1,443 @@
+//! **Issue #41 brainstorm-4 §5 — SQL embedding access boundary.**
+//!
+//! The `memories.embedding` BLOB column is the **third** durable
+//! truth in the engine (alongside `SearchState.vec_index` and
+//! `meta.active_generation`). brainstorm-4 §5 caught that without a
+//! module/trait boundary around it, any future caller can grow a
+//! raw `SELECT embedding FROM memories WHERE rid = ?` — and during
+//! a reembed, those bytes might be from the OLD vector space while
+//! the active SearchState is at the NEW one. Silent corruption when
+//! dimensions match; loud-but-late dim-mismatch when they don't.
+//!
+//! This module is the only sanctioned path through which engine code
+//! reads durable embedding bytes. Every call returns the v28
+//! `embedding_generation` stamp alongside the bytes so the caller
+//! can decide what to do with stale-generation rows (skip, queue for
+//! re-encode, refuse).
+//!
+//! ## Boundary audit
+//!
+//! [`tests::recall_rs_has_no_raw_sql_embedding_reads`] grep-scans the
+//! source of `engine/recall.rs` at test time and fails the build if
+//! a future refactor reintroduces a `SELECT ... embedding FROM
+//! memories` outside this module. Recall is the hot user-facing
+//! query path; recall.rs is the file the audit guards. The
+//! cognition/* + storage/* + materializer paths have legitimate
+//! reasons to read embedding bytes (compress for archive, score
+//! similarity in background analytics) and are allowed to call this
+//! module's API directly — they tolerate generation lag because
+//! they read durable state and inherently see the SQL-committed
+//! generation, not the in-memory one.
+//!
+//! ## Forward-compatibility with Phase 2
+//!
+//! Layer 4 Phase 2's Encoding phase reads embeddings from rows that
+//! need re-encoding. It will use [`DurableEmbeddingStore::
+//! read_embeddings_under_generation`] with the OLD generation, get
+//! back the (bytes, gen) pairs, re-encode under the new embedder,
+//! and write to `embedding_new` + `embedding_new_model`. The
+//! Swapping phase's SAVEPOINT atomically promotes embedding_new ->
+//! embedding and bumps both `embedding_generation` (row level) and
+//! `meta.active_generation` (engine level).
+
+use crate::error::Result;
+use rusqlite::params;
+use std::collections::HashMap;
+
+use super::YantrikDB;
+
+/// One row's embedding bytes plus the generation stamp.
+///
+/// `generation` is the v28 `memories.embedding_generation` column.
+/// On pre-v28 rows the column is NULL — interpreted as `Some(0)`
+/// (the initial pre-reembed generation, brainstorm-4 §6
+/// convention).
+///
+/// Callers compare `generation` against the active
+/// `SearchState.generation` to decide whether the bytes are
+/// in-vector-space for the current index. A mismatch means a
+/// reembed swap landed after this row was written; the bytes are
+/// encoded under the prior embedder.
+#[derive(Debug, Clone)]
+pub struct EmbeddingWithGeneration {
+    /// Decrypted f32-serialized embedding bytes (post-decrypt
+    /// blob — the same shape callers expect from the old
+    /// `fetch_embeddings_by_rids` API).
+    pub bytes: Vec<u8>,
+    /// Active generation at the time this row was written. NULL on
+    /// pre-v28 rows is mapped to `0` (the initial generation).
+    pub generation: u64,
+}
+
+/// Engine-internal sanctioned reader for `memories.embedding`.
+///
+/// Constructed per-call with `&YantrikDB`; holds no state of its
+/// own. The struct exists so future call sites use a typed entry
+/// point that's audit-discoverable; the methods could be free
+/// functions but the wrapper makes the boundary explicit at every
+/// call site.
+pub(crate) struct DurableEmbeddingStore<'a> {
+    db: &'a YantrikDB,
+}
+
+impl<'a> DurableEmbeddingStore<'a> {
+    /// Construct a reader bound to the engine instance.
+    pub fn new(db: &'a YantrikDB) -> Self {
+        DurableEmbeddingStore { db }
+    }
+
+    /// Batch-read embeddings for an explicit set of rids.
+    ///
+    /// Returns `(rid, EmbeddingWithGeneration)` for each rid that
+    /// has a non-NULL embedding column. Rids without an embedding
+    /// (storage_tier='cold' before hydration, tombstoned rows, or
+    /// rids that don't exist) are omitted from the result map.
+    ///
+    /// Caller policy on generation:
+    /// - `entry.generation == active_search_state.generation`:
+    ///   bytes are in the active vector space. Safe to use for
+    ///   similarity scoring.
+    /// - `entry.generation < active_search_state.generation`:
+    ///   bytes are from an earlier generation. Phase 2 Encoding
+    ///   path consumes these for re-encode; recall paths SHOULD
+    ///   skip them (or queue them — depends on RYW semantics).
+    /// - `entry.generation > active_search_state.generation`:
+    ///   impossible under the durable-linearization invariant
+    ///   (would mean SQL committed a later gen than `open()`
+    ///   restored). Caller may treat as engine bug + panic, or
+    ///   return error.
+    pub fn read_embeddings_for_rids(
+        &self,
+        rids: &[&str],
+    ) -> Result<HashMap<String, EmbeddingWithGeneration>> {
+        if rids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let placeholders: String = (0..rids.len())
+            .map(|i| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(",");
+        // The `embedding_generation IS NULL` -> 0 mapping is the
+        // brainstorm-4 §6 convention for pre-v28 rows. Done in SQL
+        // via COALESCE so callers always receive a u64.
+        let sql = format!(
+            "SELECT rid, embedding, COALESCE(embedding_generation, 0) \
+             FROM memories WHERE rid IN ({placeholders})"
+        );
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        for r in rids {
+            param_values.push(Box::new(r.to_string()));
+        }
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+
+        let conn = self.db.read_conn();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows: Vec<(String, Vec<u8>, i64)> = stmt
+            .query_map(params_ref.as_slice(), |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?, row.get::<_, i64>(2)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        drop(stmt);
+        drop(conn);
+
+        let mut map = HashMap::new();
+        for (rid, stored_emb, generation) in rows {
+            // Decrypt under the engine's at-rest encryption (no-op
+            // if encryption is disabled). The brainstorm-4 §5
+            // contract: this module is the sole caller of
+            // decrypt_embedding for durable rows on read paths
+            // (record/storage are write paths and stay separate).
+            let bytes = self.db.decrypt_embedding(&stored_emb)?;
+            map.insert(
+                rid,
+                EmbeddingWithGeneration {
+                    bytes,
+                    generation: generation as u64,
+                },
+            );
+        }
+        Ok(map)
+    }
+
+    /// **Phase-2 Encoding helper (forward-compatible).** Stream
+    /// embedding rows whose `embedding_generation` is strictly less
+    /// than the supplied `active_generation`. These are the rows
+    /// the Encoding phase needs to re-encode under the new
+    /// embedder. Caller is responsible for paginating large result
+    /// sets (Phase 2 batches at ReembedOptions::batch_size).
+    ///
+    /// Bounded to `active` rows
+    /// (`consolidation_status = 'active'`). Tombstoned / archived
+    /// rows are out of scope for re-encode.
+    ///
+    /// Returns `(rid, EmbeddingWithGeneration)` pairs in arbitrary
+    /// order. The post-swap materializer (Layer 5) uses a similar
+    /// scan but with `<= covers_through_seq` semantics; that lives
+    /// in the materializer module.
+    pub fn read_embeddings_under_generation(
+        &self,
+        active_generation: u64,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<(String, EmbeddingWithGeneration)>> {
+        let conn = self.db.read_conn();
+        let mut stmt = conn.prepare(
+            "SELECT rid, embedding, COALESCE(embedding_generation, 0) \
+             FROM memories \
+             WHERE consolidation_status = 'active' \
+               AND embedding IS NOT NULL \
+               AND COALESCE(embedding_generation, 0) < ?1 \
+             ORDER BY rid \
+             LIMIT ?2 OFFSET ?3",
+        )?;
+        let rows: Vec<(String, Vec<u8>, i64)> = stmt
+            .query_map(
+                params![active_generation as i64, limit as i64, offset as i64],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        drop(stmt);
+        drop(conn);
+
+        let mut out = Vec::with_capacity(rows.len());
+        for (rid, stored_emb, generation) in rows {
+            let bytes = self.db.decrypt_embedding(&stored_emb)?;
+            out.push((
+                rid,
+                EmbeddingWithGeneration {
+                    bytes,
+                    generation: generation as u64,
+                },
+            ));
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::YantrikDB;
+
+    fn vec_seed(seed: f32, dim: usize) -> Vec<f32> {
+        (0..dim).map(|i| seed + (i as f32) * 0.001).collect()
+    }
+
+    #[test]
+    fn read_embeddings_for_rids_returns_bytes_and_generation() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let rid = db
+            .record(
+                "durable embed read",
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(0.5, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+
+        let store = DurableEmbeddingStore::new(&db);
+        let map = store.read_embeddings_for_rids(&[&rid]).unwrap();
+        assert_eq!(map.len(), 1, "exact match");
+        let entry = map.get(&rid).unwrap();
+        assert!(!entry.bytes.is_empty(), "bytes returned");
+        assert_eq!(
+            entry.generation, 0,
+            "fresh engine writes rows at gen 0"
+        );
+    }
+
+    #[test]
+    fn read_embeddings_for_rids_reflects_generation_advance() {
+        // Lock the brainstorm-4 §6 row-level stamping contract from
+        // the consumer side: after a manual generation advance, new
+        // rows carry the new stamp.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+
+        // Manually advance the engine to gen 11 via the CAS helper.
+        let old_state = db.search_state.load_full();
+        let advanced = crate::engine::reembed::SearchState {
+            index_embedding: old_state.index_embedding.clone(),
+            embedder: old_state.embedder.clone(),
+            runtime_embedder_name: old_state.runtime_embedder_name.clone(),
+            runtime_embedder_digest: old_state.runtime_embedder_digest.clone(),
+            generation: 11,
+            covers_through_seq: old_state.covers_through_seq,
+            hnsw_m: old_state.hnsw_m,
+            hnsw_ef_construction: old_state.hnsw_ef_construction,
+            hnsw_ef_search: old_state.hnsw_ef_search,
+            vec_index: std::sync::Arc::clone(&old_state.vec_index),
+        };
+        db.try_publish_search_state(advanced).unwrap();
+
+        let rid = db
+            .record(
+                "post-advance",
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(0.5, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+
+        let store = DurableEmbeddingStore::new(&db);
+        let map = store.read_embeddings_for_rids(&[&rid]).unwrap();
+        assert_eq!(map.get(&rid).unwrap().generation, 11);
+    }
+
+    #[test]
+    fn read_embeddings_under_generation_filters_by_strict_less_than() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        // Record under gen 0.
+        let rid_old = db
+            .record(
+                "old gen",
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(0.1, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+
+        // Advance gen to 5 and record one more row.
+        let old_state = db.search_state.load_full();
+        let advanced = crate::engine::reembed::SearchState {
+            index_embedding: old_state.index_embedding.clone(),
+            embedder: old_state.embedder.clone(),
+            runtime_embedder_name: old_state.runtime_embedder_name.clone(),
+            runtime_embedder_digest: old_state.runtime_embedder_digest.clone(),
+            generation: 5,
+            covers_through_seq: old_state.covers_through_seq,
+            hnsw_m: old_state.hnsw_m,
+            hnsw_ef_construction: old_state.hnsw_ef_construction,
+            hnsw_ef_search: old_state.hnsw_ef_search,
+            vec_index: std::sync::Arc::clone(&old_state.vec_index),
+        };
+        db.try_publish_search_state(advanced).unwrap();
+        let rid_new = db
+            .record(
+                "new gen",
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(0.2, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+
+        let store = DurableEmbeddingStore::new(&db);
+        // Asking for "rows under gen 5" returns rid_old only.
+        let rows = store.read_embeddings_under_generation(5, 1000, 0).unwrap();
+        let rids: Vec<&str> = rows.iter().map(|(r, _)| r.as_str()).collect();
+        assert!(
+            rids.contains(&rid_old.as_str()),
+            "rid_old (gen 0 < 5) must appear"
+        );
+        assert!(
+            !rids.contains(&rid_new.as_str()),
+            "rid_new (gen 5 not strictly less than 5) must NOT appear"
+        );
+
+        // Asking for "rows under gen 6" returns both.
+        let rows = store.read_embeddings_under_generation(6, 1000, 0).unwrap();
+        let rids: Vec<&str> = rows.iter().map(|(r, _)| r.as_str()).collect();
+        assert!(rids.contains(&rid_old.as_str()));
+        assert!(rids.contains(&rid_new.as_str()));
+    }
+
+    /// **brainstorm-4 §5 / §10.7 boundary audit.** Grep-scans
+    /// `engine/recall.rs` for raw `SELECT ... embedding FROM
+    /// memories` patterns. A non-empty match means a future
+    /// refactor reintroduced direct SQL embedding access in the
+    /// hot recall path; the failure forces the refactor through
+    /// this module's typed API.
+    ///
+    /// Limitation: regex match catches `embedding` and
+    /// `embedding_*` (e.g. embedding_generation, embedding_new) —
+    /// the test allowlist permits suffixed names; only bare
+    /// `embedding` is flagged.
+    #[test]
+    fn recall_rs_has_no_raw_sql_embedding_reads() {
+        let src = include_str!("recall.rs");
+
+        let mut offenders: Vec<&str> = Vec::new();
+        for line in src.lines() {
+            let trimmed = line.trim();
+            // Heuristic: a SELECT/FROM clause that names bare
+            // `embedding` (no underscore suffix) as a column. The
+            // patterns we want to forbid are: `SELECT embedding`,
+            // `, embedding`, `SELECT rid, embedding`, and
+            // similar shapes.
+            //
+            // Permitted: `embedding_hash`, `embedding_new`,
+            // `embedding_model`, `embedding_generation` — those are
+            // metadata columns that don't carry the durable vector
+            // bytes.
+            if !(trimmed.starts_with("//") || trimmed.starts_with("///")) {
+                let lower = trimmed.to_ascii_lowercase();
+                // A match must look like a SQL string-literal
+                // fragment that names `embedding` followed by a
+                // boundary (comma, space, end-quote, or FROM
+                // keyword) — NOT followed by an underscore.
+                for cand in [
+                    "select embedding ",
+                    "select embedding,",
+                    "select embedding\"",
+                    "select embedding\\",
+                    ", embedding ",
+                    ", embedding,",
+                    ", embedding\"",
+                    ", embedding\\",
+                    ", embedding\n",
+                ] {
+                    if lower.contains(cand) {
+                        offenders.push(line);
+                        break;
+                    }
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "brainstorm-4 §5 audit: recall.rs grew {} raw SQL embedding read(s); \
+             route through engine::durable_embeddings::DurableEmbeddingStore. \
+             Offending line(s):\n{}",
+            offenders.len(),
+            offenders.join("\n")
+        );
+    }
+}

--- a/crates/yantrikdb-core/src/engine/indices.rs
+++ b/crates/yantrikdb-core/src/engine/indices.rs
@@ -54,7 +54,9 @@ impl YantrikDB {
             Self::build_vec_index_with_enc(&conn, self.embedding_dim, self.enc.as_ref())?;
         let count = new_index.len();
         drop(conn);
-        self.vec_index.install_cold(new_index);
+        // **Issue #41 brainstorm-4 §1.** Install the rebuilt cold tier
+        // into the active-generation DeltaIndex via SearchState.
+        self.search_state.load().vec_index.install_cold(new_index);
         Ok(count)
     }
 

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -337,8 +337,11 @@ impl YantrikDB {
         // before SQL has applied. Cluster followers may have the rid in
         // their delta from a recent record_with_rid that has not yet
         // compacted into cold; the tombstone marker covers that window.
+        //
+        // **Issue #41 brainstorm-4 §1.** Snapshot SearchState — the
+        // tombstone lands on the active generation's DeltaIndex.
         let seq = self.assign_seq(seq);
-        self.vec_index.tombstone(rid, seq);
+        self.search_state.load().vec_index.tombstone(rid, seq);
         if let Some(ns) = &ns_to_bump {
             self.bump_visible_seq(ns, seq);
         }

--- a/crates/yantrikdb-core/src/engine/materializer.rs
+++ b/crates/yantrikdb-core/src/engine/materializer.rs
@@ -218,8 +218,28 @@ fn compactor_loop(weak: Weak<YantrikDB>, shutdown: Arc<AtomicBool>) {
             break;
         };
 
-        if db.vec_index.should_compact() {
-            match db.vec_index.compact() {
+        // **Issue #41 brainstorm-4 §1.** Load the SearchState snapshot
+        // once, extract the Arc<DeltaIndex>, drop the SearchState Arc
+        // BEFORE the long blocking wait. Holding Arc<SearchState>
+        // across the wait would pin the old HNSW cold tier in
+        // memory across a reembed swap (multi-GB on large DBs);
+        // holding Arc<DeltaIndex> only is bounded — the DeltaIndex is
+        // the working set, not the historical state.
+        //
+        // If a Phase-2 swap publishes a NEW SearchState mid-iteration,
+        // this iteration's `vec_index` Arc is the OLD DeltaIndex. The
+        // install_cold call (inside compact) writes to the OLD
+        // DeltaIndex's internal cold slot — harmless waste, not
+        // corruption, because the OLD DeltaIndex is no longer the
+        // published vec_index. The next loop iteration loads the NEW
+        // SearchState and operates on the NEW DeltaIndex.
+        let vec_index = {
+            let state = db.search_state.load_full();
+            std::sync::Arc::clone(&state.vec_index)
+        };
+
+        if vec_index.should_compact() {
+            match vec_index.compact() {
                 Ok(0) => {}
                 Ok(n) => {
                     tracing::debug!(applied = n, "compaction drained delta into cold");
@@ -238,7 +258,8 @@ fn compactor_loop(weak: Weak<YantrikDB>, shutdown: Arc<AtomicBool>) {
         // shutdown. yantrikdb-server bench (msg b9c98a4d) showed
         // the unconditional sleep racing the delta refill at
         // 1000 wps; this closes that race.
-        let _ = db.vec_index.wait_for_compaction_signal(COMPACTOR_INTERVAL);
+        let _ = vec_index.wait_for_compaction_signal(COMPACTOR_INTERVAL);
+        drop(vec_index);
         drop(db);
     }
 
@@ -407,7 +428,9 @@ mod tests {
                 .vec_seq
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                 + 1;
-            db.vec_index
+            db.search_state
+                .load()
+                .vec_index
                 .append(format!("rid_{i}"), normalized, seq)
                 .unwrap();
         }
@@ -432,13 +455,14 @@ mod tests {
         // variance, still fails fast if the compactor is genuinely
         // stuck.
         let mut tries = 0;
-        while db.vec_index.delta_len() >= 128 && tries < 300 {
+        while db.search_state.load().vec_index.delta_len() >= 128 && tries < 300 {
             std::thread::sleep(Duration::from_millis(100));
             tries += 1;
         }
 
-        let cold = db.vec_index.cold_len();
-        let delta = db.vec_index.delta_len();
+        let state = db.search_state.load_full();
+        let cold = state.vec_index.cold_len();
+        let delta = state.vec_index.delta_len();
         assert!(
             delta < 128,
             "compactor should have drained delta below half-cap within 30s, \

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1148,6 +1148,41 @@ impl YantrikDB {
     }
 
     /// Record a memory with automatic embedding generation.
+    ///
+    /// **Issue #41 brainstorm-4 §2 — writer revalidation loop.**
+    /// `record_text` performs the engine-side embed step, which is
+    /// SLOW (e.g. tens of ms for a model embedding). Per brainstorm-4
+    /// the embed runs OUTSIDE the `WriteRouter` guard so reembed
+    /// throughput stays bounded by the index rebuild, not by every
+    /// in-flight `record_text`. The price of "embed outside the
+    /// barrier" is that the active generation can advance between
+    /// the embed and the commit — landing an old-embedder vector in
+    /// the new-generation index is durable silent corruption when
+    /// dims happen to match (and a noisy `EmbeddingDimensionMismatch`
+    /// when they don't).
+    ///
+    /// The loop closes that window:
+    /// 1. Snapshot SearchState (`gen_pre`, embedder, digest_pre).
+    /// 2. Embed under that embedder. NO guard held — slow step.
+    /// 3. Try to acquire the sync guard. If the router has flipped to
+    ///    Queueing, route to `record_queued(text)` — the post-swap
+    ///    materializer will re-encode under the new embedder.
+    /// 4. With guard held, re-snapshot SearchState (`gen_post`,
+    ///    digest_post). Guard prevents reembed from completing its
+    ///    swap from this point onward.
+    /// 5. If `gen_pre == gen_post && digest_pre == digest_post`: the
+    ///    embedding we computed is consistent with the active
+    ///    generation. Commit via `record_under_guard_and_state`.
+    /// 6. Otherwise: a reembed swap completed between step 1 and
+    ///    step 4. Drop the guard and retry from step 1 — the next
+    ///    iteration embeds under the NEW embedder.
+    ///
+    /// The loop is bounded in expectation because reembed completes
+    /// at most once per outer call (it advances generation
+    /// monotonically and waits-for-no-sync-writers before swapping).
+    /// The retry budget is unbounded in the API surface — a
+    /// pathological caller can flap embedders forever, but real
+    /// reembed runs land once and then stay landed.
     pub fn record_text(
         &self,
         text: &str,
@@ -1162,21 +1197,99 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
     ) -> Result<String> {
-        let embedding = self.embed(text)?;
-        self.record(
-            text,
-            memory_type,
-            importance,
-            valence,
-            half_life,
-            metadata,
-            &embedding,
-            namespace,
-            certainty,
-            domain,
-            source,
-            emotional_state,
-        )
+        loop {
+            // Step 1: snapshot SearchState for the embed — capture
+            // generation + digest so we can revalidate after the embed.
+            let state_for_embed = self.search_state.load_full();
+            let gen_pre = state_for_embed.generation;
+            let digest_pre = state_for_embed.runtime_embedder_digest.clone();
+            let embedder = state_for_embed
+                .embedder
+                .as_ref()
+                .ok_or(YantrikDbError::NoEmbedder)?
+                .clone();
+            // Release the Arc<SearchState> BEFORE the slow embed —
+            // brainstorm-4 §4 invariant ("no holding SearchState
+            // across long ops"). The embedder Arc is the small,
+            // bounded retention.
+            drop(state_for_embed);
+
+            // Step 2: embed OUTSIDE any guard. Slow step.
+            let embedding = embedder
+                .embed(text)
+                .map_err(|e| YantrikDbError::Inference(e.to_string()))?;
+
+            // Step 3: try to enter sync path.
+            let sync_guard = match self.write_router.try_enter_sync_writer() {
+                Some(g) => g,
+                None => {
+                    // Queueing state — reembed cutover is in
+                    // flight. Route to the queued path. The
+                    // pre-computed embedding is discarded; the
+                    // queued path stores TEXT and the post-swap
+                    // materializer re-encodes under the new
+                    // embedder (brainstorm-3 invariant 8).
+                    return self.record_queued(
+                        text,
+                        memory_type,
+                        importance,
+                        valence,
+                        half_life,
+                        metadata,
+                        &embedding,
+                        namespace,
+                        certainty,
+                        domain,
+                        source,
+                        emotional_state,
+                    );
+                }
+            };
+
+            // Step 4: re-snapshot SearchState UNDER the guard. From
+            // this point, reembed cannot complete its swap until
+            // our guard drops, so the loaded state is stable for
+            // the rest of the critical section.
+            let state_for_commit = self.search_state.load_full();
+
+            // Step 5: revalidate. If a swap completed between step 1
+            // and step 4, the embedding is in the wrong vector
+            // space and we must retry.
+            if state_for_commit.generation != gen_pre
+                || state_for_commit.runtime_embedder_digest != digest_pre
+            {
+                // Generation or digest advanced. Drop guard and
+                // retry the whole loop — next iteration embeds
+                // under the new active embedder.
+                drop(sync_guard);
+                tracing::info!(
+                    gen_pre,
+                    gen_post = state_for_commit.generation,
+                    "record_text: SearchState advanced mid-embed, retrying",
+                );
+                continue;
+            }
+
+            // Step 6: commit. The shared post-guard helper handles
+            // SQL insert + vec_index.append + log_op (which itself
+            // stamps applied_generation = state.generation).
+            return self.record_under_guard_and_state(
+                state_for_commit,
+                sync_guard,
+                text,
+                memory_type,
+                importance,
+                valence,
+                half_life,
+                metadata,
+                &embedding,
+                namespace,
+                certainty,
+                domain,
+                source,
+                emotional_state,
+            );
+        }
     }
 
     /// Recall memories by text query with automatic embedding.

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1108,11 +1108,84 @@ impl YantrikDB {
             }
         };
 
-        self.search_state.store(std::sync::Arc::new(new_state));
+        // **Issue #41 brainstorm-4 §3.** Route through the
+        // monotonic-generation CAS helper so the invariant
+        // "SearchState generation never regresses" is enforced
+        // uniformly across every publisher. set_embedder publishes
+        // with `new_state.generation == state.generation` (it does
+        // not advance the vector-space generation; only reembed
+        // Phase-2 does), so the >= check inside the helper passes
+        // here trivially.
+        self.try_publish_search_state(new_state)?;
         // Legacy slot retired post-#41: all reads now route through
         // search_state. Clear it to catch any latent reader.
         self.embedder = None;
         Ok(())
+    }
+
+    /// **Issue #41 brainstorm-4 §3 — monotonic-generation CAS for
+    /// SearchState publication.**
+    ///
+    /// The single chokepoint through which any code path mutates
+    /// `self.search_state`. The invariant is strict: a new
+    /// SearchState may only be published if its `generation` is
+    /// `>= self.search_state.load().generation`. Strictly-lesser
+    /// generations are rejected — they represent stale work from a
+    /// compactor / writer / reembed step whose snapshot was
+    /// invalidated by a concurrent generation advance.
+    ///
+    /// brainstorm-4 §3 motivation: without this, a future
+    /// compactor-style path that runs on the OLD SearchState and
+    /// republishes after a reembed swap would ABA-rollback the
+    /// active generation. That rollback is durable data omission —
+    /// the post-swap materializer reapplies queued ops that were
+    /// already covered by the new generation's `covers_through_seq`,
+    /// double-applying writes and breaking RYW semantics.
+    ///
+    /// CAS implementation: uses ArcSwap's `compare_and_swap` so
+    /// concurrent publishers race only on pointer identity, not
+    /// generation values. The retry loop re-validates the
+    /// generation guard each iteration; if a concurrent publisher
+    /// races AND has a higher generation, this call returns
+    /// `SearchStatePublishStaleGeneration` instead of looping
+    /// forever — caller must rebuild their proposed state under the
+    /// new active generation.
+    ///
+    /// Equal-generation publishes (same vector-space, different
+    /// runtime metadata — e.g. set_embedder runtime-only Arc swap)
+    /// are allowed: the generation tracks the index's vector space,
+    /// not arbitrary state changes.
+    pub(crate) fn try_publish_search_state(
+        &self,
+        new_state: crate::engine::reembed::SearchState,
+    ) -> Result<()> {
+        let new_arc = std::sync::Arc::new(new_state);
+        loop {
+            let current = self.search_state.load_full();
+            if new_arc.generation < current.generation {
+                return Err(YantrikDbError::SearchStatePublishStaleGeneration {
+                    current_generation: current.generation,
+                    attempted_generation: new_arc.generation,
+                });
+            }
+            // ArcSwap::compare_and_swap returns the previous Arc.
+            // If it's pointer-equal to `current`, the swap landed.
+            // Otherwise a concurrent publisher raced; loop and
+            // re-validate against the new current.
+            let prev = self
+                .search_state
+                .compare_and_swap(&current, std::sync::Arc::clone(&new_arc));
+            if std::sync::Arc::ptr_eq(&prev, &current) {
+                return Ok(());
+            }
+            // Concurrent publisher swapped between load and CAS.
+            // Loop: re-load, re-validate. The retry budget is
+            // bounded by the number of concurrent publishers, which
+            // is bounded by the index_write_lock (today only
+            // set_embedder + reembed contend, and the lock
+            // serializes them anyway — the CAS is defense in
+            // depth).
+        }
     }
 
     /// Internal helper for `set_embedder*` / future `reembed()`: count

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -39,6 +39,7 @@ mod recall;
 mod receptivity;
 mod record;
 pub mod reembed;
+pub mod write_router;
 mod replay_engine;
 mod schema_induction_engine;
 mod session;

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -91,11 +91,15 @@ use crate::types::*;
 ///
 /// Thread-safe: all internal state is protected by `Mutex` or `RwLock`.
 /// `conn` uses `Mutex` because `rusqlite::Connection` is `!Sync`.
-/// Read-heavy fields (`scoring_cache`, `vec_index`, `graph_index`,
+/// Read-heavy fields (`scoring_cache`, `graph_index`,
 /// `active_sessions`) use `RwLock` for concurrent reader throughput.
+/// The vector index lives inside `search_state` as `Arc<DeltaIndex>`
+/// (issue #41 brainstorm-4 §1) — `DeltaIndex` carries its own
+/// internal locks, and `ArcSwap<SearchState>` is the atomic
+/// publication wrapper.
 ///
 /// **Lock ordering** (always acquire in this order to prevent deadlocks):
-///   conn → hlc → scoring_cache → vec_index → graph_index → active_sessions
+///   conn → hlc → scoring_cache → SearchState.vec_index → graph_index → active_sessions
 ///
 /// ## Concurrent recall (read pool)
 ///
@@ -124,25 +128,15 @@ pub struct YantrikDB {
     pub(crate) hlc: Mutex<HLC>,
     pub(crate) actor_id: String,
     pub(crate) scoring_cache: RwLock<HashMap<String, ScoringRow>>,
-    /// **Issue #41 brainstorm-4 transitional shape.** Held as
-    /// `Arc<DeltaIndex>` (not bare `DeltaIndex`) so this slot can share
-    /// the exact same `DeltaIndex` allocation as
-    /// `SearchState.vec_index` — `Arc::clone` here is the publication
-    /// primitive. All `DeltaIndex` methods take `&self`, so the
-    /// `Arc<_>` deref-coerces and existing `self.vec_index.X()` call
-    /// sites compile unchanged. A follow-up checkpoint migrates hot
-    /// paths to load `Arc<SearchState>` once per operation and use
-    /// `state.vec_index` (single atomic snapshot — provenance + dim +
-    /// index all in one Arc), at which point this standalone field
-    /// retires. Until then, the field exists only because it is also
-    /// the field name on `YantrikDB` that ~20 call sites still
-    /// reference; the underlying `DeltaIndex` is the same object as
-    /// the one in `SearchState`, so today there is no split-brain
-    /// possible (reembed phase 2 swap, which would publish a *new*
-    /// `DeltaIndex` and create the split-brain risk, has not landed
-    /// yet — the migration sweep precedes it).
-    pub(crate) vec_index: std::sync::Arc<crate::vector::delta_index::DeltaIndex>,
-    /// Monotonic seq counter for vec_index appends/tombstones.
+    // Issue #41 brainstorm-4 §1: standalone `vec_index` field retired.
+    // The vector index now lives ONLY inside `search_state` as
+    // `Arc<DeltaIndex>`, so `search_state.store(new_state)` becomes the
+    // single atomic publication unit for (embedder + provenance + dim
+    // + generation + vec_index). Reembed Phase-2 swap can republish a
+    // brand-new `DeltaIndex` atomically with the rest of SearchState
+    // without any split-brain window. Readers do
+    // `self.search_state.load[_full]().vec_index.X(...)`.
+    /// Monotonic seq counter for SearchState.vec_index appends/tombstones.
     /// Used by Phase 6 RYW (recall_with_seq); also feeds DeltaIndex's
     /// per-entry seq tag for compaction ordering.
     pub(crate) vec_seq: std::sync::atomic::AtomicU64,
@@ -654,14 +648,12 @@ impl YantrikDB {
             })
             .unwrap_or(0);
 
-        // Build the DeltaIndex once, wrap in Arc, then share the same
-        // Arc between the standalone `vec_index` field and the
-        // initial `SearchState.vec_index` slot. This is the
-        // brainstorm-4 transitional shape: today both paths read the
-        // same `DeltaIndex` object so there is no split-brain; once
-        // the call-site migration sweep retires the standalone field,
-        // `SearchState.vec_index` is the only path and reembed phase
-        // 2 can republish a new `DeltaIndex` atomically.
+        // Build the DeltaIndex once, wrap in Arc, and move it into the
+        // initial `SearchState`. After issue #41 brainstorm-4 §1, the
+        // SearchState is the only owner of the index — there is no
+        // standalone field anymore. Reembed Phase-2 can later publish
+        // a brand-new `DeltaIndex` atomically with the rest of the
+        // SearchState bundle via `search_state.store(new_state)`.
         let vec_index_arc: std::sync::Arc<crate::vector::delta_index::DeltaIndex> = {
             let delta_max = std::env::var("YANTRIKDB_DELTA_MAX")
                 .ok()
@@ -689,7 +681,6 @@ impl YantrikDB {
             hlc: Mutex::new(HLC::new(node_id)),
             actor_id,
             scoring_cache: RwLock::new(scoring_cache),
-            vec_index: std::sync::Arc::clone(&vec_index_arc),
             vec_seq: std::sync::atomic::AtomicU64::new(0),
             pending_op_count: std::sync::atomic::AtomicI64::new(initial_pending),
             visible_seq: dashmap::DashMap::new(),
@@ -724,7 +715,7 @@ impl YantrikDB {
                     16,
                     200,
                     50,
-                    std::sync::Arc::clone(&vec_index_arc),
+                    vec_index_arc,
                 ),
             )),
             index_write_lock: parking_lot::Mutex::new(()),
@@ -916,13 +907,13 @@ impl YantrikDB {
     /// engine capacity — see CONCURRENCY.md and the cross-stack rule
     /// "engine pressure suppresses enrichment" (saga task 16).
     pub fn delta_max(&self) -> usize {
-        self.vec_index.delta_max()
+        self.search_state.load().vec_index.delta_max()
     }
 
     /// Current delta-tier length (live entries + tombstone markers).
     /// Pairs with `delta_max()` for pressure-ratio computation.
     pub fn delta_len(&self) -> usize {
-        self.vec_index.delta_len()
+        self.search_state.load().vec_index.delta_len()
     }
 
     /// Current cold-tier length (entries that have been merged into
@@ -930,7 +921,7 @@ impl YantrikDB {
     /// hot/cold split — most reads against a healthy engine should
     /// hit cold rather than the linear delta scan.
     pub fn cold_len(&self) -> usize {
-        self.vec_index.cold_len()
+        self.search_state.load().vec_index.cold_len()
     }
 
     /// Get the embedding dimension.

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -189,6 +189,38 @@ pub struct YantrikDB {
     /// brainstorm-2 rationale and the cutover-sequence regression
     /// test.
     pub(crate) write_router: crate::engine::write_router::SharedWriteRouter,
+
+    /// **Issue #41 — layer 2 / brainstorm-3.** Atomically-swappable
+    /// SearchState carrying the runtime embedder + index_embedding
+    /// provenance + generation + HNSW params. Read paths acquire once
+    /// via `self.search_state.load_full()` and use the snapshot for
+    /// the full request — this prevents observing a mixed embedder /
+    /// provenance / dim state mid-set_embedder or mid-reembed.
+    ///
+    /// Today this co-exists with the legacy `embedder: Option<Box<...>>`
+    /// and `embedding_dim: usize` fields above. The migration retires
+    /// those in a later checkpoint; until then, search_state mirrors
+    /// the legacy fields on every set_embedder / new(). See
+    /// `engine::reembed::SearchState` for the field semantics.
+    pub(crate) search_state: arc_swap::ArcSwap<crate::engine::reembed::SearchState>,
+
+    /// **Issue #41 — layer 2 / brainstorm-3.** Serializes SearchState
+    /// republication. Acquired by:
+    /// - `set_embedder` / `set_embedder_named` (mode validation +
+    ///    coherent-bundle publication)
+    /// - Future `reembed()` cutover (final swap)
+    /// - Future empty-index-reset paths
+    ///
+    /// NOT held by writers — writers serialize via `write_router`. Two
+    /// separate primitives for two separate invariants:
+    /// - `write_router` = "is this writer allowed to take the sync
+    ///    path right now?"
+    /// - `index_write_lock` = "is the SearchState mid-republication
+    ///    right now?"
+    ///
+    /// No double-locking risk: set_embedder doesn't acquire
+    /// write_router, writers don't acquire index_write_lock.
+    pub(crate) index_write_lock: parking_lot::Mutex<()>,
 }
 
 impl YantrikDB {
@@ -640,6 +672,26 @@ impl YantrikDB {
             write_router: std::sync::Arc::new(
                 crate::engine::write_router::WriteRouter::new(),
             ),
+            // Issue #41 layer 2: initial SearchState mirrors the
+            // legacy embedder/embedding_dim fields. Provenance is
+            // ExternalOrUnknown(embedding_dim) until set_embedder*
+            // populates it with Known(name, digest, dim) or a future
+            // reembed publishes a new bundle. HNSW params (M=16,
+            // ef_construction=200, ef_search=50) are the engine
+            // defaults; the actual DeltaIndex uses those today. The
+            // search_state copy here is the source of truth going
+            // forward; the future migration sweep retires the legacy
+            // embedding_dim + embedder fields and points all readers
+            // here.
+            search_state: arc_swap::ArcSwap::from(std::sync::Arc::new(
+                crate::engine::reembed::SearchState::initial(
+                    embedding_dim,
+                    16,
+                    200,
+                    50,
+                ),
+            )),
+            index_write_lock: parking_lot::Mutex::new(()),
         })
     }
 

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -177,6 +177,18 @@ pub struct YantrikDB {
     embedder: Option<Box<dyn crate::types::Embedder + Send + Sync>>,
     /// Cache of active sessions: namespace → session_id
     pub(crate) active_sessions: RwLock<HashMap<String, String>>,
+    /// **Issue #41 reembed primitive.** Synchronized cutover barrier
+    /// between synchronous writes (`Normal` state) and queued writes
+    /// (`Queueing` state during reembed). Writers acquire via
+    /// `try_enter_sync_writer()` and hold the RAII guard for the full
+    /// memories INSERT + vec_index.append + oplog write critical
+    /// section. Reembed flips state to `Queueing`, waits for
+    /// `wait_for_no_sync_writers()`, then can safely capture
+    /// `build_hwm` knowing no synchronous writer can still commit to
+    /// the old generation. See `engine::write_router` module for the
+    /// brainstorm-2 rationale and the cutover-sequence regression
+    /// test.
+    pub(crate) write_router: crate::engine::write_router::SharedWriteRouter,
 }
 
 impl YantrikDB {
@@ -620,6 +632,14 @@ impl YantrikDB {
             enc,
             embedder: None,
             active_sessions: RwLock::new(active_sessions),
+            // Issue #41: WriteRouter starts in Normal state. Reembed
+            // is the only path that flips it to Queueing; until then,
+            // every record/record_text takes the synchronous path
+            // unchanged. Adding the field is a no-op for non-reembed
+            // code paths until record() is wired to check the gate.
+            write_router: std::sync::Arc::new(
+                crate::engine::write_router::WriteRouter::new(),
+            ),
         })
     }
 

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -35,6 +35,7 @@ mod planner;
 mod policy;
 mod procedural;
 mod query_dsl;
+mod durable_embeddings;
 mod recall;
 mod receptivity;
 mod record;

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -10,6 +10,7 @@ mod cognition;
 mod coherence;
 mod conflict;
 mod counterfactual_engine;
+mod durable_embeddings;
 mod evaluator;
 mod experimenter;
 mod extractor;
@@ -35,12 +36,10 @@ mod planner;
 mod policy;
 mod procedural;
 mod query_dsl;
-mod durable_embeddings;
 mod recall;
 mod receptivity;
 mod record;
 pub mod reembed;
-pub mod write_router;
 mod replay_engine;
 mod schema_induction_engine;
 mod session;
@@ -57,6 +56,7 @@ mod tests;
 mod tick;
 mod warrant;
 mod world_model;
+pub mod write_router;
 
 use std::collections::HashMap;
 // parking_lot::Mutex and RwLock: non-poisoning (no PoisonError on panic),
@@ -82,9 +82,9 @@ use crate::schema::{
     MIGRATE_V14_TO_V15, MIGRATE_V15_TO_V16, MIGRATE_V16_TO_V17, MIGRATE_V17_TO_V18,
     MIGRATE_V18_TO_V19, MIGRATE_V19_TO_V20, MIGRATE_V1_TO_V2, MIGRATE_V20_TO_V21,
     MIGRATE_V21_TO_V22, MIGRATE_V22_TO_V23, MIGRATE_V23_TO_V24, MIGRATE_V24_TO_V25,
-    MIGRATE_V25_TO_V26, MIGRATE_V26_TO_V27, MIGRATE_V27_TO_V28, MIGRATE_V2_TO_V3, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5,
-    MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10,
-    SCHEMA_SQL, SCHEMA_VERSION,
+    MIGRATE_V25_TO_V26, MIGRATE_V26_TO_V27, MIGRATE_V27_TO_V28, MIGRATE_V2_TO_V3, MIGRATE_V3_TO_V4,
+    MIGRATE_V4_TO_V5, MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9,
+    MIGRATE_V9_TO_V10, SCHEMA_SQL, SCHEMA_VERSION,
 };
 use crate::types::*;
 
@@ -626,10 +626,7 @@ impl YantrikDB {
                          embedding_new_model = NULL WHERE embedding_new IS NOT NULL",
                         [],
                     )?;
-                    conn.execute(
-                        "DELETE FROM meta WHERE key = 'reembed_state'",
-                        [],
-                    )?;
+                    conn.execute("DELETE FROM meta WHERE key = 'reembed_state'", [])?;
                     let evt_payload = serde_json::json!({
                         "recovery": "discarded_staging",
                         "reason": format!(
@@ -663,10 +660,7 @@ impl YantrikDB {
                          embedding_new_model = NULL WHERE embedding_new IS NOT NULL",
                         [],
                     )?;
-                    conn.execute(
-                        "DELETE FROM meta WHERE key = 'reembed_state'",
-                        [],
-                    )?;
+                    conn.execute("DELETE FROM meta WHERE key = 'reembed_state'", [])?;
                     let evt_payload = serde_json::json!({
                         "recovery": "completed_durable",
                         "reason": format!(
@@ -830,13 +824,11 @@ impl YantrikDB {
                 .and_then(|v| v.parse::<u64>().ok())
                 .map(std::time::Duration::from_secs)
                 .unwrap_or(crate::vector::delta_index::DEFAULT_MAX_DIRTY_AGE);
-            std::sync::Arc::new(
-                crate::vector::delta_index::DeltaIndex::from_cold_with_age(
-                    vec_index,
-                    delta_max,
-                    max_dirty_age,
-                ),
-            )
+            std::sync::Arc::new(crate::vector::delta_index::DeltaIndex::from_cold_with_age(
+                vec_index,
+                delta_max,
+                max_dirty_age,
+            ))
         };
 
         Ok(Self {
@@ -861,9 +853,7 @@ impl YantrikDB {
             // every record/record_text takes the synchronous path
             // unchanged. Adding the field is a no-op for non-reembed
             // code paths until record() is wired to check the gate.
-            write_router: std::sync::Arc::new(
-                crate::engine::write_router::WriteRouter::new(),
-            ),
+            write_router: std::sync::Arc::new(crate::engine::write_router::WriteRouter::new()),
             // Issue #41 layer 2: initial SearchState mirrors the
             // legacy embedder/embedding_dim fields. Provenance is
             // ExternalOrUnknown(embedding_dim) until set_embedder*

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -562,6 +562,147 @@ impl YantrikDB {
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
 
+        // **Layer 7 — crash recovery for in-flight reembed.**
+        //
+        // If `meta.reembed_state` is set, the engine crashed mid-
+        // reembed. Decide what to do based on the durable
+        // `meta.active_generation`:
+        //
+        // - If `active_generation < in_flight_generation`: the SQL
+        //   swap transaction (Phase 2 step 5) did NOT commit before
+        //   the crash. The staging columns (`memories.embedding_new`
+        //   + `embedding_new_model`) may be partially populated; we
+        //   discard them and clear `meta.reembed_state`. The next
+        //   `db.reembed(target_name)` call starts fresh and
+        //   overwrites whatever staging survived.
+        //
+        // - If `active_generation >= in_flight_generation`: the SQL
+        //   swap DID commit; the in-memory SearchState publish
+        //   (step 6) is what was lost. SQL is durably at the new
+        //   generation. The SearchState is rebuilt at the new
+        //   generation by the standard open path. Staging columns
+        //   should already be cleared by the swap transaction, but
+        //   we defensively clear any leftover (the in-memory
+        //   `apply_pending_ops_once` / Layer 5 path is fine here:
+        //   any queued ops with embedding_model NOT NULL get
+        //   re-encoded under the new embedder via the standard
+        //   drain).
+        //
+        // The decision is durable + idempotent (re-running open()
+        // produces the same result). An audit event is written to
+        // reembed_events so operators can see "this reembed crashed
+        // and was recovered as discarded / completed".
+        let reembed_recovery_summary: Option<String> = {
+            let in_flight: Option<(u64, String)> = {
+                let payload_json: Option<String> = conn
+                    .query_row(
+                        "SELECT value FROM meta WHERE key = 'reembed_state'",
+                        [],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .ok();
+                payload_json.and_then(|s| {
+                    let v: serde_json::Value = serde_json::from_str(&s).ok()?;
+                    let g = v.get("generation")?.as_u64()?;
+                    let phase = v
+                        .get("phase")
+                        .and_then(|p| p.as_str())
+                        .unwrap_or("Probing")
+                        .to_string();
+                    Some((g, phase))
+                })
+            };
+
+            if let Some((in_flight_gen, in_flight_phase)) = in_flight {
+                let recovery_event_ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs_f64())
+                    .unwrap_or(0.0);
+
+                if active_generation < in_flight_gen {
+                    // SQL swap didn't commit. Discard staging.
+                    conn.execute(
+                        "UPDATE memories SET embedding_new = NULL, \
+                         embedding_new_model = NULL WHERE embedding_new IS NOT NULL",
+                        [],
+                    )?;
+                    conn.execute(
+                        "DELETE FROM meta WHERE key = 'reembed_state'",
+                        [],
+                    )?;
+                    let evt_payload = serde_json::json!({
+                        "recovery": "discarded_staging",
+                        "reason": format!(
+                            "crash at phase {in_flight_phase}; SQL swap not committed \
+                             (active_generation={active_generation} < \
+                             in_flight_generation={in_flight_gen})"
+                        ),
+                        "active_generation_after": active_generation,
+                    });
+                    conn.execute(
+                        "INSERT INTO reembed_events (generation, phase, timestamp, payload_json) \
+                         VALUES (?1, ?2, ?3, ?4)",
+                        params![
+                            in_flight_gen as i64,
+                            "Aborted",
+                            recovery_event_ts,
+                            serde_json::to_string(&evt_payload)?,
+                        ],
+                    )?;
+                    Some(format!(
+                        "discarded_staging (in-flight gen {in_flight_gen} phase {in_flight_phase})"
+                    ))
+                } else {
+                    // SQL swap committed before crash. SearchState will
+                    // rebuild at the new generation (active_generation
+                    // read above). Defensive: clear any staging
+                    // leftover; the swap transaction normally clears
+                    // it but we don't trust a crashed transaction.
+                    conn.execute(
+                        "UPDATE memories SET embedding_new = NULL, \
+                         embedding_new_model = NULL WHERE embedding_new IS NOT NULL",
+                        [],
+                    )?;
+                    conn.execute(
+                        "DELETE FROM meta WHERE key = 'reembed_state'",
+                        [],
+                    )?;
+                    let evt_payload = serde_json::json!({
+                        "recovery": "completed_durable",
+                        "reason": format!(
+                            "crash at phase {in_flight_phase}; SQL swap committed \
+                             (active_generation={active_generation} >= \
+                             in_flight_generation={in_flight_gen}); SearchState \
+                             rebuilt at new generation"
+                        ),
+                        "active_generation_after": active_generation,
+                    });
+                    conn.execute(
+                        "INSERT INTO reembed_events (generation, phase, timestamp, payload_json) \
+                         VALUES (?1, ?2, ?3, ?4)",
+                        params![
+                            in_flight_gen as i64,
+                            "Completed",
+                            recovery_event_ts,
+                            serde_json::to_string(&evt_payload)?,
+                        ],
+                    )?;
+                    Some(format!(
+                        "completed_durable (gen {in_flight_gen} phase {in_flight_phase})"
+                    ))
+                }
+            } else {
+                None
+            }
+        };
+        if let Some(summary) = &reembed_recovery_summary {
+            tracing::warn!(
+                target: "yantrikdb::reembed::recovery",
+                summary = %summary,
+                "open(): in-flight reembed detected; applied crash-recovery decision"
+            );
+        }
+
         // Resolve node_id: stored in meta > generate random
         let node_id: u32 = match Self::get_meta(&conn, "node_id")? {
             Some(s) => s.parse().unwrap_or_else(|_| {

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -81,7 +81,7 @@ use crate::schema::{
     MIGRATE_V14_TO_V15, MIGRATE_V15_TO_V16, MIGRATE_V16_TO_V17, MIGRATE_V17_TO_V18,
     MIGRATE_V18_TO_V19, MIGRATE_V19_TO_V20, MIGRATE_V1_TO_V2, MIGRATE_V20_TO_V21,
     MIGRATE_V21_TO_V22, MIGRATE_V22_TO_V23, MIGRATE_V23_TO_V24, MIGRATE_V24_TO_V25,
-    MIGRATE_V25_TO_V26, MIGRATE_V26_TO_V27, MIGRATE_V2_TO_V3, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5,
+    MIGRATE_V25_TO_V26, MIGRATE_V26_TO_V27, MIGRATE_V27_TO_V28, MIGRATE_V2_TO_V3, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5,
     MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10,
     SCHEMA_SQL, SCHEMA_VERSION,
 };
@@ -476,6 +476,7 @@ impl YantrikDB {
             (24, MIGRATE_V24_TO_V25),
             (25, MIGRATE_V25_TO_V26),
             (26, MIGRATE_V26_TO_V27),
+            (27, MIGRATE_V27_TO_V28),
         ];
         if let Some(v) = existing_version {
             for &(from_v, sql) in migrations {
@@ -516,6 +517,19 @@ impl YantrikDB {
             params![stamp.to_string()],
         )?;
 
+        // **v28 (issue #41 brainstorm-4 §6).** Seed meta.active_generation
+        // on first install. INSERT OR IGNORE preserves the durable
+        // value on subsequent opens — reembed Phase-2's swap
+        // transaction is the only path that mutates it. If a fresh
+        // install runs without ever reembedding, the row stays '0'
+        // for the engine's entire lifetime, and pre-v28 rows whose
+        // embedding_generation IS NULL are correctly treated as
+        // "covered by generation 0."
+        conn.execute(
+            "INSERT OR IGNORE INTO meta (key, value) VALUES ('active_generation', '0')",
+            [],
+        )?;
+
         // Resolve actor_id: explicit > stored in meta > generate new
         let actor_id = if let Some(id) = actor_id {
             conn.execute(
@@ -536,6 +550,16 @@ impl YantrikDB {
                 }
             }
         };
+
+        // **v28 (issue #41 brainstorm-4 §6).** Read the durable
+        // active SearchState generation. Defaults to 0 if missing —
+        // covers both fresh installs (the INSERT OR IGNORE above
+        // wrote '0') and pre-v28 DBs that haven't been touched by
+        // the v28 migration yet (shouldn't happen — migration ran
+        // above — but defensive).
+        let active_generation: u64 = Self::get_meta(&conn, "active_generation")?
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
 
         // Resolve node_id: stored in meta > generate random
         let node_id: u32 = match Self::get_meta(&conn, "node_id")? {
@@ -709,15 +733,27 @@ impl YantrikDB {
             // forward; the future migration sweep retires the legacy
             // embedding_dim + embedder fields and points all readers
             // here.
-            search_state: arc_swap::ArcSwap::from(std::sync::Arc::new(
-                crate::engine::reembed::SearchState::initial(
+            //
+            // **v28 (issue #41 brainstorm-4 §6).** Override the
+            // initial generation (which SearchState::initial defaults
+            // to 0) with `meta.active_generation` read above. This is
+            // the durable-linearization-point read at open: if the
+            // engine crashed between reembed's SQL swap-commit (which
+            // updates meta.active_generation) and the in-memory
+            // SearchState publish, open() recovers the correct
+            // generation here. Pre-v28 DBs and fresh installs both
+            // read 0, preserving existing behavior.
+            search_state: arc_swap::ArcSwap::from(std::sync::Arc::new({
+                let mut s = crate::engine::reembed::SearchState::initial(
                     embedding_dim,
                     16,
                     200,
                     50,
                     vec_index_arc,
-                ),
-            )),
+                );
+                s.generation = active_generation;
+                s
+            })),
             index_write_lock: parking_lot::Mutex::new(()),
         })
     }

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -38,6 +38,7 @@ mod query_dsl;
 mod recall;
 mod receptivity;
 mod record;
+pub mod reembed;
 mod replay_engine;
 mod schema_induction_engine;
 mod session;
@@ -79,9 +80,9 @@ use crate::schema::{
     MIGRATE_V14_TO_V15, MIGRATE_V15_TO_V16, MIGRATE_V16_TO_V17, MIGRATE_V17_TO_V18,
     MIGRATE_V18_TO_V19, MIGRATE_V19_TO_V20, MIGRATE_V1_TO_V2, MIGRATE_V20_TO_V21,
     MIGRATE_V21_TO_V22, MIGRATE_V22_TO_V23, MIGRATE_V23_TO_V24, MIGRATE_V24_TO_V25,
-    MIGRATE_V25_TO_V26, MIGRATE_V2_TO_V3, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5, MIGRATE_V5_TO_V6,
-    MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10, SCHEMA_SQL,
-    SCHEMA_VERSION,
+    MIGRATE_V25_TO_V26, MIGRATE_V26_TO_V27, MIGRATE_V2_TO_V3, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5,
+    MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10,
+    SCHEMA_SQL, SCHEMA_VERSION,
 };
 use crate::types::*;
 
@@ -412,6 +413,7 @@ impl YantrikDB {
             (23, MIGRATE_V23_TO_V24),
             (24, MIGRATE_V24_TO_V25),
             (25, MIGRATE_V25_TO_V26),
+            (26, MIGRATE_V26_TO_V27),
         ];
         if let Some(v) = existing_version {
             for &(from_v, sql) in migrations {

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -337,7 +337,7 @@ impl YantrikDB {
                 downloaded.dim(),
             )));
         }
-        self.set_embedder(Box::new(downloaded));
+        self.set_embedder(Box::new(downloaded))?;
         Ok(())
     }
 
@@ -377,7 +377,13 @@ impl YantrikDB {
         {
             use crate::embedder::{BundledEmbedder, BUNDLED_EMBEDDER_DIM};
             if db.embedding_dim() == BUNDLED_EMBEDDER_DIM {
-                db.set_embedder(Box::new(BundledEmbedder::new()));
+                // set_embedder returns Result post-#41 (mode-aware
+                // refactor). Auto-attach is best-effort — if it fails
+                // for any reason (currently only dim mismatch, but
+                // that's already gated by the if above) we proceed
+                // without an embedder and the user can wire one
+                // manually. Failure here is not catastrophic.
+                let _ = db.set_embedder(Box::new(BundledEmbedder::new()));
             }
         }
     }
@@ -965,24 +971,150 @@ impl YantrikDB {
             .map_err(|(_, e)| YantrikDbError::Database(e))
     }
 
-    // ── Embedder integration ──
+    // ── Embedder integration (issue #41 layer 2: SearchState-derived) ──
 
-    /// Set the text-to-embedding converter. Enables `embed()`, `record_text()`,
-    /// and `recall_text()` which auto-embed text without an external server.
-    pub fn set_embedder(&mut self, embedder: Box<dyn crate::types::Embedder + Send + Sync>) {
-        self.embedder = Some(embedder);
+    /// Set the text-to-embedding converter (mode-aware per brainstorm-3).
+    /// Enables `embed()`, `record_text()`, and `recall_text()`.
+    ///
+    /// **Behavior change vs pre-#41:** the call now returns `Result<()>`
+    /// and rejects the silent-corruption shape:
+    /// - Different dim → `Err(ChangeEmbedderDimensionRequiresReembed)`
+    /// - Different fingerprint on populated `Known`-provenance DB →
+    ///   `Err(ChangeEmbedderDigestRequiresReembed)`
+    /// - Compatible cases (empty DB, matching digest, or compat-attach
+    ///   to `ExternalOrUnknown` provenance) → `Ok(())`
+    ///
+    /// All publication is under `index_write_lock` so concurrent
+    /// set_embedder/reembed calls serialize cleanly.
+    pub fn set_embedder(
+        &mut self,
+        embedder: Box<dyn crate::types::Embedder + Send + Sync>,
+    ) -> Result<()> {
+        let candidate_dim = embedder.dim();
+        let candidate_fp = embedder.fingerprint();
+        let candidate_name = embedder.name();
+        let arc_embedder: std::sync::Arc<dyn crate::types::Embedder + Send + Sync> =
+            std::sync::Arc::from(embedder);
+
+        let _guard = self.index_write_lock.lock();
+        let state = self.search_state.load_full();
+
+        if candidate_dim != state.dim() {
+            let memory_count = self.count_indexed_memories_for_set_embedder()?;
+            return Err(YantrikDbError::ChangeEmbedderDimensionRequiresReembed {
+                active_dim: state.dim(),
+                candidate_dim,
+                memory_count,
+            });
+        }
+
+        let memory_count = self.count_indexed_memories_for_set_embedder()?;
+        let index_empty = memory_count == 0;
+
+        let new_state = if index_empty {
+            // Empty index: attach + (if candidate has fingerprint)
+            // upgrade provenance to Known. Otherwise stay ExternalOrUnknown.
+            let new_provenance = match candidate_fp.as_deref() {
+                Some(fp) => crate::engine::reembed::EmbeddingProvenance::Known {
+                    name: candidate_name.clone(),
+                    digest: fp.to_string(),
+                    dim: candidate_dim,
+                },
+                None => crate::engine::reembed::EmbeddingProvenance::ExternalOrUnknown {
+                    dim: candidate_dim,
+                },
+            };
+            crate::engine::reembed::SearchState {
+                index_embedding: new_provenance,
+                embedder: Some(arc_embedder),
+                runtime_embedder_name: candidate_name,
+                runtime_embedder_digest: candidate_fp,
+                generation: state.generation,
+                covers_through_seq: state.covers_through_seq,
+                hnsw_m: state.hnsw_m,
+                hnsw_ef_construction: state.hnsw_ef_construction,
+                hnsw_ef_search: state.hnsw_ef_search,
+            }
+        } else {
+            match &state.index_embedding {
+                crate::engine::reembed::EmbeddingProvenance::Known { digest, dim, .. } => {
+                    if candidate_fp.as_deref() != Some(digest.as_str()) {
+                        return Err(YantrikDbError::ChangeEmbedderDigestRequiresReembed {
+                            active_digest: Some(digest.clone()),
+                            candidate_digest: candidate_fp,
+                            dim: *dim,
+                            memory_count,
+                        });
+                    }
+                    // Same digest: Arc-swap runtime embedder, no
+                    // generation/provenance change.
+                    crate::engine::reembed::SearchState {
+                        index_embedding: state.index_embedding.clone(),
+                        embedder: Some(arc_embedder),
+                        runtime_embedder_name: candidate_name,
+                        runtime_embedder_digest: candidate_fp,
+                        generation: state.generation,
+                        covers_through_seq: state.covers_through_seq,
+                        hnsw_m: state.hnsw_m,
+                        hnsw_ef_construction: state.hnsw_ef_construction,
+                        hnsw_ef_search: state.hnsw_ef_search,
+                    }
+                }
+                crate::engine::reembed::EmbeddingProvenance::ExternalOrUnknown { .. } => {
+                    // Compat-attach: dim matches, provenance stays
+                    // ExternalOrUnknown (we cannot claim the index is
+                    // in this embedder's vector space — we don't know
+                    // who built the existing vectors).
+                    crate::engine::reembed::SearchState {
+                        index_embedding: state.index_embedding.clone(),
+                        embedder: Some(arc_embedder),
+                        runtime_embedder_name: candidate_name,
+                        runtime_embedder_digest: candidate_fp,
+                        generation: state.generation,
+                        covers_through_seq: state.covers_through_seq,
+                        hnsw_m: state.hnsw_m,
+                        hnsw_ef_construction: state.hnsw_ef_construction,
+                        hnsw_ef_search: state.hnsw_ef_search,
+                    }
+                }
+            }
+        };
+
+        self.search_state.store(std::sync::Arc::new(new_state));
+        // Legacy slot retired post-#41: all reads now route through
+        // search_state. Clear it to catch any latent reader.
+        self.embedder = None;
+        Ok(())
     }
 
-    /// Whether an embedder is configured.
+    /// Internal helper for `set_embedder*` / future `reembed()`: count
+    /// memories that have an embedding (indexed vectors). Uses SQL count
+    /// for consistency across delta / cold / tombstoned states. Called
+    /// under `index_write_lock`.
+    pub(crate) fn count_indexed_memories_for_set_embedder(&self) -> Result<u64> {
+        let conn = self.read_conn();
+        let n: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM memories WHERE embedding IS NOT NULL \
+             AND consolidation_status = 'active'",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(n.max(0) as u64)
+    }
+
+    /// Whether a runtime embedder is configured. Derives from
+    /// SearchState — single source of truth after #41 layer 2.
     pub fn has_embedder(&self) -> bool {
-        self.embedder.is_some()
+        self.search_state.load().embedder.is_some()
     }
 
-    /// Embed text using the configured embedder.
+    /// Embed text using the configured runtime embedder. Acquires one
+    /// SearchState snapshot at the start so the call uses a consistent
+    /// embedder even if set_embedder/reembed runs concurrently.
     pub fn embed(&self, text: &str) -> Result<Vec<f32>> {
-        self.embedder
-            .as_ref()
-            .ok_or(YantrikDbError::NoEmbedder)?
+        let state = self.search_state.load_full();
+        let embedder = state.embedder.as_ref().ok_or(YantrikDbError::NoEmbedder)?;
+        embedder
             .embed(text)
             .map_err(|e| YantrikDbError::Inference(e.to_string()))
     }

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -124,7 +124,24 @@ pub struct YantrikDB {
     pub(crate) hlc: Mutex<HLC>,
     pub(crate) actor_id: String,
     pub(crate) scoring_cache: RwLock<HashMap<String, ScoringRow>>,
-    pub(crate) vec_index: crate::vector::delta_index::DeltaIndex,
+    /// **Issue #41 brainstorm-4 transitional shape.** Held as
+    /// `Arc<DeltaIndex>` (not bare `DeltaIndex`) so this slot can share
+    /// the exact same `DeltaIndex` allocation as
+    /// `SearchState.vec_index` — `Arc::clone` here is the publication
+    /// primitive. All `DeltaIndex` methods take `&self`, so the
+    /// `Arc<_>` deref-coerces and existing `self.vec_index.X()` call
+    /// sites compile unchanged. A follow-up checkpoint migrates hot
+    /// paths to load `Arc<SearchState>` once per operation and use
+    /// `state.vec_index` (single atomic snapshot — provenance + dim +
+    /// index all in one Arc), at which point this standalone field
+    /// retires. Until then, the field exists only because it is also
+    /// the field name on `YantrikDB` that ~20 call sites still
+    /// reference; the underlying `DeltaIndex` is the same object as
+    /// the one in `SearchState`, so today there is no split-brain
+    /// possible (reembed phase 2 swap, which would publish a *new*
+    /// `DeltaIndex` and create the split-brain risk, has not landed
+    /// yet — the migration sweep precedes it).
+    pub(crate) vec_index: std::sync::Arc<crate::vector::delta_index::DeltaIndex>,
     /// Monotonic seq counter for vec_index appends/tombstones.
     /// Used by Phase 6 RYW (recall_with_seq); also feeds DeltaIndex's
     /// per-entry seq tag for compaction ordering.
@@ -637,6 +654,33 @@ impl YantrikDB {
             })
             .unwrap_or(0);
 
+        // Build the DeltaIndex once, wrap in Arc, then share the same
+        // Arc between the standalone `vec_index` field and the
+        // initial `SearchState.vec_index` slot. This is the
+        // brainstorm-4 transitional shape: today both paths read the
+        // same `DeltaIndex` object so there is no split-brain; once
+        // the call-site migration sweep retires the standalone field,
+        // `SearchState.vec_index` is the only path and reembed phase
+        // 2 can republish a new `DeltaIndex` atomically.
+        let vec_index_arc: std::sync::Arc<crate::vector::delta_index::DeltaIndex> = {
+            let delta_max = std::env::var("YANTRIKDB_DELTA_MAX")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(crate::vector::delta_index::DEFAULT_DELTA_MAX);
+            let max_dirty_age = std::env::var("YANTRIKDB_MAX_DIRTY_AGE_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(std::time::Duration::from_secs)
+                .unwrap_or(crate::vector::delta_index::DEFAULT_MAX_DIRTY_AGE);
+            std::sync::Arc::new(
+                crate::vector::delta_index::DeltaIndex::from_cold_with_age(
+                    vec_index,
+                    delta_max,
+                    max_dirty_age,
+                ),
+            )
+        };
+
         Ok(Self {
             conn: Mutex::new(conn),
             read_conns,
@@ -645,22 +689,7 @@ impl YantrikDB {
             hlc: Mutex::new(HLC::new(node_id)),
             actor_id,
             scoring_cache: RwLock::new(scoring_cache),
-            vec_index: {
-                let delta_max = std::env::var("YANTRIKDB_DELTA_MAX")
-                    .ok()
-                    .and_then(|v| v.parse::<usize>().ok())
-                    .unwrap_or(crate::vector::delta_index::DEFAULT_DELTA_MAX);
-                let max_dirty_age = std::env::var("YANTRIKDB_MAX_DIRTY_AGE_SECS")
-                    .ok()
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .map(std::time::Duration::from_secs)
-                    .unwrap_or(crate::vector::delta_index::DEFAULT_MAX_DIRTY_AGE);
-                crate::vector::delta_index::DeltaIndex::from_cold_with_age(
-                    vec_index,
-                    delta_max,
-                    max_dirty_age,
-                )
-            },
+            vec_index: std::sync::Arc::clone(&vec_index_arc),
             vec_seq: std::sync::atomic::AtomicU64::new(0),
             pending_op_count: std::sync::atomic::AtomicI64::new(initial_pending),
             visible_seq: dashmap::DashMap::new(),
@@ -695,6 +724,7 @@ impl YantrikDB {
                     16,
                     200,
                     50,
+                    std::sync::Arc::clone(&vec_index_arc),
                 ),
             )),
             index_write_lock: parking_lot::Mutex::new(()),
@@ -1034,6 +1064,11 @@ impl YantrikDB {
                 hnsw_m: state.hnsw_m,
                 hnsw_ef_construction: state.hnsw_ef_construction,
                 hnsw_ef_search: state.hnsw_ef_search,
+                // set_embedder never swaps the physical index — only
+                // embedder/provenance. Reuse the same Arc<DeltaIndex>
+                // so reembed phase 2 stays the only path that
+                // republishes a new `vec_index` (brainstorm-4 §1).
+                vec_index: std::sync::Arc::clone(&state.vec_index),
             }
         } else {
             match &state.index_embedding {
@@ -1058,6 +1093,7 @@ impl YantrikDB {
                         hnsw_m: state.hnsw_m,
                         hnsw_ef_construction: state.hnsw_ef_construction,
                         hnsw_ef_search: state.hnsw_ef_search,
+                        vec_index: std::sync::Arc::clone(&state.vec_index),
                     }
                 }
                 crate::engine::reembed::EmbeddingProvenance::ExternalOrUnknown { .. } => {
@@ -1075,6 +1111,7 @@ impl YantrikDB {
                         hnsw_m: state.hnsw_m,
                         hnsw_ef_construction: state.hnsw_ef_construction,
                         hnsw_ef_search: state.hnsw_ef_search,
+                        vec_index: std::sync::Arc::clone(&state.vec_index),
                     }
                 }
             }

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -3876,41 +3876,27 @@ impl YantrikDB {
     }
 
     /// Batch-fetch embeddings for a set of RIDs (for graph-only candidate scoring).
+    ///
+    /// **Issue #41 brainstorm-4 §5 — routes through the
+    /// `DurableEmbeddingStore` module boundary.** Recall is the hot
+    /// user-facing query path and is the file the §5 audit test
+    /// guards; direct `SELECT ... embedding FROM memories` here
+    /// would bypass the generation-stamp surface and silently
+    /// return stale-vector-space bytes during a reembed. Going
+    /// through the store gives every entry an
+    /// `EmbeddingWithGeneration` tag — discarded here for the
+    /// graph-only scoring path which tolerates lag, surfaced where
+    /// callers need to discriminate.
     pub(crate) fn fetch_embeddings_by_rids(
         &self,
         rids: &[&str],
     ) -> Result<HashMap<String, Vec<u8>>> {
-        if rids.is_empty() {
-            return Ok(HashMap::new());
-        }
-        let placeholders: String = (0..rids.len())
-            .map(|i| format!("?{}", i + 1))
-            .collect::<Vec<_>>()
-            .join(",");
-        let sql = format!("SELECT rid, embedding FROM memories WHERE rid IN ({placeholders})");
-        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-        for r in rids {
-            param_values.push(Box::new(r.to_string()));
-        }
-        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
-            param_values.iter().map(|p| p.as_ref()).collect();
-
-        let conn = self.read_conn();
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt
-            .query_map(params_ref.as_slice(), |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
-            })?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        drop(stmt);
-        drop(conn);
-
-        let mut map = HashMap::new();
-        for (rid, stored_emb) in rows {
-            let emb = self.decrypt_embedding(&stored_emb)?;
-            map.insert(rid, emb);
-        }
-        Ok(map)
+        let store = super::durable_embeddings::DurableEmbeddingStore::new(self);
+        let stamped = store.read_embeddings_for_rids(rids)?;
+        Ok(stamped
+            .into_iter()
+            .map(|(rid, entry)| (rid, entry.bytes))
+            .collect())
     }
 
     /// Reinforce a memory on access — increase half_life, update last_access,

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -169,9 +169,14 @@ impl YantrikDB {
         // Step 1: Vector candidate generation via HNSW
         // Fetch a large pool to ensure diverse, high-quality candidates survive MMR filtering.
         let fetch_k = (top_k * 20).min(500);
+        // **Issue #41 brainstorm-4 §1.** Snapshot SearchState once for
+        // the full recall path so the HNSW search sees the same
+        // generation-anchored index every time it's queried within
+        // this call.
+        let state = self.search_state.load_full();
         let vec_results = {
             let _span = tracing::debug_span!("hnsw_search", fetch_k).entered();
-            self.vec_index.search(query_embedding, fetch_k)?
+            state.vec_index.search(query_embedding, fetch_k)?
         };
 
         if vec_results.is_empty() {
@@ -2289,7 +2294,11 @@ impl YantrikDB {
         let t_vec = Instant::now();
         let ts = now();
         let fetch_k = (top_k * 20).min(500);
-        let vec_results = self.vec_index.search(query_embedding, fetch_k)?;
+        // **Issue #41 brainstorm-4 §1.** SearchState snapshot for the
+        // profiled-recall variant. Same generation-anchoring contract
+        // as `recall_ranked`.
+        let state = self.search_state.load_full();
+        let vec_results = state.vec_index.search(query_embedding, fetch_k)?;
         let vec_search_ms = t_vec.elapsed().as_secs_f64() * 1000.0;
         let candidate_count = vec_results.len();
 

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -152,6 +152,16 @@ impl YantrikDB {
         // Read active session for this namespace into a local before acquiring conn
         let session_id = self.active_sessions.read().get(namespace).cloned();
 
+        // **Issue #41 brainstorm-4 §6.** Stamp the v28
+        // embedding_generation column with the snapshot's generation
+        // so the post-swap materializer can discriminate "this row
+        // was indexed under the active generation — skip" from "this
+        // row was inserted under an old generation — needs re-encode."
+        // Read from `state.generation` (not a fresh load) because we
+        // hold the SyncWriteGuard for the entire sync path:
+        // search_state cannot advance under us until the guard drops.
+        let embedding_generation: i64 = state.generation as i64;
+
         // Acquire conn, do all SQL, then drop before other locks
         {
             let conn = self.conn();
@@ -159,8 +169,8 @@ impl YantrikDB {
                 "INSERT INTO memories \
                  (rid, type, text, embedding, created_at, updated_at, importance, \
                   half_life, last_access, valence, metadata, namespace, \
-                  certainty, domain, source, emotional_state) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                  certainty, domain, source, emotional_state, embedding_generation) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                 params![
                     rid,
                     memory_type,
@@ -177,7 +187,8 @@ impl YantrikDB {
                     certainty,
                     domain,
                     source,
-                    emotional_state
+                    emotional_state,
+                    embedding_generation,
                 ],
             )?;
 
@@ -336,16 +347,19 @@ impl YantrikDB {
                 let stored_meta = self.encrypt_text(&meta_str)?;
                 let stored_emb = self.encrypt_embedding(&emb_blob)?;
 
+                // **Issue #41 brainstorm-4 §6.** v28 embedding_generation
+                // stamped from the batch's snapshot.
+                let embedding_generation: i64 = state.generation as i64;
                 let result = conn.execute(
                     "INSERT INTO memories \
                      (rid, type, text, embedding, created_at, updated_at, importance, \
                       half_life, last_access, valence, metadata, namespace, \
-                      certainty, domain, source, emotional_state) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                      certainty, domain, source, emotional_state, embedding_generation) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                     params![rid, input.memory_type, stored_text, stored_emb, ts, ts,
                             input.importance, input.half_life, ts, input.valence, stored_meta,
                             input.namespace, input.certainty, input.domain, input.source,
-                            input.emotional_state],
+                            input.emotional_state, embedding_generation],
                 );
 
                 if let Err(e) = result {
@@ -593,19 +607,23 @@ impl YantrikDB {
             conn.execute_batch("SAVEPOINT record_with_rid")?;
 
             let result: Result<bool> = (|| {
+                // **Issue #41 brainstorm-4 §6.** v28 embedding_generation
+                // stamp from the SearchState snapshot loaded above.
+                let embedding_generation: i64 = state.generation as i64;
                 let inserted = conn.execute(
                     "INSERT OR IGNORE INTO memories \
                      (rid, type, text, embedding, created_at, updated_at, importance, \
                       half_life, last_access, valence, metadata, namespace, \
                       certainty, domain, source, emotional_state, \
-                      created_at_unix_micros, embedding_model) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6, ?7, ?5, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                      created_at_unix_micros, embedding_model, embedding_generation) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6, ?7, ?5, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                     params![
                         rid, memory_type, stored_text, stored_emb,
                         ts_secs,
                         importance, half_life, valence, stored_meta, namespace,
                         certainty, domain, source, emotional_state,
                         created_at_unix_micros, embedding_model,
+                        embedding_generation,
                     ],
                 )?;
                 let was_new_row = inserted == 1;

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1,9 +1,12 @@
 use rusqlite::params;
+use std::sync::Arc;
 
 use crate::error::Result;
 use crate::serde_helpers::serialize_f32;
 use crate::types::*;
 
+use super::reembed::SearchState;
+use super::write_router::SyncWriteGuard;
 use super::{embedding_hash, now, YantrikDB};
 
 impl YantrikDB {
@@ -70,20 +73,72 @@ impl YantrikDB {
             );
         }
         // guard is held; RAII Drop at function exit decrements inflight.
-        let _guard = sync_guard;
+        let guard = sync_guard.unwrap();
 
-        // **Issue #41 brainstorm-4 §1.** Load SearchState once for
-        // this operation. The Arc<DeltaIndex> in `state.vec_index` is
-        // captured here so the rest of the function — SQL insert,
-        // vec_index.append, oplog log — all references the same
-        // generation-anchored index. The follow-up checkpoint adds
-        // a generation revalidation against `state.generation` at
-        // commit time (brainstorm-4 §2). Until then, the standalone
-        // field and `state.vec_index` point to the same DeltaIndex
-        // so this snapshot pattern is forward-compatible with no
-        // behavior change.
+        // **Issue #41 brainstorm-4 §1.** Load SearchState AFTER the
+        // guard is acquired. With the guard held, reembed cannot
+        // complete its swap, so the loaded state is the published
+        // active generation for the entire critical section. Note:
+        // for `record()` (caller-supplied embedding), the engine
+        // cannot verify the embedding's generation provenance — the
+        // caller is responsible for using the embedder consistent
+        // with the active generation. `record_text()` (engine-
+        // supplied embedding) has a revalidation loop that ensures
+        // the embedding and the active generation match.
         let state = self.search_state.load_full();
 
+        self.record_under_guard_and_state(
+            state,
+            guard,
+            text,
+            memory_type,
+            importance,
+            valence,
+            half_life,
+            metadata,
+            embedding,
+            namespace,
+            certainty,
+            domain,
+            source,
+            emotional_state,
+        )
+    }
+
+    /// **Issue #41 brainstorm-4 §2.** The post-guard, post-load
+    /// critical section shared by `record()` and `record_text()`.
+    ///
+    /// Caller MUST hold the `SyncWriteGuard` — this is the contract
+    /// that prevents reembed from completing its SearchState swap
+    /// while we are mid-commit, and the contract that makes
+    /// `state.generation` the durable answer to "what generation am I
+    /// committing under." The guard is moved in by value and drops
+    /// via RAII at function exit, decrementing the in-flight counter.
+    ///
+    /// Caller MUST also pre-load `state` from `self.search_state` and
+    /// pass it in — this commit path uses the snapshot rather than
+    /// re-loading, so writer revalidation logic in `record_text()`
+    /// (which re-loads after embed to detect a generation advance)
+    /// is the single source of truth for generation safety on the
+    /// text-embed path.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn record_under_guard_and_state(
+        &self,
+        state: Arc<SearchState>,
+        _guard: SyncWriteGuard<'_>,
+        text: &str,
+        memory_type: &str,
+        importance: f64,
+        valence: f64,
+        half_life: f64,
+        metadata: &serde_json::Value,
+        embedding: &[f32],
+        namespace: &str,
+        certainty: f64,
+        domain: &str,
+        source: &str,
+        emotional_state: Option<&str>,
+    ) -> Result<String> {
         let rid = crate::id::new_id();
         let ts = now();
         let emb_blob = serialize_f32(embedding);

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -8,6 +8,28 @@ use super::{embedding_hash, now, YantrikDB};
 
 impl YantrikDB {
     /// Store a new memory and return its RID.
+    ///
+    /// **Issue #41 layer 3 — WriteRouter gating.** At entry, the writer
+    /// attempts to acquire a `SyncWriteGuard`. If the engine's
+    /// `write_router` is in `Normal` state (no reembed in progress),
+    /// the guard is acquired and the synchronous path runs: INSERT
+    /// memories + vec_index.append + log_op (applied=1). The guard is
+    /// held for the full critical section and drops via RAII when
+    /// `record` returns, decrementing the inflight-writer counter.
+    /// This is the brainstorm-2 invariant that prevents in-flight
+    /// writers from committing `applied=1` against an about-to-be-
+    /// discarded old generation during reembed cutover.
+    ///
+    /// If the router is in `Queueing` state (reembed has flipped the
+    /// gate and is waiting for writers to drain before capturing
+    /// `build_hwm`), `try_enter_sync_writer()` returns None and this
+    /// call routes through the queued path: the op is appended to
+    /// `oplog` with `applied=0`, `embedding_model = old_embedder_name`,
+    /// the full record payload (text + metadata) — the post-swap
+    /// materializer re-encodes under the new embedder + applies to
+    /// the new generation. The caller's return value (rid + seq) is
+    /// the same shape; read-after-write requires `recall_with_seq` to
+    /// wait for the new generation's `visible_seq` to advance.
     #[tracing::instrument(skip(self, metadata, embedding), fields(memory_type, namespace))]
     pub fn record(
         &self,
@@ -24,6 +46,32 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
     ) -> Result<String> {
+        // Issue #41 layer 3: route on write_router state. The guard
+        // (if acquired) is held for the full sync path and drops via
+        // RAII at function return, panic-safe.
+        let sync_guard = self.write_router.try_enter_sync_writer();
+        if sync_guard.is_none() {
+            // Queueing state — take the queued path. Reembed cutover
+            // is in flight; writes go to oplog and the post-swap
+            // materializer applies them under the new embedder.
+            return self.record_queued(
+                text,
+                memory_type,
+                importance,
+                valence,
+                half_life,
+                metadata,
+                embedding,
+                namespace,
+                certainty,
+                domain,
+                source,
+                emotional_state,
+            );
+        }
+        // guard is held; RAII Drop at function exit decrements inflight.
+        let _guard = sync_guard;
+
         let rid = crate::id::new_id();
         let ts = now();
         let emb_blob = serialize_f32(embedding);
@@ -621,5 +669,162 @@ impl YantrikDB {
         }
 
         Ok(())
+    }
+
+    /// **Issue #41 layer 3 — queued write path.** Called from `record()`
+    /// when `write_router.try_enter_sync_writer()` returned None
+    /// (router is in `Queueing` state during reembed cutover). The op
+    /// is logged to `oplog` with `applied=0` and the v27 columns
+    /// (`embedding_model = current_runtime_embedder_name`,
+    /// `applied_generation = NULL`). The post-swap materializer drains
+    /// these ops, re-encodes the text under the new embedder, and
+    /// applies to the new generation's memories table + HNSW.
+    ///
+    /// Important invariants from brainstorm-2/3 enforced here:
+    /// - DO NOT write to `memories` table (would mix old+new dim under
+    ///   the rebuild snapshot)
+    /// - DO NOT call `vec_index.append` (same reason)
+    /// - DO NOT bump `visible_seq` (active generation doesn't yet
+    ///   cover this seq; the post-swap materializer bumps it after
+    ///   applying)
+    /// - DO assign a `vec_seq` for the caller's RYW use
+    ///   (`recall_with_seq(min_seq=N)` waits for the new generation to
+    ///   advance past N)
+    ///
+    /// The pre-computed `embedding` argument is intentionally
+    /// IGNORED. Per brainstorm-3 invariant 8 (queued payload
+    /// correctness), the oplog stores logical text and the materializer
+    /// re-encodes under the NEW embedder at replay time. Storing a
+    /// pre-encoded old-embedder vector in oplog would race against
+    /// post-swap replay and produce dim mismatch when the new HNSW is
+    /// at a different dim.
+    pub(crate) fn record_queued(
+        &self,
+        text: &str,
+        memory_type: &str,
+        importance: f64,
+        valence: f64,
+        half_life: f64,
+        metadata: &serde_json::Value,
+        _embedding: &[f32],
+        namespace: &str,
+        certainty: f64,
+        domain: &str,
+        source: &str,
+        emotional_state: Option<&str>,
+    ) -> Result<String> {
+        let rid = crate::id::new_id();
+        let ts = now();
+
+        // Assign a seq for caller's RYW use. Note we do NOT bump
+        // visible_seq — the active generation doesn't yet cover this
+        // op; the post-swap materializer is responsible for advancing
+        // visible_seq as it drains queued ops.
+        let _seq = self
+            .vec_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+
+        // Capture the current runtime embedder name (the one active
+        // before reembed flipped the router). The post-swap materializer
+        // uses this to discriminate ops queued under the old embedder
+        // (need re-encode) from ops produced by the new generation's
+        // own writers (apply embedding bytes directly).
+        let current_embedder_name = self
+            .search_state
+            .load()
+            .runtime_embedder_name
+            .clone();
+
+        // Full record payload — what the materializer needs to
+        // reconstruct the row.
+        let payload = serde_json::json!({
+            "rid": rid,
+            "type": memory_type,
+            "text": text,
+            "importance": importance,
+            "valence": valence,
+            "half_life": half_life,
+            "metadata": metadata,
+            "created_at": ts,
+            "updated_at": ts,
+            "namespace": namespace,
+            "certainty": certainty,
+            "domain": domain,
+            "source": source,
+            "emotional_state": emotional_state,
+        });
+
+        // Write to oplog with applied=0. The v27 `embedding_model`
+        // column carries the OLD embedder name so the post-swap
+        // materializer knows this needs re-encoding (vs being a
+        // legacy pre-v27 op where embedding_model IS NULL and the
+        // materializer trusts the embedding bytes as-is).
+        self.log_op_pending_for_reembed_queue(
+            "record",
+            Some(&rid),
+            &payload,
+            current_embedder_name.as_deref(),
+        )?;
+
+        Ok(rid)
+    }
+
+    /// **Issue #41 layer 3 — variant of `log_op_pending` that populates
+    /// the v27 `oplog.embedding_model` column.** Used by the queued
+    /// write path during reembed; lets the post-swap materializer
+    /// discriminate queued-during-reembed ops (which need re-encoding
+    /// under the new embedder) from legacy pre-v27 ops (which have
+    /// NULL `embedding_model` and trust their stored embedding bytes).
+    pub(crate) fn log_op_pending_for_reembed_queue(
+        &self,
+        op_type: &str,
+        target_rid: Option<&str>,
+        payload: &serde_json::Value,
+        embedding_model: Option<&str>,
+    ) -> Result<String> {
+        use rusqlite::params;
+        use std::sync::atomic::Ordering;
+
+        let op_id = crate::id::new_id();
+        let hlc_ts = self.tick_hlc();
+        let hlc_bytes = hlc_ts.to_bytes().to_vec();
+        let payload_str = serde_json::to_string(payload)?;
+
+        // Backpressure check (mirrors log_op_pending's contract).
+        const MAX_PENDING_OPS: i64 = 10_000;
+        let pending_now = self.pending_op_count.load(Ordering::Relaxed);
+        if pending_now >= MAX_PENDING_OPS {
+            return Err(crate::error::YantrikDbError::Backpressure {
+                pending: pending_now,
+                max: MAX_PENDING_OPS,
+                retry_after_ms: 50,
+            });
+        }
+
+        let conn = self.conn.lock();
+        conn.execute(
+            "INSERT OR IGNORE INTO oplog \
+             (op_id, op_type, timestamp, target_rid, payload, \
+              actor_id, hlc, embedding_hash, origin_actor, applied, \
+              embedding, embedding_model, applied_generation) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0, NULL, ?10, NULL)",
+            params![
+                op_id,
+                op_type,
+                now(),
+                target_rid,
+                payload_str,
+                self.actor_id,
+                hlc_bytes,
+                None::<Vec<u8>>,
+                self.actor_id,
+                embedding_model,
+            ],
+        )?;
+        if conn.changes() > 0 {
+            self.pending_op_count.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(op_id)
     }
 }

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -72,6 +72,18 @@ impl YantrikDB {
         // guard is held; RAII Drop at function exit decrements inflight.
         let _guard = sync_guard;
 
+        // **Issue #41 brainstorm-4 §1.** Load SearchState once for
+        // this operation. The Arc<DeltaIndex> in `state.vec_index` is
+        // captured here so the rest of the function — SQL insert,
+        // vec_index.append, oplog log — all references the same
+        // generation-anchored index. The follow-up checkpoint adds
+        // a generation revalidation against `state.generation` at
+        // commit time (brainstorm-4 §2). Until then, the standalone
+        // field and `state.vec_index` point to the same DeltaIndex
+        // so this snapshot pattern is forward-compatible with no
+        // behavior change.
+        let state = self.search_state.load_full();
+
         let rid = crate::id::new_id();
         let ts = now();
         let emb_blob = serialize_f32(embedding);
@@ -133,7 +145,8 @@ impl YantrikDB {
             .vec_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             + 1;
-        self.vec_index
+        state
+            .vec_index
             .append(rid.clone(), embedding.to_vec(), seq)?;
         self.bump_visible_seq(namespace, seq);
 
@@ -220,6 +233,11 @@ impl YantrikDB {
         if inputs.is_empty() {
             return Ok(vec![]);
         }
+
+        // **Issue #41 brainstorm-4 §1.** SearchState snapshot for the
+        // batch — every append in this batch lands on the same
+        // generation-anchored DeltaIndex.
+        let state = self.search_state.load_full();
 
         // Clone active sessions map before acquiring conn
         let sessions = self.active_sessions.read().clone();
@@ -371,7 +389,8 @@ impl YantrikDB {
                 .vec_seq
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                 + 1;
-            self.vec_index
+            state
+                .vec_index
                 .append(rid.clone(), input.embedding.clone(), seq)?;
             self.bump_visible_seq(&input.namespace, seq);
         }
@@ -489,6 +508,11 @@ impl YantrikDB {
             });
         }
 
+        // **Issue #41 brainstorm-4 §1.** SearchState snapshot for the
+        // determinstic-replay path. The replicated write lands on the
+        // currently-active generation's DeltaIndex.
+        let state = self.search_state.load_full();
+
         // Caller-supplied timestamp — NEVER call now() on this path.
         let ts_secs = (created_at_unix_micros as f64) / 1_000_000.0;
         let emb_blob = serialize_f32(embedding);
@@ -577,7 +601,8 @@ impl YantrikDB {
         // (single-node retry); the compactor's highest-seq-wins rule
         // converges state identically on both paths.
         let seq = self.assign_seq(seq);
-        self.vec_index
+        state
+            .vec_index
             .append(rid.to_string(), embedding.to_vec(), seq)?;
         self.bump_visible_seq(namespace, seq);
 

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -828,11 +828,7 @@ impl YantrikDB {
         // uses this to discriminate ops queued under the old embedder
         // (need re-encode) from ops produced by the new generation's
         // own writers (apply embedding bytes directly).
-        let current_embedder_name = self
-            .search_state
-            .load()
-            .runtime_embedder_name
-            .clone();
+        let current_embedder_name = self.search_state.load().runtime_embedder_name.clone();
 
         // Full record payload — what the materializer needs to
         // reconstruct the row.

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -1739,6 +1739,40 @@ mod tests {
         }
     }
 
+    /// Sentinel variant for Layer 5 drain tests. The first element
+    /// of the produced vector is set to `sentinel`, so tests can
+    /// assert "this embedding came from THIS embedder" by checking
+    /// vec[0].
+    struct PhaseTestEmbedderSentinel {
+        pub dim: usize,
+        pub fp: String,
+        pub name: String,
+        pub sentinel: f32,
+    }
+
+    impl crate::types::Embedder for PhaseTestEmbedderSentinel {
+        fn embed(
+            &self,
+            _text: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>>
+        {
+            let mut v = vec![0.0_f32; self.dim];
+            if !v.is_empty() {
+                v[0] = self.sentinel;
+            }
+            Ok(v)
+        }
+        fn dim(&self) -> usize {
+            self.dim
+        }
+        fn fingerprint(&self) -> Option<String> {
+            Some(self.fp.clone())
+        }
+        fn name(&self) -> Option<String> {
+            Some(self.name.clone())
+        }
+    }
+
     #[test]
     fn reembed_same_name_is_no_op() {
         // Caller asks for the embedder already loaded — must short-
@@ -1942,6 +1976,197 @@ mod tests {
         assert!(
             db.write_router.try_enter_sync_writer().is_some(),
             "WriteRouter must be Normal after reembed completion"
+        );
+    }
+
+    #[test]
+    fn layer_5_materializer_drains_queued_record_under_new_embedder() {
+        // **Issue #41 Layer 5 — full Queue-mode integration.**
+        // Flow:
+        //   1. Engine at gen 0 with embedder E0 ("sentinel=0.42").
+        //   2. Flip WriteRouter to Queueing manually (simulating
+        //      a reembed in flight at the cutover preamble).
+        //   3. record_text → revalidation loop sees Queueing →
+        //      routes to record_queued → writes oplog applied=0
+        //      with embedding_model="E0-name" and TEXT payload.
+        //   4. Manually swap SearchState to gen 1 with embedder E1
+        //      ("sentinel=0.99") via try_publish_search_state +
+        //      flip router back to Normal (mimics what Phase 2 does).
+        //   5. Run apply_pending_ops_once. Layer 5 picks up the
+        //      queued op, re-encodes the text under E1, INSERTs
+        //      the memory row at embedding_generation=1, appends
+        //      to the active vec_index.
+        //   6. Assert: memories table now has the row with
+        //      embedding_generation=1, the stored bytes encode to
+        //      0.99 (E1's signature, not 0.42 of E0), oplog row
+        //      is applied=1.
+        use std::sync::Arc;
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+
+        // Configure E0 as active.
+        db.set_embedder(Box::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:E0".to_string(),
+            name: "E0-name".to_string(),
+            sentinel: 0.42,
+        }))
+        .unwrap();
+
+        // Simulate reembed cutover preamble: flip router to Queueing.
+        db.write_router.switch_to_queueing();
+
+        // record_text routes through the queue path.
+        let queued_rid = db
+            .record_text(
+                "queue-drain-test-text",
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({"k": "v"}),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+
+        // memories table is NOT yet written — queue path stores text in oplog.
+        let mem_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE rid = ?1",
+                [&queued_rid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(mem_count, 0, "queue path does not write memories yet");
+
+        // Now simulate Phase 2 completing the swap: build a new
+        // SearchState at gen 1 with embedder E1, publish via CAS,
+        // flip router back to Normal.
+        let old_state = db.search_state.load_full();
+        let e1: Arc<dyn crate::types::Embedder + Send + Sync> =
+            Arc::new(PhaseTestEmbedderSentinel {
+                dim: 8,
+                fp: "sha256:E1".to_string(),
+                name: "E1-name".to_string(),
+                sentinel: 0.99,
+            });
+        let new_state = SearchState {
+            index_embedding: EmbeddingProvenance::Known {
+                name: Some("E1-name".to_string()),
+                digest: "sha256:E1".to_string(),
+                dim: 8,
+            },
+            embedder: Some(Arc::clone(&e1)),
+            runtime_embedder_name: Some("E1-name".to_string()),
+            runtime_embedder_digest: Some("sha256:E1".to_string()),
+            generation: 1,
+            covers_through_seq: old_state.covers_through_seq,
+            hnsw_m: old_state.hnsw_m,
+            hnsw_ef_construction: old_state.hnsw_ef_construction,
+            hnsw_ef_search: old_state.hnsw_ef_search,
+            vec_index: Arc::clone(&old_state.vec_index),
+        };
+        db.try_publish_search_state(new_state).unwrap();
+        db.write_router.switch_to_normal();
+
+        // Layer 5 drain: materializer picks up the queued op and
+        // re-encodes under E1.
+        let n_applied = db.apply_pending_ops_once(100).unwrap();
+        assert!(
+            n_applied >= 1,
+            "Layer 5 materializer must drain the queued record (applied >= 1, got {n_applied})"
+        );
+
+        // Memories row exists, stamped with new generation, encoded
+        // under E1 (sentinel 0.99).
+        let conn = db.conn();
+        let (row_gen, stored_emb_blob): (i64, Vec<u8>) = conn
+            .query_row(
+                "SELECT embedding_generation, embedding FROM memories WHERE rid = ?1",
+                [&queued_rid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(row_gen, 1, "Layer 5 stamped row at new generation 1");
+        let plain = db.decrypt_embedding(&stored_emb_blob).unwrap();
+        let vec = crate::serde_helpers::deserialize_f32(&plain);
+        assert!(
+            (vec[0] - 0.99).abs() < 1e-6,
+            "row encoded under E1 (sentinel 0.99), got vec[0]={}",
+            vec[0]
+        );
+
+        // Oplog op is applied=1.
+        let applied: i64 = conn
+            .query_row(
+                "SELECT applied FROM oplog WHERE target_rid = ?1 AND op_type = 'record'",
+                [&queued_rid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(applied, 1, "queued oplog row marked applied=1 after drain");
+    }
+
+    #[test]
+    fn layer_5_defers_drain_while_reembed_in_flight() {
+        // **Layer 5 invariant — pause-during-reembed.** While
+        // meta.reembed_state is set (reembed mid-flight), Layer 5
+        // must NOT drain queued reembed writes. It returns
+        // applied=0 (the op stays pending) so the next tick after
+        // reembed completes picks it up.
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:E0".to_string(),
+            name: "E0-name".to_string(),
+            sentinel: 0.42,
+        }))
+        .unwrap();
+
+        // Flip to Queueing + record_text → queued op.
+        db.write_router.switch_to_queueing();
+        let queued_rid = db
+            .record_text(
+                "deferred-drain-test",
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+
+        // Manually write meta.reembed_state to simulate reembed in flight.
+        db.write_reembed_state_meta(&serde_json::json!({
+            "generation": 1,
+            "phase": "Encoding",
+        }))
+        .unwrap();
+
+        // Drain should NOT touch the queued op.
+        let _ = db.apply_pending_ops_once(100).unwrap();
+
+        // Oplog row still applied=0.
+        let applied: i64 = db
+            .conn()
+            .query_row(
+                "SELECT applied FROM oplog WHERE target_rid = ?1 AND op_type = 'record'",
+                [&queued_rid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            applied, 0,
+            "Layer 5 must defer drain while reembed in flight; got applied={applied}"
         );
     }
 

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -377,9 +377,7 @@ pub enum EmbeddingProvenance {
     /// not provable. `set_embedder*` with matching dim can attach a
     /// runtime embedder via the compat path without claiming the index
     /// is in the new embedder's vector space.
-    ExternalOrUnknown {
-        dim: usize,
-    },
+    ExternalOrUnknown { dim: usize },
 }
 
 impl EmbeddingProvenance {
@@ -627,11 +625,7 @@ impl YantrikDB {
             .unwrap_or_default();
         if active_name_for_check == new_embedder_name {
             // Same-name no-op: skip registry resolution entirely.
-            return self.reembed_with_embedder(
-                new_embedder_name,
-                None,
-                options,
-            );
+            return self.reembed_with_embedder(new_embedder_name, None, options);
         }
         drop(probing_state_for_name_check);
 
@@ -749,9 +743,7 @@ impl YantrikDB {
         })?;
 
         let new_dim = new_embedder.dim();
-        let new_embedder_digest = new_embedder
-            .fingerprint()
-            .unwrap_or_default();
+        let new_embedder_digest = new_embedder.fingerprint().unwrap_or_default();
         let new_embedder_name_resolved = new_embedder
             .name()
             .unwrap_or_else(|| new_embedder_name.to_string());
@@ -924,8 +916,7 @@ impl YantrikDB {
             // Re-encode each row's text under the new embedder.
             // Done OUTSIDE the conn lock — embedder.embed() can be
             // slow (model inference) and must not bottleneck SQL.
-            let mut encoded_pairs: Vec<(String, Vec<u8>)> =
-                Vec::with_capacity(batch.len());
+            let mut encoded_pairs: Vec<(String, Vec<u8>)> = Vec::with_capacity(batch.len());
             for (rid, stored_text) in &batch {
                 let plain = self.decrypt_text(stored_text)?;
                 let new_emb = new_embedder.embed(&plain).map_err(|e| {
@@ -1066,10 +1057,9 @@ impl YantrikDB {
                      LIMIT ?1 OFFSET ?2",
                 )?;
                 let rows = stmt
-                    .query_map(
-                        params![batch_size as i64, rebuild_offset as i64],
-                        |r| Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?)),
-                    )?
+                    .query_map(params![batch_size as i64, rebuild_offset as i64], |r| {
+                        Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?))
+                    })?
                     .collect::<std::result::Result<Vec<_>, _>>()?;
                 drop(stmt);
                 drop(conn);
@@ -1178,9 +1168,7 @@ impl YantrikDB {
         // (after the SQL swap) in the NEW index. Writes past this
         // seq either are queued in oplog (Queueing) or arrived
         // post-cutover and will be applied to the new gen directly.
-        let covers_through_seq = self
-            .vec_seq
-            .load(std::sync::atomic::Ordering::Acquire);
+        let covers_through_seq = self.vec_seq.load(std::sync::atomic::Ordering::Acquire);
 
         // Cutover step 4: tail-catchup. Encode any rows whose
         // embedding_generation is still under the new generation
@@ -1292,13 +1280,11 @@ impl YantrikDB {
                 .and_then(|v| v.parse::<u64>().ok())
                 .map(std::time::Duration::from_secs)
                 .unwrap_or(crate::vector::delta_index::DEFAULT_MAX_DIRTY_AGE);
-            std::sync::Arc::new(
-                crate::vector::delta_index::DeltaIndex::from_cold_with_age(
-                    new_hnsw,
-                    delta_max,
-                    max_dirty_age,
-                ),
-            )
+            std::sync::Arc::new(crate::vector::delta_index::DeltaIndex::from_cold_with_age(
+                new_hnsw,
+                delta_max,
+                max_dirty_age,
+            ))
         };
 
         let new_search_state = SearchState {
@@ -1453,16 +1439,13 @@ impl YantrikDB {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        let old_dim = payload
-            .get("old_dim")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as usize;
+        let old_dim = payload.get("old_dim").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
         let started_at_unix = payload
             .get("started_at_unix")
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
-        let started_at = std::time::UNIX_EPOCH
-            + std::time::Duration::from_secs_f64(started_at_unix.max(0.0));
+        let started_at =
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs_f64(started_at_unix.max(0.0));
         let write_policy = match payload.get("write_policy").and_then(|v| v.as_str()) {
             Some("Pause") => ReembedWritePolicy::Pause,
             _ => ReembedWritePolicy::Queue,
@@ -1514,10 +1497,7 @@ impl YantrikDB {
     }
 
     /// Write `meta.reembed_state` with the current job summary JSON.
-    pub(crate) fn write_reembed_state_meta(
-        &self,
-        state_json: &serde_json::Value,
-    ) -> Result<()> {
+    pub(crate) fn write_reembed_state_meta(&self, state_json: &serde_json::Value) -> Result<()> {
         use rusqlite::params;
         let s = serde_json::to_string(state_json)?;
         let conn = self.conn();
@@ -1558,9 +1538,8 @@ impl YantrikDB {
             // No durable row to update — clear-state path took it.
             return Ok(());
         };
-        let mut state: serde_json::Value = serde_json::from_str(&s).unwrap_or_else(|_| {
-            serde_json::json!({})
-        });
+        let mut state: serde_json::Value =
+            serde_json::from_str(&s).unwrap_or_else(|_| serde_json::json!({}));
         if let Some(map) = state.as_object_mut() {
             map.insert(
                 "phase".to_string(),
@@ -1684,9 +1663,7 @@ mod tests {
         // embedder has populated the index yet), embedder is None
         // (caller may pass pre-computed vectors), generation=0,
         // covers_through_seq=0.
-        let vec_index = Arc::new(
-            crate::vector::delta_index::DeltaIndex::new(384),
-        );
+        let vec_index = Arc::new(crate::vector::delta_index::DeltaIndex::new(384));
         let s = SearchState::initial(384, 16, 200, 50, vec_index);
         assert_eq!(s.dim(), 384);
         assert!(matches!(
@@ -1724,8 +1701,7 @@ mod tests {
         fn embed(
             &self,
             _text: &str,
-        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>>
-        {
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
             Ok(vec![0.1_f32; self.dim])
         }
         fn dim(&self) -> usize {
@@ -1754,8 +1730,7 @@ mod tests {
         fn embed(
             &self,
             _text: &str,
-        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>>
-        {
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
             let mut v = vec![0.0_f32; self.dim];
             if !v.is_empty() {
                 v[0] = self.sentinel;
@@ -1792,7 +1767,10 @@ mod tests {
         assert_eq!(report.old_embedder, "model-x");
         assert_eq!(report.new_embedder, "model-x");
         // No meta.reembed_state row written — confirms full no-op shape.
-        assert!(db.reembed_status().is_none(), "no-op must not leave reembed_status");
+        assert!(
+            db.reembed_status().is_none(),
+            "no-op must not leave reembed_status"
+        );
     }
 
     #[test]
@@ -1843,7 +1821,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert!(event_count >= 1, "Probing event must be in audit log even for dry-run");
+        assert!(
+            event_count >= 1,
+            "Probing event must be in audit log even for dry-run"
+        );
     }
 
     #[test]
@@ -1905,15 +1886,15 @@ mod tests {
         assert_eq!(report.new_embedder, "target-model");
         assert_eq!(report.old_dim, 8);
         assert_eq!(report.new_dim, 8);
-        assert!(report.build_hwm >= 3, "covers_through_seq covers all writes");
+        assert!(
+            report.build_hwm >= 3,
+            "covers_through_seq covers all writes"
+        );
 
         // In-memory SearchState.
         let state = db.search_state.load_full();
         assert_eq!(state.generation, 1, "in-memory generation advanced");
-        assert_eq!(
-            state.runtime_embedder_name.as_deref(),
-            Some("target-model")
-        );
+        assert_eq!(state.runtime_embedder_name.as_deref(), Some("target-model"));
         assert!(
             matches!(
                 &state.index_embedding,
@@ -1952,7 +1933,10 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(staging_count, 0, "staging columns must be cleared post-swap");
+        assert_eq!(
+            staging_count, 0,
+            "staging columns must be cleared post-swap"
+        );
 
         // No mid-reembed signal lingering.
         drop(conn);
@@ -2204,7 +2188,10 @@ mod tests {
                     msg.contains("Cross-dim reembed is not yet supported"),
                     "expected cross-dim guard message, got: {msg}"
                 );
-                assert!(msg.contains("dim=8") && msg.contains("dim=16"), "msg: {msg}");
+                assert!(
+                    msg.contains("dim=8") && msg.contains("dim=16"),
+                    "msg: {msg}"
+                );
             }
             other => panic!("expected Inference, got {other:?}"),
         }
@@ -2303,8 +2290,7 @@ mod tests {
         // drift between "what we think the dim is" and "what's
         // actually in the index." Failing this test means someone
         // re-added the standalone field.
-        let vec_index_known =
-            Arc::new(crate::vector::delta_index::DeltaIndex::new(768));
+        let vec_index_known = Arc::new(crate::vector::delta_index::DeltaIndex::new(768));
         let s_known = SearchState {
             index_embedding: EmbeddingProvenance::Known {
                 name: None,
@@ -2322,8 +2308,7 @@ mod tests {
             vec_index: vec_index_known,
         };
         assert_eq!(s_known.dim(), 768);
-        let vec_index_unknown =
-            Arc::new(crate::vector::delta_index::DeltaIndex::new(128));
+        let vec_index_unknown = Arc::new(crate::vector::delta_index::DeltaIndex::new(128));
         let s_unknown = SearchState {
             index_embedding: EmbeddingProvenance::ExternalOrUnknown { dim: 128 },
             embedder: None,
@@ -2402,7 +2387,9 @@ mod tests {
         // Recall under E1's vector space.
         let query = vec![0.99_f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let results = db
-            .recall(&query, 5, None, None, false, true, None, true, None, None, None)
+            .recall(
+                &query, 5, None, None, false, true, None, true, None, None, None,
+            )
             .unwrap();
         assert_eq!(
             results.len(),
@@ -2447,7 +2434,14 @@ mod tests {
         assert_eq!(report.generation, 1);
         // All phase audit events present even for the empty case.
         let conn = db.conn();
-        for phase in ["Probing", "Encoding", "Rebuilding", "Swapping", "Verifying", "Completed"] {
+        for phase in [
+            "Probing",
+            "Encoding",
+            "Rebuilding",
+            "Swapping",
+            "Verifying",
+            "Completed",
+        ] {
             let count: i64 = conn
                 .query_row(
                     "SELECT COUNT(*) FROM reembed_events WHERE phase = ?1 AND generation = 1",
@@ -2517,7 +2511,10 @@ mod tests {
             .reembed_with_embedder("E2", Some(e2), ReembedOptions::default())
             .unwrap();
         assert_eq!(r2.generation, 2);
-        assert_eq!(r2.encoded_count, 1, "second reembed re-encodes the planted row");
+        assert_eq!(
+            r2.encoded_count, 1,
+            "second reembed re-encodes the planted row"
+        );
 
         // Row's stamp is the latest generation.
         let row_gen: i64 = db
@@ -2581,9 +2578,7 @@ mod tests {
         let phases: Vec<String> = {
             let conn = db.conn();
             let mut stmt = conn
-                .prepare(
-                    "SELECT phase FROM reembed_events WHERE generation = 1 ORDER BY timestamp",
-                )
+                .prepare("SELECT phase FROM reembed_events WHERE generation = 1 ORDER BY timestamp")
                 .unwrap();
             stmt.query_map([], |r| r.get::<_, String>(0))
                 .unwrap()
@@ -2593,7 +2588,13 @@ mod tests {
 
         // First event is Probing; subsequent events include all phases.
         assert_eq!(phases.first().map(String::as_str), Some("Probing"));
-        for required in ["Encoding", "Rebuilding", "Swapping", "Verifying", "Completed"] {
+        for required in [
+            "Encoding",
+            "Rebuilding",
+            "Swapping",
+            "Verifying",
+            "Completed",
+        ] {
             assert!(
                 phases.iter().any(|p| p == required),
                 "audit log missing {required} event; phases recorded: {phases:?}"
@@ -2673,7 +2674,10 @@ mod tests {
                     |r| r.get(0),
                 )
                 .unwrap();
-            assert_eq!(count, 2, "namespace {ns} must have 2 rows at gen 1, got {count}");
+            assert_eq!(
+                count, 2,
+                "namespace {ns} must have 2 rows at gen 1, got {count}"
+            );
         }
     }
 }

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -491,6 +491,18 @@ pub struct SearchState {
     pub hnsw_m: u32,
     pub hnsw_ef_construction: u32,
     pub hnsw_ef_search: u32,
+
+    /// **Brainstorm-4 design pivot.** The active vector index lives
+    /// INSIDE SearchState so search_state.store() is the single atomic
+    /// publication unit. Holding two separate ArcSwaps (search_state +
+    /// vec_index) would have created a split-brain window — readers
+    /// could observe new embedder/dim with old index or vice versa.
+    /// Moving vec_index in here eliminates the class.
+    ///
+    /// Arc shared with the engine's prior `vec_index` field (now
+    /// retired). DeltaIndex's internal locks handle concurrent
+    /// append/search; this Arc is just for ArcSwap-friendly publication.
+    pub vec_index: Arc<crate::vector::delta_index::DeltaIndex>,
 }
 
 impl SearchState {
@@ -503,6 +515,7 @@ impl SearchState {
         hnsw_m: u32,
         hnsw_ef_construction: u32,
         hnsw_ef_search: u32,
+        vec_index: Arc<crate::vector::delta_index::DeltaIndex>,
     ) -> Self {
         SearchState {
             index_embedding: EmbeddingProvenance::ExternalOrUnknown { dim },
@@ -514,6 +527,7 @@ impl SearchState {
             hnsw_m,
             hnsw_ef_construction,
             hnsw_ef_search,
+            vec_index,
         }
     }
 
@@ -936,7 +950,10 @@ mod tests {
         // embedder has populated the index yet), embedder is None
         // (caller may pass pre-computed vectors), generation=0,
         // covers_through_seq=0.
-        let s = SearchState::initial(384, 16, 200, 50);
+        let vec_index = Arc::new(
+            crate::vector::delta_index::DeltaIndex::new(384),
+        );
+        let s = SearchState::initial(384, 16, 200, 50, vec_index);
         assert_eq!(s.dim(), 384);
         assert!(matches!(
             s.index_embedding,
@@ -951,6 +968,10 @@ mod tests {
         assert_eq!(s.hnsw_m, 16);
         assert_eq!(s.hnsw_ef_construction, 200);
         assert_eq!(s.hnsw_ef_search, 50);
+        // Brainstorm-4: SearchState owns its DeltaIndex; the freshly-
+        // constructed initial state has a delta-only index with no
+        // entries yet.
+        assert_eq!(s.vec_index.len(), 0);
     }
 
     // ─────────────────────────────────────────────────────────────────
@@ -1102,6 +1123,8 @@ mod tests {
         // drift between "what we think the dim is" and "what's
         // actually in the index." Failing this test means someone
         // re-added the standalone field.
+        let vec_index_known =
+            Arc::new(crate::vector::delta_index::DeltaIndex::new(768));
         let s_known = SearchState {
             index_embedding: EmbeddingProvenance::Known {
                 name: None,
@@ -1116,8 +1139,11 @@ mod tests {
             hnsw_m: 16,
             hnsw_ef_construction: 200,
             hnsw_ef_search: 50,
+            vec_index: vec_index_known,
         };
         assert_eq!(s_known.dim(), 768);
+        let vec_index_unknown =
+            Arc::new(crate::vector::delta_index::DeltaIndex::new(128));
         let s_unknown = SearchState {
             index_embedding: EmbeddingProvenance::ExternalOrUnknown { dim: 128 },
             embedder: None,
@@ -1128,6 +1154,7 @@ mod tests {
             hnsw_m: 16,
             hnsw_ef_construction: 200,
             hnsw_ef_search: 50,
+            vec_index: vec_index_unknown,
         };
         assert_eq!(s_unknown.dim(), 128);
     }

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -1,0 +1,500 @@
+//! In-place embedder migration for `YantrikDB` (issue #41).
+//!
+//! `db.reembed(new_embedder_name, options)` rebuilds every memory's
+//! embedding under a new embedder + swaps the active HNSW index, all
+//! while concurrent recalls continue serving and (by default) concurrent
+//! writes queue rather than block. The operation is atomic from the
+//! caller's perspective: at completion the active `SearchState` carries
+//! the new embedder + new dim + new index, and every prior memory + every
+//! write that arrived during the operation is reflected.
+//!
+//! ## Why this exists
+//!
+//! Without it, callers wanting to upgrade between embedder dimensions
+//! (e.g. potion-base-2M at dim=64 → potion-base-32M at dim=256) have to
+//! dump-and-replay through `record_text`, which loses graph edges,
+//! consolidation state, and conflict-detection metadata. Reported by
+//! yantrikdb-hermes-agent for downstream user wysie. Engine-side
+//! primitive is the right place per the cross-cutting nature of the
+//! change (memories table, HNSW lifecycle, embedder slot all need to
+//! change in lockstep).
+//!
+//! ## Correctness invariants (locked by brainstorm 2 redteam)
+//!
+//! See yantrikos/yantrikdb#41 for the full design rationale. Eight
+//! testable invariants the implementation enforces:
+//!
+//! 1. **Single classification:** every write during reembed is either
+//!    sync-before-barrier (in `build_hwm` and rebuilt into new HNSW)
+//!    OR queued-after-barrier (replayed into the new generation by the
+//!    post-swap materializer). No middle state.
+//! 2. **No old application after barrier:** post-cutover, no code path
+//!    may mark an oplog row `applied_generation = old_generation` in a
+//!    way that suppresses replay into the new generation.
+//! 3. **Generation-scoped application:** `oplog.applied_generation`
+//!    (v27 column) is the source of truth, not boolean `applied`. The
+//!    boolean is kept as derived hint for back-compat only.
+//! 4. **High-water coverage:** `SearchState(G).covers_through_seq` is
+//!    a durable per-generation coverage statement. Every write with
+//!    `seq <= covers_through_seq` is reflected in the active index.
+//! 5. **Replay rule:** the post-swap G1 materializer replays
+//!    `WHERE applied_generation IS NULL OR applied_generation < G`
+//!    ordered by `op_id`.
+//! 6. **RYW rule:** `recall_with_seq(N)` waits on the active
+//!    generation's `visible_seq >= N` regardless of which generation
+//!    accepted the write.
+//! 7. **Atomic SearchState:** embedder + index + dim + generation +
+//!    covers_through_seq + hnsw_params are swapped together via a
+//!    single `ArcSwap<SearchState>::store`. No code path can observe
+//!    a mismatched embedder-vs-index pair.
+//! 8. **Queued payload correctness:** writes queued during reembed
+//!    store logical text only (not pre-encoded embeddings). The G1
+//!    materializer computes embeddings under E1 at replay time.
+//!
+//! ## Module layout
+//!
+//! This file holds the public type surface only — `ReembedOptions`,
+//! `ReembedProgress`, `ReembedReport`, `ReembedPhase`, `ReembedStatus`,
+//! `ReembedWritePolicy`, `NamespaceReembedStats`. The actual reembed
+//! loop, WriteRouter, and SearchState swap machinery live in sibling
+//! modules `reembed_loop` (TODO) and on `YantrikDB` itself once wired.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────────────────────────────────────────────────
+// Public API surface
+// ─────────────────────────────────────────────────────────────────────
+
+/// Concurrent-write policy during a reembed operation.
+///
+/// v1 ships both modes. Default is `Queue` per the brainstorm-2 design
+/// lock — the engine already has the oplog `applied=0` + materializer
+/// machinery from v0.6.6 / v0.7.x, and shipping pause-only-v1 would
+/// force downstream consumers to write workarounds that become
+/// obsolete when queue lands. The queue infrastructure is plumbing,
+/// not novel design, given the safety invariants (`applied_generation`
+/// + `covers_through_seq` + WriteRouter + paused-materializer) the
+/// implementation enforces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReembedWritePolicy {
+    /// Concurrent `record()` / `record_text()` calls return
+    /// `Err(YantrikDbError::WriteRejected { retry_after_ms })`. The
+    /// caller is expected to retry after the reembed completes.
+    /// Simpler for the engine; harsher for the caller.
+    Pause,
+    /// Concurrent writes go through `log_op_pending` (applied=0,
+    /// `embedding_model = old_embedder_name`). After the SearchState
+    /// swap, the post-swap materializer reads the text from each
+    /// queued op's payload, encodes it under the new embedder, and
+    /// applies to the new HNSW. Read-after-write requires
+    /// `recall_with_seq(min_seq)` because the active `visible_seq`
+    /// only advances as the materializer drains. Default.
+    Queue,
+}
+
+impl Default for ReembedWritePolicy {
+    /// Defaults to `Queue` per the brainstorm-2 design lock + Pranab's
+    /// 2026-05-17 decision. Do NOT change to `Pause` without revisiting
+    /// the AskUserQuestion record on issue #41.
+    fn default() -> Self {
+        ReembedWritePolicy::Queue
+    }
+}
+
+/// Discrete phases of the reembed state machine. Authoritative source
+/// is the `reembed_events` table; the in-memory `on_phase_complete`
+/// callback in [`ReembedOptions`] is best-effort notification only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ReembedPhase {
+    /// Resolve embedder name → digest, download if needed, sanity-encode
+    /// a test string, validate dim, write `meta.reembed_state` with the
+    /// resolved identity. Failure here leaves no durable state.
+    Probing,
+    /// Iterate `memories ORDER BY rid` in `batch_size` chunks, encode
+    /// each row's text under the new embedder, write to staging columns
+    /// `memories.embedding_new` + `memories.embedding_new_model`. The
+    /// active `memories.embedding` column is untouched throughout, so
+    /// concurrent recall traffic continues to score consistently
+    /// against the old SearchState.
+    Encoding,
+    /// Build new `HnswIndex` from `memories.embedding_new` values via
+    /// the existing `DeltaIndex` clone-rebuild path. Disposable on
+    /// crash — recovery restarts from Encoding.
+    Rebuilding,
+    /// Atomic `ArcSwap<SearchState>::store(new_state)` inside the same
+    /// SQL transaction as `UPDATE memories SET embedding = embedding_new`.
+    /// Past point of no return — crash here completes the swap on
+    /// next `open()`.
+    Swapping,
+    /// Sanity-check that all rows have `embedding_model = new_embedder`,
+    /// clear staging columns of any residual non-NULL values, clear
+    /// `meta.reembed_state`. Safe to retry.
+    Verifying,
+    /// Reembed completed successfully. Terminal state.
+    Completed,
+    /// Reembed aborted before Swap (Probing failed, Encoding crashed
+    /// with `resume_from_checkpoint=false`, etc.). Terminal state; the
+    /// caller can safely retry from scratch.
+    Aborted,
+}
+
+impl ReembedPhase {
+    /// Stable string form for `reembed_events.phase` rows and
+    /// `meta.reembed_state` JSON. Tied to the SQL representation; do
+    /// NOT rename without a schema migration.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ReembedPhase::Probing => "Probing",
+            ReembedPhase::Encoding => "Encoding",
+            ReembedPhase::Rebuilding => "Rebuilding",
+            ReembedPhase::Swapping => "Swapping",
+            ReembedPhase::Verifying => "Verifying",
+            ReembedPhase::Completed => "Completed",
+            ReembedPhase::Aborted => "Aborted",
+        }
+    }
+
+    /// Parse from the SQL string form. Returns `None` for unknown
+    /// strings — caller must treat that as corruption.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "Probing" => Some(ReembedPhase::Probing),
+            "Encoding" => Some(ReembedPhase::Encoding),
+            "Rebuilding" => Some(ReembedPhase::Rebuilding),
+            "Swapping" => Some(ReembedPhase::Swapping),
+            "Verifying" => Some(ReembedPhase::Verifying),
+            "Completed" => Some(ReembedPhase::Completed),
+            "Aborted" => Some(ReembedPhase::Aborted),
+            _ => None,
+        }
+    }
+
+    /// True if the reembed operation has terminated (success or abort).
+    /// `open()` recovery treats terminal states as "no in-flight work"
+    /// and clears `meta.reembed_state`.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, ReembedPhase::Completed | ReembedPhase::Aborted)
+    }
+}
+
+impl fmt::Display for ReembedPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Per-batch progress emitted to the optional `progress_cb` callback in
+/// [`ReembedOptions`]. The callback is best-effort notification — it
+/// runs synchronously on the reembed thread, so a slow callback slows
+/// the operation. Authoritative phase-transition history is in the
+/// `reembed_events` table; use `db.reembed_status()` for snapshots.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReembedProgress {
+    pub phase: ReembedPhase,
+    /// Memories processed in the current phase so far. Monotonic
+    /// within a phase; resets at phase transitions.
+    pub processed: u64,
+    /// Total memories the current phase will process. May be `None`
+    /// during Probing (before count is known) or during Rebuilding /
+    /// Swapping / Verifying (phase has no per-row work).
+    pub total: Option<u64>,
+    /// Wall-clock time since the reembed call started.
+    pub elapsed_ms: u64,
+    /// If the reembed is namespace-scoped, the namespace being
+    /// processed. `None` for cross-namespace reembeds.
+    pub namespace: Option<String>,
+}
+
+/// Caller-side options for a reembed call.
+///
+/// Construct via [`ReembedOptions::default()`] (`write_policy = Queue`,
+/// `batch_size = 256`, `resume_from_checkpoint = true`, no callbacks)
+/// and override per-field as needed.
+pub struct ReembedOptions {
+    /// If set, only re-embed memories in this namespace. Cross-
+    /// namespace reembed is rejected if another reembed is in flight
+    /// (single-job invariant via `meta.reembed_state`).
+    pub namespace: Option<String>,
+
+    /// Best-effort progress callback fired after each Encoding batch +
+    /// at each phase transition. Runs on the reembed thread; keep it
+    /// fast. Use `db.reembed_status()` for snapshots instead if you
+    /// need durable / pollable observability.
+    pub progress_cb: Option<Box<dyn Fn(ReembedProgress) + Send + Sync>>,
+
+    /// Best-effort callback fired at each phase transition. NOT
+    /// authoritative — the durable record is in `reembed_events`. If
+    /// this callback panics or is slow, the durable record still
+    /// reflects the transition.
+    pub on_phase_complete: Option<Box<dyn Fn(ReembedPhase, &ReembedStatus) + Send + Sync>>,
+
+    /// Encoding batch size. Higher = fewer SQL transactions but more
+    /// memory pressure per batch. Default 256 is balanced for typical
+    /// dims (64-768) and memory counts up to ~1M.
+    pub batch_size: usize,
+
+    /// Concurrent-write policy. See [`ReembedWritePolicy`]. Default
+    /// `Queue`.
+    pub write_policy: ReembedWritePolicy,
+
+    /// HNSW M parameter override. `None` preserves the current
+    /// SearchState's M. Set explicitly if the new embedder's vector
+    /// space has materially different cluster properties.
+    pub hnsw_m: Option<u32>,
+    /// HNSW efConstruction override. `None` preserves current.
+    pub hnsw_ef_construction: Option<u32>,
+    /// HNSW efSearch override. `None` preserves current.
+    pub hnsw_ef_search: Option<u32>,
+
+    /// If `true` (default) and a previous reembed was interrupted at
+    /// Encoding/Rebuilding phase, `open()` resumes from the recorded
+    /// checkpoint. If `false`, `open()` rolls back the partial work
+    /// and clears `meta.reembed_state`. Swapping/Verifying always
+    /// complete forward (past the point of no return).
+    pub resume_from_checkpoint: bool,
+
+    /// If `true`, run Probing only and return without writing
+    /// `meta.reembed_state` or touching any memories. Useful for "would
+    /// this reembed succeed?" checks before committing.
+    pub dry_run: bool,
+}
+
+impl Default for ReembedOptions {
+    fn default() -> Self {
+        ReembedOptions {
+            namespace: None,
+            progress_cb: None,
+            on_phase_complete: None,
+            batch_size: 256,
+            write_policy: ReembedWritePolicy::default(),
+            hnsw_m: None,
+            hnsw_ef_construction: None,
+            hnsw_ef_search: None,
+            resume_from_checkpoint: true,
+            dry_run: false,
+        }
+    }
+}
+
+// ReembedOptions intentionally does NOT derive Debug because progress_cb
+// and on_phase_complete are dyn Fn closures (no Debug). A manual impl
+// would just print "<callbacks>" placeholders; not worth the noise.
+
+/// Per-namespace breakdown of a reembed report.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NamespaceReembedStats {
+    pub encoded_count: u64,
+    pub skipped_count: u64,
+    pub duration_ms: u64,
+}
+
+/// Terminal report from a successful `db.reembed()` call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReembedReport {
+    pub generation: u64,
+    pub encoded_count: u64,
+    /// Memories that had no text content (rare; happens when text was
+    /// nulled out via correction or other manipulation). Skipped in
+    /// Encoding; their HNSW entries are pruned.
+    pub skipped_count: u64,
+    pub duration: Duration,
+    pub old_embedder: String,
+    pub old_embedder_digest: String,
+    pub new_embedder: String,
+    pub new_embedder_digest: String,
+    pub old_dim: usize,
+    pub new_dim: usize,
+    /// Coverage seq the new generation covers. Every write with
+    /// `seq <= build_hwm` was rebuilt into the new HNSW;
+    /// `seq > build_hwm` is replayed by the post-swap materializer.
+    pub build_hwm: u64,
+    pub per_namespace: HashMap<String, NamespaceReembedStats>,
+}
+
+/// Read-only snapshot of an in-flight reembed. Returned by
+/// `db.reembed_status()`. None when no reembed is active. Authoritative
+/// state lives in `reembed_events` + `meta.reembed_state`; this struct
+/// is the queryable projection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReembedStatus {
+    pub generation: u64,
+    pub phase: ReembedPhase,
+    pub old_embedder: String,
+    pub old_embedder_digest: String,
+    pub new_embedder: String,
+    pub new_embedder_digest: String,
+    pub old_dim: usize,
+    pub new_dim: usize,
+    pub memories_total: u64,
+    pub memories_encoded: u64,
+    pub queued_writes: u64,
+    pub checkpoint_rid: Option<String>,
+    pub started_at: SystemTime,
+    pub last_event_at: SystemTime,
+    pub last_error: Option<String>,
+    pub write_policy: ReembedWritePolicy,
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// SearchState — the single atomic swap unit
+// ─────────────────────────────────────────────────────────────────────
+
+/// The coherent (embedder + index + dim + generation + coverage + HNSW
+/// params) tuple that every read path acquires once via `ArcSwap.load()`
+/// and uses for the entire request. Locked by brainstorm 2 invariant 7:
+/// no code path may observe a mismatched embedder-vs-index pair.
+///
+/// All fields are immutable after construction. Mutation is by
+/// `ArcSwap<SearchState>::store(new_state)`.
+///
+/// **NOTE**: this struct is the future of embedder ownership on
+/// `YantrikDB`. Today (pre-#41) the engine has a separate `embedder:
+/// Option<Box<dyn Embedder + Send + Sync>>` field that recall + record
+/// paths read directly. The reembed implementation migrates all those
+/// paths to `self.search_state.load().embedder.clone()` and retires the
+/// standalone field. Until that refactor lands, `SearchState` is a
+/// declaration only; live read paths still use the legacy slot.
+pub struct SearchState {
+    /// Active embedder. Cloning the Arc is cheap; cloning the embedder
+    /// itself is not (some embedders hold large model weights).
+    pub embedder: Arc<dyn crate::types::Embedder + Send + Sync>,
+    /// User-visible name of the embedder (e.g. "potion-base-2M").
+    /// Stored in `memories.embedding_model` and `oplog.embedding_model`
+    /// alongside written rows so reembed and replay can discriminate.
+    pub embedder_name: String,
+    /// Stronger identifier than name — the SHA-256 of the embedder's
+    /// model weights. Two embedders with the same name but different
+    /// weights have different digests; the no-op detection in
+    /// `db.reembed()` uses digest equality, not name equality.
+    pub embedder_digest: String,
+    /// Embedding dimensionality. Must match the active HNSW's dim.
+    pub dim: usize,
+    /// Monotonic generation id. Incremented at each successful Swap.
+    /// `oplog.applied_generation` references this. Generation 0 is the
+    /// pre-reembed sentinel for "the engine has never reembedded."
+    pub generation: u64,
+    /// High-water mark of `vec_seq` captured at the cutover barrier
+    /// for the generation that built this SearchState. Every write
+    /// with `vec_seq <= covers_through_seq` is reflected in the
+    /// `index` below. Writes with `vec_seq > covers_through_seq` are
+    /// replayed by the post-swap materializer.
+    pub covers_through_seq: u64,
+    /// HNSW M parameter at construction time. Stored here (not just on
+    /// the index) so the reembed loop can preserve / override it
+    /// independently of the index's internal state.
+    pub hnsw_m: u32,
+    pub hnsw_ef_construction: u32,
+    pub hnsw_ef_search: u32,
+    // NOTE: the actual HNSW index handle (Arc<HnswIndex> or
+    // Arc<DeltaIndex>) is intentionally NOT a member of this struct in
+    // the v1 design. The engine's existing `vec_index: DeltaIndex`
+    // field continues to own the index lifecycle. SearchState's swap
+    // atomically updates the embedder + metadata; the DeltaIndex's
+    // internal ArcSwap<HnswIndex> swap handles the index. Reembed
+    // sequences both swaps inside the same critical section so they
+    // are observed atomically by readers. This avoids a bigger refactor
+    // of DeltaIndex.
+    //
+    // If a future redesign moves the index into SearchState, the
+    // changes are: add `pub index: Arc<HnswIndex>`, retire
+    // `vec_index: DeltaIndex` from YantrikDB, and the reembed swap
+    // becomes a single `search_state.store(new_state)` call. That
+    // change is bigger than v1 reembed scope; deferring.
+}
+
+impl fmt::Debug for SearchState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SearchState")
+            .field("embedder_name", &self.embedder_name)
+            .field("embedder_digest", &self.embedder_digest)
+            .field("dim", &self.dim)
+            .field("generation", &self.generation)
+            .field("covers_through_seq", &self.covers_through_seq)
+            .field("hnsw_m", &self.hnsw_m)
+            .field("hnsw_ef_construction", &self.hnsw_ef_construction)
+            .field("hnsw_ef_search", &self.hnsw_ef_search)
+            .finish_non_exhaustive()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_string_round_trip() {
+        // Every phase must survive a string round-trip via as_str + parse.
+        // The strings appear in the `reembed_events.phase` column and in
+        // `meta.reembed_state` JSON; they are part of the on-disk format.
+        for &phase in &[
+            ReembedPhase::Probing,
+            ReembedPhase::Encoding,
+            ReembedPhase::Rebuilding,
+            ReembedPhase::Swapping,
+            ReembedPhase::Verifying,
+            ReembedPhase::Completed,
+            ReembedPhase::Aborted,
+        ] {
+            let s = phase.as_str();
+            let parsed = ReembedPhase::parse(s).unwrap_or_else(|| {
+                panic!("ReembedPhase::parse({s:?}) returned None; persisted state would be unparseable on restart")
+            });
+            assert_eq!(parsed, phase, "round-trip mismatch for {phase:?}");
+        }
+    }
+
+    #[test]
+    fn phase_parse_rejects_unknown() {
+        assert!(ReembedPhase::parse("Nonsense").is_none());
+        assert!(ReembedPhase::parse("").is_none());
+        // Lowercase variants are NOT accepted — the on-disk format is
+        // case-sensitive. A pre-v27 binary writing lowercase would be a
+        // corruption signal, not something to silently accept.
+        assert!(ReembedPhase::parse("probing").is_none());
+    }
+
+    #[test]
+    fn phase_terminal_classification() {
+        assert!(ReembedPhase::Completed.is_terminal());
+        assert!(ReembedPhase::Aborted.is_terminal());
+        assert!(!ReembedPhase::Probing.is_terminal());
+        assert!(!ReembedPhase::Encoding.is_terminal());
+        assert!(!ReembedPhase::Rebuilding.is_terminal());
+        assert!(!ReembedPhase::Swapping.is_terminal());
+        assert!(!ReembedPhase::Verifying.is_terminal());
+    }
+
+    #[test]
+    fn write_policy_default_is_queue() {
+        // Locked by brainstorm-2 + Pranab's 2026-05-17 decision. The
+        // default is what production handlers + most callers get without
+        // opting in; flipping this silently would change downstream
+        // behavior. If a future maintainer wants to flip the default,
+        // they must read the AskUserQuestion record on issue #41 first.
+        assert_eq!(ReembedWritePolicy::default(), ReembedWritePolicy::Queue);
+    }
+
+    #[test]
+    fn options_default_shape_matches_locked_design() {
+        let opts = ReembedOptions::default();
+        assert!(opts.namespace.is_none());
+        assert!(opts.progress_cb.is_none());
+        assert!(opts.on_phase_complete.is_none());
+        assert_eq!(opts.batch_size, 256);
+        assert_eq!(opts.write_policy, ReembedWritePolicy::Queue);
+        assert!(opts.hnsw_m.is_none());
+        assert!(opts.hnsw_ef_construction.is_none());
+        assert!(opts.hnsw_ef_search.is_none());
+        assert!(opts.resume_from_checkpoint);
+        assert!(!opts.dry_run);
+    }
+}

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -2338,4 +2338,342 @@ mod tests {
         };
         assert_eq!(s_unknown.dim(), 128);
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // Layer 8 — functional matrix. Integration tests covering the
+    // happy paths + corner cases that aren't structurally proven
+    // by checkpoint-9–19 unit tests.
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn reembed_post_swap_recall_returns_rows_under_new_embedder() {
+        // **Layer 8 end-to-end correctness.** After db.reembed(),
+        // a recall against the new embedder must return the
+        // memory rows that existed before the swap. Locks the
+        // "user-facing query still works" contract — the most
+        // important property the feature delivers.
+        use std::sync::Arc;
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+
+        // E0: sentinel 0.42 (every vec has [0.42, 0, ...]).
+        db.set_embedder(Box::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:E0".to_string(),
+            name: "E0-name".to_string(),
+            sentinel: 0.42,
+        }))
+        .unwrap();
+
+        // Plant 5 rows via record_text so the engine computes
+        // embeddings under E0.
+        let rids: Vec<String> = (0..5)
+            .map(|i| {
+                db.record_text(
+                    &format!("layer-8 row {i}"),
+                    "episodic",
+                    0.5,
+                    0.0,
+                    604800.0,
+                    &serde_json::json!({"i": i}),
+                    "default",
+                    0.8,
+                    "general",
+                    "user",
+                    None,
+                )
+                .unwrap()
+            })
+            .collect();
+
+        // Run a full reembed under E1.
+        let e1: Arc<dyn crate::types::Embedder + Send + Sync> =
+            Arc::new(PhaseTestEmbedderSentinel {
+                dim: 8,
+                fp: "sha256:E1".to_string(),
+                name: "E1-name".to_string(),
+                sentinel: 0.99,
+            });
+        let report = db
+            .reembed_with_embedder("E1-name", Some(e1), ReembedOptions::default())
+            .unwrap();
+        assert_eq!(report.generation, 1);
+        assert_eq!(report.encoded_count, 5);
+
+        // Recall under E1's vector space.
+        let query = vec![0.99_f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let results = db
+            .recall(&query, 5, None, None, false, true, None, true, None, None, None)
+            .unwrap();
+        assert_eq!(
+            results.len(),
+            5,
+            "recall must return all 5 planted rows after reembed; got {}",
+            results.len()
+        );
+        for r in &results {
+            assert!(
+                rids.contains(&r.rid),
+                "recall returned unexpected rid {:?}",
+                r.rid
+            );
+        }
+    }
+
+    #[test]
+    fn reembed_on_empty_engine_returns_gracefully() {
+        // **Layer 8 corner case.** Fresh engine with no rows: a
+        // full reembed should run through every phase and return
+        // a clean report with encoded_count=0.
+        use std::sync::Arc;
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:E0".to_string(),
+            name: "E0".to_string(),
+            sentinel: 0.42,
+        }))
+        .unwrap();
+        let e1: Arc<dyn crate::types::Embedder + Send + Sync> =
+            Arc::new(PhaseTestEmbedderSentinel {
+                dim: 8,
+                fp: "sha256:E1".to_string(),
+                name: "E1".to_string(),
+                sentinel: 0.99,
+            });
+        let report = db
+            .reembed_with_embedder("E1", Some(e1), ReembedOptions::default())
+            .unwrap();
+        assert_eq!(report.encoded_count, 0);
+        assert_eq!(report.generation, 1);
+        // All phase audit events present even for the empty case.
+        let conn = db.conn();
+        for phase in ["Probing", "Encoding", "Rebuilding", "Swapping", "Verifying", "Completed"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM reembed_events WHERE phase = ?1 AND generation = 1",
+                    params![phase],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert!(
+                count >= 1,
+                "expected {phase} event for empty-engine reembed (got {count})"
+            );
+        }
+    }
+
+    #[test]
+    fn reembed_sequential_runs_advance_generation_monotonically() {
+        // **Layer 8 corner case.** Two back-to-back reembeds.
+        // Generation must advance 0 → 1 → 2; the second reembed
+        // sees rows stamped at gen 1 and re-encodes them again.
+        use std::sync::Arc;
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:E0".to_string(),
+            name: "E0".to_string(),
+            sentinel: 0.10,
+        }))
+        .unwrap();
+        let rid = db
+            .record_text(
+                "seq",
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+
+        // First reembed: gen 0 → 1.
+        let e1: Arc<dyn crate::types::Embedder + Send + Sync> =
+            Arc::new(PhaseTestEmbedderSentinel {
+                dim: 8,
+                fp: "sha256:E1".to_string(),
+                name: "E1".to_string(),
+                sentinel: 0.50,
+            });
+        let r1 = db
+            .reembed_with_embedder("E1", Some(e1), ReembedOptions::default())
+            .unwrap();
+        assert_eq!(r1.generation, 1);
+
+        // Second reembed: gen 1 → 2.
+        let e2: Arc<dyn crate::types::Embedder + Send + Sync> =
+            Arc::new(PhaseTestEmbedderSentinel {
+                dim: 8,
+                fp: "sha256:E2".to_string(),
+                name: "E2".to_string(),
+                sentinel: 0.90,
+            });
+        let r2 = db
+            .reembed_with_embedder("E2", Some(e2), ReembedOptions::default())
+            .unwrap();
+        assert_eq!(r2.generation, 2);
+        assert_eq!(r2.encoded_count, 1, "second reembed re-encodes the planted row");
+
+        // Row's stamp is the latest generation.
+        let row_gen: i64 = db
+            .conn()
+            .query_row(
+                "SELECT embedding_generation FROM memories WHERE rid = ?1",
+                [&rid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(row_gen, 2);
+
+        // Engine SearchState is at gen 2.
+        assert_eq!(db.search_state.load().generation, 2);
+    }
+
+    #[test]
+    fn reembed_audit_event_sequence_is_complete_and_ordered() {
+        // **Layer 8 audit-trail lock.** A successful reembed must
+        // emit the full state-machine event sequence in order:
+        // Probing → Encoding → Rebuilding → Swapping → Verifying
+        // → Completed. Per phase there are start + completion
+        // events; Probing emits one (start only). The audit log
+        // is what operators read post-incident to understand
+        // what happened.
+        use std::sync::Arc;
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:E0".to_string(),
+            name: "E0".to_string(),
+            sentinel: 0.10,
+        }))
+        .unwrap();
+        let _ = db.record_text(
+            "audit",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({}),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        );
+
+        let e1: Arc<dyn crate::types::Embedder + Send + Sync> =
+            Arc::new(PhaseTestEmbedderSentinel {
+                dim: 8,
+                fp: "sha256:E1".to_string(),
+                name: "E1".to_string(),
+                sentinel: 0.50,
+            });
+        let _ = db
+            .reembed_with_embedder("E1", Some(e1), ReembedOptions::default())
+            .unwrap();
+
+        // Read all events for gen 1 in timestamp order.
+        let phases: Vec<String> = {
+            let conn = db.conn();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT phase FROM reembed_events WHERE generation = 1 ORDER BY timestamp",
+                )
+                .unwrap();
+            stmt.query_map([], |r| r.get::<_, String>(0))
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap()
+        };
+
+        // First event is Probing; subsequent events include all phases.
+        assert_eq!(phases.first().map(String::as_str), Some("Probing"));
+        for required in ["Encoding", "Rebuilding", "Swapping", "Verifying", "Completed"] {
+            assert!(
+                phases.iter().any(|p| p == required),
+                "audit log missing {required} event; phases recorded: {phases:?}"
+            );
+        }
+        // Completed is the last meaningful event (followups would
+        // come from a NEXT reembed at gen 2).
+        let last_meaningful = phases.last().map(String::as_str);
+        assert_eq!(
+            last_meaningful,
+            Some("Completed"),
+            "Completed must be the terminal event for the reembed run; got {last_meaningful:?}"
+        );
+    }
+
+    #[test]
+    fn reembed_re_encodes_rows_from_multiple_namespaces() {
+        // **Layer 8 multi-namespace coverage.** A reembed without
+        // a `namespace` option re-encodes EVERY active row
+        // regardless of namespace. Locks the cross-namespace
+        // uniformity invariant — without this, a reembed could
+        // silently skip namespaces the agent forgot to pass
+        // (a bug class the user hits when namespaces are
+        // dynamically created).
+        use std::sync::Arc;
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:E0".to_string(),
+            name: "E0".to_string(),
+            sentinel: 0.10,
+        }))
+        .unwrap();
+
+        for ns in ["alpha", "beta", "gamma"] {
+            for i in 0..2 {
+                db.record_text(
+                    &format!("{ns} row {i}"),
+                    "episodic",
+                    0.5,
+                    0.0,
+                    604800.0,
+                    &serde_json::json!({}),
+                    ns,
+                    0.8,
+                    "general",
+                    "user",
+                    None,
+                )
+                .unwrap();
+            }
+        }
+
+        let e1: Arc<dyn crate::types::Embedder + Send + Sync> =
+            Arc::new(PhaseTestEmbedderSentinel {
+                dim: 8,
+                fp: "sha256:E1".to_string(),
+                name: "E1".to_string(),
+                sentinel: 0.90,
+            });
+        let report = db
+            .reembed_with_embedder("E1", Some(e1), ReembedOptions::default())
+            .unwrap();
+        assert_eq!(
+            report.encoded_count, 6,
+            "6 rows across 3 namespaces must all be re-encoded"
+        );
+
+        // Every row in every namespace has embedding_generation = 1.
+        let conn = db.conn();
+        for ns in ["alpha", "beta", "gamma"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memories WHERE namespace = ?1 \
+                     AND embedding_generation = 1 AND consolidation_status = 'active'",
+                    params![ns],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 2, "namespace {ns} must have 2 rows at gen 1, got {count}");
+        }
+    }
 }

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -341,84 +341,208 @@ pub struct ReembedStatus {
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// EmbeddingProvenance — what model produced the vectors in the index
+// ─────────────────────────────────────────────────────────────────────
+
+/// Provenance of vectors currently stored in the active vector index.
+///
+/// **Independent of the runtime embedder.** After restart with no
+/// embedder loaded, the index still has knowable provenance — the
+/// embedder name + digest under which its vectors were built. The
+/// runtime embedder slot tracks "is there a local embedder available
+/// for embed_text() right now?" — a separate question.
+///
+/// Locked by brainstorm-3 round 2: conflating these two facts loses
+/// critical safety information. See yantrikos/yantrikdb#41 comment
+/// chain for the bad-state scenarios.
+#[derive(Debug, Clone)]
+pub enum EmbeddingProvenance {
+    /// Index vectors were built with a known embedder identity. Set by
+    /// a completed reembed() or by initial population of an empty DB
+    /// via record_text() with a configured embedder. The
+    /// `set_embedder*` mode logic uses this to reject silent-corruption
+    /// scenarios (same-dim-different-digest, dim-mismatch).
+    Known {
+        /// Optional human-readable name (e.g. "potion-base-2M").
+        name: Option<String>,
+        /// SHA-256 or equivalent stable fingerprint of the embedder
+        /// model. Compared by `set_embedder*` for exact-identity match.
+        digest: String,
+        /// Dimensionality of vectors in the active index.
+        dim: usize,
+    },
+    /// Index vectors come from external/precomputed input, or from a
+    /// legacy DB created before fingerprint tracking. Dimensionality is
+    /// known (it's the physical index dim); the originating embedder is
+    /// not provable. `set_embedder*` with matching dim can attach a
+    /// runtime embedder via the compat path without claiming the index
+    /// is in the new embedder's vector space.
+    ExternalOrUnknown {
+        dim: usize,
+    },
+}
+
+impl EmbeddingProvenance {
+    /// Dimensionality of vectors in the index, regardless of provenance
+    /// variant. Single accessor so callers don't pattern-match.
+    pub fn dim(&self) -> usize {
+        match self {
+            EmbeddingProvenance::Known { dim, .. } => *dim,
+            EmbeddingProvenance::ExternalOrUnknown { dim } => *dim,
+        }
+    }
+
+    /// Stable fingerprint of the index-building embedder, if known.
+    /// `None` for `ExternalOrUnknown` variant.
+    pub fn digest(&self) -> Option<&str> {
+        match self {
+            EmbeddingProvenance::Known { digest, .. } => Some(digest),
+            EmbeddingProvenance::ExternalOrUnknown { .. } => None,
+        }
+    }
+
+    /// Human-readable name of the index-building embedder, if recorded.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            EmbeddingProvenance::Known { name, .. } => name.as_deref(),
+            EmbeddingProvenance::ExternalOrUnknown { .. } => None,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // SearchState — the single atomic swap unit
 // ─────────────────────────────────────────────────────────────────────
 
-/// The coherent (embedder + index + dim + generation + coverage + HNSW
-/// params) tuple that every read path acquires once via `ArcSwap.load()`
-/// and uses for the entire request. Locked by brainstorm 2 invariant 7:
-/// no code path may observe a mismatched embedder-vs-index pair.
+/// The coherent search-stack snapshot that every read path acquires
+/// once via `ArcSwap.load()` and uses for the entire request. Locked by
+/// brainstorm-2 invariant 7 (atomic SearchState) + brainstorm-3 round 2
+/// (provenance and runtime embedder are separate facts).
 ///
 /// All fields are immutable after construction. Mutation is by
-/// `ArcSwap<SearchState>::store(new_state)`.
+/// `ArcSwap<Arc<SearchState>>::store(new_state)` under the engine's
+/// `index_write_lock`.
 ///
-/// **NOTE**: this struct is the future of embedder ownership on
-/// `YantrikDB`. Today (pre-#41) the engine has a separate `embedder:
-/// Option<Box<dyn Embedder + Send + Sync>>` field that recall + record
-/// paths read directly. The reembed implementation migrates all those
-/// paths to `self.search_state.load().embedder.clone()` and retires the
-/// standalone field. Until that refactor lands, `SearchState` is a
-/// declaration only; live read paths still use the legacy slot.
+/// ## Field design rationale
+///
+/// `index_embedding` describes what's IN the active index — provenance
+/// of stored vectors. `embedder` + `runtime_embedder_*` describes what
+/// the engine can produce NOW for embed_text(). These can disagree: a
+/// freshly-opened DB has `index_embedding = Known(...)` but
+/// `embedder = None` until `set_embedder*` is called.
+///
+/// **`SearchState.dim` is derived**: use `state.index_embedding.dim()`,
+/// not a separate field. The standalone `YantrikDB.embedding_dim` field
+/// retires in this refactor; that derivation is the new source of truth.
+///
+/// ## What's NOT in this struct in v1
+///
+/// The actual HNSW index handle is intentionally NOT a member. The
+/// engine's existing `vec_index: DeltaIndex` continues to own the index
+/// lifecycle. Reembed sequences SearchState.store + vec_index.cold
+/// ArcSwap inside the same critical section (`index_write_lock`) so
+/// they're observed atomically. Moving the index handle into
+/// SearchState is a bigger refactor (changes DeltaIndex ownership)
+/// deferred to a future release.
+///
+/// Compensating invariants enforced at runtime:
+/// - `set_embedder*` empty-DB path resets vec_index to new dim under
+///   the index_write_lock — same critical section as SearchState.store
+/// - reembed() cutover holds the same lock across both swaps
+/// - recall paths debug_assert `state.index_embedding.dim() == vec_index.dim()`
 pub struct SearchState {
-    /// Active embedder. Cloning the Arc is cheap; cloning the embedder
-    /// itself is not (some embedders hold large model weights).
-    pub embedder: Arc<dyn crate::types::Embedder + Send + Sync>,
-    /// User-visible name of the embedder (e.g. "potion-base-2M").
-    /// Stored in `memories.embedding_model` and `oplog.embedding_model`
-    /// alongside written rows so reembed and replay can discriminate.
-    pub embedder_name: String,
-    /// Stronger identifier than name — the SHA-256 of the embedder's
-    /// model weights. Two embedders with the same name but different
-    /// weights have different digests; the no-op detection in
-    /// `db.reembed()` uses digest equality, not name equality.
-    pub embedder_digest: String,
-    /// Embedding dimensionality. Must match the active HNSW's dim.
-    pub dim: usize,
-    /// Monotonic generation id. Incremented at each successful Swap.
-    /// `oplog.applied_generation` references this. Generation 0 is the
-    /// pre-reembed sentinel for "the engine has never reembedded."
+    /// Provenance of vectors currently in the active index. Independent
+    /// of `embedder` below.
+    pub index_embedding: EmbeddingProvenance,
+
+    /// Runtime embedder available now for embed_text(). `None` means
+    /// the caller must supply pre-computed vectors. Cloning the Arc is
+    /// cheap; cloning the embedder itself is expensive (model weights).
+    pub embedder: Option<Arc<dyn crate::types::Embedder + Send + Sync>>,
+
+    /// Human-readable name of the currently-loaded runtime embedder,
+    /// if known. May differ from `index_embedding.name()` during the
+    /// compat-attach path (e.g. legacy DB with ExternalOrUnknown
+    /// provenance + a newly-attached named embedder).
+    pub runtime_embedder_name: Option<String>,
+
+    /// Stable fingerprint of the currently-loaded runtime embedder, if
+    /// known. May differ from `index_embedding.digest()` during compat
+    /// attachment.
+    pub runtime_embedder_digest: Option<String>,
+
+    /// Monotonic generation id. Bumps ONLY when a coherent (index +
+    /// provenance) bundle is atomically published — i.e. completed
+    /// reembed() or empty-DB-with-new-embedder coherent reset. Does NOT
+    /// bump on runtime embedder attachment to an existing populated
+    /// index. Generation 0 is the pre-reembed sentinel for "the engine
+    /// has never published a new index bundle."
     pub generation: u64,
-    /// High-water mark of `vec_seq` captured at the cutover barrier
-    /// for the generation that built this SearchState. Every write
-    /// with `vec_seq <= covers_through_seq` is reflected in the
-    /// `index` below. Writes with `vec_seq > covers_through_seq` are
-    /// replayed by the post-swap materializer.
+
+    /// High-water mark of `vec_seq` captured at the cutover barrier for
+    /// the generation that built this SearchState. Every write with
+    /// `vec_seq <= covers_through_seq` is reflected in the active
+    /// index. Writes with `vec_seq > covers_through_seq` are replayed
+    /// by the post-swap materializer.
     pub covers_through_seq: u64,
-    /// HNSW M parameter at construction time. Stored here (not just on
-    /// the index) so the reembed loop can preserve / override it
-    /// independently of the index's internal state.
+
+    /// HNSW M parameter. Stored on SearchState (not just on the index)
+    /// so reembed can preserve / override it independently.
     pub hnsw_m: u32,
     pub hnsw_ef_construction: u32,
     pub hnsw_ef_search: u32,
-    // NOTE: the actual HNSW index handle (Arc<HnswIndex> or
-    // Arc<DeltaIndex>) is intentionally NOT a member of this struct in
-    // the v1 design. The engine's existing `vec_index: DeltaIndex`
-    // field continues to own the index lifecycle. SearchState's swap
-    // atomically updates the embedder + metadata; the DeltaIndex's
-    // internal ArcSwap<HnswIndex> swap handles the index. Reembed
-    // sequences both swaps inside the same critical section so they
-    // are observed atomically by readers. This avoids a bigger refactor
-    // of DeltaIndex.
-    //
-    // If a future redesign moves the index into SearchState, the
-    // changes are: add `pub index: Arc<HnswIndex>`, retire
-    // `vec_index: DeltaIndex` from YantrikDB, and the reembed swap
-    // becomes a single `search_state.store(new_state)` call. That
-    // change is bigger than v1 reembed scope; deferring.
+}
+
+impl SearchState {
+    /// Initial SearchState for a fresh engine. Provenance is
+    /// `ExternalOrUnknown { dim }` until set_embedder* or
+    /// record_text() with a configured embedder populates the index
+    /// with Known-provenance vectors.
+    pub fn initial(
+        dim: usize,
+        hnsw_m: u32,
+        hnsw_ef_construction: u32,
+        hnsw_ef_search: u32,
+    ) -> Self {
+        SearchState {
+            index_embedding: EmbeddingProvenance::ExternalOrUnknown { dim },
+            embedder: None,
+            runtime_embedder_name: None,
+            runtime_embedder_digest: None,
+            generation: 0,
+            covers_through_seq: 0,
+            hnsw_m,
+            hnsw_ef_construction,
+            hnsw_ef_search,
+        }
+    }
+
+    /// Dimensionality of vectors in the active index. Derived from
+    /// `index_embedding` — the single source of truth.
+    pub fn dim(&self) -> usize {
+        self.index_embedding.dim()
+    }
+
+    /// True if the runtime embedder is present and can encode text.
+    /// Used by `YantrikDB::has_embedder()`.
+    pub fn has_runtime_embedder(&self) -> bool {
+        self.embedder.is_some()
+    }
 }
 
 impl fmt::Debug for SearchState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SearchState")
-            .field("embedder_name", &self.embedder_name)
-            .field("embedder_digest", &self.embedder_digest)
-            .field("dim", &self.dim)
+            .field("index_embedding", &self.index_embedding)
+            .field("runtime_embedder_name", &self.runtime_embedder_name)
+            .field("runtime_embedder_digest", &self.runtime_embedder_digest)
+            .field("has_embedder", &self.embedder.is_some())
             .field("generation", &self.generation)
             .field("covers_through_seq", &self.covers_through_seq)
             .field("hnsw_m", &self.hnsw_m)
             .field("hnsw_ef_construction", &self.hnsw_ef_construction)
             .field("hnsw_ef_search", &self.hnsw_ef_search)
-            .finish_non_exhaustive()
+            .finish()
     }
 }
 
@@ -496,5 +620,85 @@ mod tests {
         assert!(opts.hnsw_ef_search.is_none());
         assert!(opts.resume_from_checkpoint);
         assert!(!opts.dry_run);
+    }
+
+    #[test]
+    fn provenance_known_dim_digest_name_accessors() {
+        let p = EmbeddingProvenance::Known {
+            name: Some("potion-base-2M".to_string()),
+            digest: "sha256:abc123".to_string(),
+            dim: 64,
+        };
+        assert_eq!(p.dim(), 64);
+        assert_eq!(p.digest(), Some("sha256:abc123"));
+        assert_eq!(p.name(), Some("potion-base-2M"));
+    }
+
+    #[test]
+    fn provenance_external_or_unknown_has_dim_no_digest_no_name() {
+        let p = EmbeddingProvenance::ExternalOrUnknown { dim: 384 };
+        assert_eq!(p.dim(), 384);
+        assert_eq!(p.digest(), None);
+        assert_eq!(p.name(), None);
+    }
+
+    #[test]
+    fn search_state_initial_is_external_or_unknown_with_no_embedder() {
+        // Fresh engine state: index_embedding is ExternalOrUnknown (no
+        // embedder has populated the index yet), embedder is None
+        // (caller may pass pre-computed vectors), generation=0,
+        // covers_through_seq=0.
+        let s = SearchState::initial(384, 16, 200, 50);
+        assert_eq!(s.dim(), 384);
+        assert!(matches!(
+            s.index_embedding,
+            EmbeddingProvenance::ExternalOrUnknown { dim: 384 }
+        ));
+        assert!(!s.has_runtime_embedder());
+        assert!(s.embedder.is_none());
+        assert!(s.runtime_embedder_name.is_none());
+        assert!(s.runtime_embedder_digest.is_none());
+        assert_eq!(s.generation, 0);
+        assert_eq!(s.covers_through_seq, 0);
+        assert_eq!(s.hnsw_m, 16);
+        assert_eq!(s.hnsw_ef_construction, 200);
+        assert_eq!(s.hnsw_ef_search, 50);
+    }
+
+    #[test]
+    fn search_state_dim_derives_from_provenance_not_a_separate_field() {
+        // Locked by brainstorm-3: SearchState.dim() must derive from
+        // index_embedding.dim(). A separate `dim` field would risk
+        // drift between "what we think the dim is" and "what's
+        // actually in the index." Failing this test means someone
+        // re-added the standalone field.
+        let s_known = SearchState {
+            index_embedding: EmbeddingProvenance::Known {
+                name: None,
+                digest: "x".into(),
+                dim: 768,
+            },
+            embedder: None,
+            runtime_embedder_name: None,
+            runtime_embedder_digest: None,
+            generation: 5,
+            covers_through_seq: 1000,
+            hnsw_m: 16,
+            hnsw_ef_construction: 200,
+            hnsw_ef_search: 50,
+        };
+        assert_eq!(s_known.dim(), 768);
+        let s_unknown = SearchState {
+            index_embedding: EmbeddingProvenance::ExternalOrUnknown { dim: 128 },
+            embedder: None,
+            runtime_embedder_name: None,
+            runtime_embedder_digest: None,
+            generation: 0,
+            covers_through_seq: 0,
+            hnsw_m: 16,
+            hnsw_ef_construction: 200,
+            hnsw_ef_search: 50,
+        };
+        assert_eq!(s_unknown.dim(), 128);
     }
 }

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -564,7 +564,10 @@ impl fmt::Debug for SearchState {
 // db.reembed() — engine entry point (Layer 4 phase 1)
 // ─────────────────────────────────────────────────────────────────────
 
+use rusqlite::params;
+
 use crate::error::{Result, YantrikDbError};
+use crate::serde_helpers::serialize_f32;
 use crate::YantrikDB;
 
 impl YantrikDB {
@@ -603,6 +606,71 @@ impl YantrikDB {
     pub fn reembed(
         &self,
         new_embedder_name: &str,
+        options: ReembedOptions,
+    ) -> Result<ReembedReport> {
+        // **Issue #41 brainstorm-4 — Phase 2 part A.**
+        // Resolve the new embedder by name via the embedder-download
+        // registry, then delegate to the internal entrypoint that
+        // accepts a pre-resolved Arc<dyn Embedder>. The split lets
+        // tests inject synthetic embedders without round-tripping
+        // through the registry, while production callers get the
+        // implicit auto-load behavior hermes asked for in swarmcode
+        // msg 0886504c.
+        //
+        // The same-name short-circuit lives in the inner entrypoint
+        // so registry-resolution is skipped for the no-op case.
+        let probing_state_for_name_check = self.search_state.load_full();
+        let active_name_for_check = probing_state_for_name_check
+            .runtime_embedder_name
+            .clone()
+            .unwrap_or_default();
+        if active_name_for_check == new_embedder_name {
+            // Same-name no-op: skip registry resolution entirely.
+            return self.reembed_with_embedder(
+                new_embedder_name,
+                None,
+                options,
+            );
+        }
+        drop(probing_state_for_name_check);
+
+        #[cfg(feature = "embedder-download")]
+        let resolved: std::sync::Arc<dyn crate::types::Embedder + Send + Sync> = {
+            use crate::embedder::DownloadedEmbedder;
+            let downloaded = DownloadedEmbedder::fetch(new_embedder_name).map_err(|e| {
+                YantrikDbError::Inference(format!(
+                    "reembed: failed to resolve embedder {new_embedder_name:?}: {e}"
+                ))
+            })?;
+            std::sync::Arc::new(downloaded)
+        };
+        #[cfg(not(feature = "embedder-download"))]
+        let resolved: std::sync::Arc<dyn crate::types::Embedder + Send + Sync> = {
+            return Err(YantrikDbError::Inference(format!(
+                "reembed by name {new_embedder_name:?} requires the `embedder-download` \
+                 cargo feature (enabled by default). Slim builds must call \
+                 reembed_with_embedder() directly with a Box<dyn Embedder>."
+            )));
+        };
+        self.reembed_with_embedder(new_embedder_name, Some(resolved), options)
+    }
+
+    /// **Issue #41 brainstorm-4 — Phase 2 internal entrypoint.**
+    ///
+    /// Same contract as [`Self::reembed`] but skips registry
+    /// resolution. When `pre_resolved` is `Some`, the embedder is
+    /// used as-is (tests inject synthetic embedders here). When
+    /// `None`, this is the same-name no-op path (the caller already
+    /// confirmed the active embedder matches the requested name, so
+    /// no embedder resolution is needed).
+    ///
+    /// Public-crate-visible so the test module + future callers
+    /// (e.g. an offline test harness that builds embedders without
+    /// the download registry) can drive Phase 2 directly.
+    pub(crate) fn reembed_with_embedder(
+        &self,
+        new_embedder_name: &str,
+        pre_resolved: Option<std::sync::Arc<dyn crate::types::Embedder + Send + Sync>>,
         options: ReembedOptions,
     ) -> Result<ReembedReport> {
         let started_at = SystemTime::now();
@@ -662,12 +730,86 @@ impl YantrikDB {
             }),
         )?;
 
+        // **Issue #41 brainstorm-4 — Phase 2 Encoding implementation.**
+        //
+        // Use the pre-resolved embedder injected by the caller. The
+        // public reembed() entry point resolves via the embedder-
+        // download registry before delegating here; test paths
+        // inject synthetic embedders directly. `pre_resolved` is
+        // None only on the same-name path which short-circuited
+        // above; if we reach here without one, that's an engine
+        // invariant break.
+        let new_embedder = pre_resolved.ok_or_else(|| {
+            YantrikDbError::Inference(
+                "reembed_with_embedder: pre_resolved=None reached past same-name short-circuit \
+                 — engine invariant violation"
+                    .to_string(),
+            )
+        })?;
+
+        let new_dim = new_embedder.dim();
+        let new_embedder_digest = new_embedder
+            .fingerprint()
+            .unwrap_or_default();
+        let new_embedder_name_resolved = new_embedder
+            .name()
+            .unwrap_or_else(|| new_embedder_name.to_string());
+
+        // **Phase 2 v1 limitation — same-dim only.** The engine's
+        // standalone `embedding_dim` field is still consulted by
+        // ~7 sites (engine/conflict.rs, engine/indices.rs,
+        // engine/record.rs, distributed/replication.rs). Until
+        // those migrate to SearchState.dim(), reembed cannot
+        // safely change dim — record_with_rid's determinism gate
+        // would reject post-reembed writes from new-dim leaders.
+        // Cross-dim migration is the next structural increment;
+        // the documented escape hatch is "open a new DB at the
+        // new dim and copy memories over."
+        if new_dim != active_dim {
+            // Abort cleanly — Probing event was already written; emit Aborted.
+            self.write_reembed_event(
+                next_generation,
+                ReembedPhase::Aborted,
+                systime_to_unix_secs(SystemTime::now()),
+                &serde_json::json!({
+                    "reason": "cross-dim reembed not yet supported",
+                    "active_dim": active_dim,
+                    "new_dim": new_dim,
+                }),
+            )?;
+            return Err(YantrikDbError::Inference(format!(
+                "reembed: new embedder {new_embedder_name_resolved:?} dim={new_dim} \
+                 differs from active dim={active_dim}. Cross-dim reembed is not yet \
+                 supported (engine's standalone embedding_dim field still gates \
+                 record_with_rid/replication paths). Workaround: open a new database \
+                 with YantrikDB::new(path, {new_dim}) and copy memories via export/import."
+            )));
+        }
+
+        // Count rows that need re-encoding. Used to populate the
+        // ReembedProgress.total field for hermes's "show 0/N
+        // immediately" UX ask (swarmcode msg 0886504c).
+        let total_to_encode: u64 = {
+            let conn = self.read_conn();
+            let n: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM memories \
+                     WHERE consolidation_status = 'active' \
+                       AND embedding IS NOT NULL \
+                       AND COALESCE(embedding_generation, 0) < ?1",
+                    params![next_generation as i64],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            n.max(0) as u64
+        };
+
         if let Some(cb) = progress_cb {
             cb(ReembedProgress {
                 phase: ReembedPhase::Probing,
                 processed: 0,
-                total: None,
-                elapsed_ms: 0,
+                total: Some(total_to_encode),
+                elapsed_ms: started_at.elapsed().unwrap_or_default().as_millis() as u64,
                 namespace: options.namespace.clone(),
             });
         }
@@ -680,14 +822,14 @@ impl YantrikDB {
             return Ok(ReembedReport {
                 generation: probing_state.generation,
                 encoded_count: 0,
-                skipped_count: 0,
+                skipped_count: total_to_encode,
                 duration,
                 old_embedder: active_name.clone(),
                 old_embedder_digest: active_digest.clone().unwrap_or_default(),
-                new_embedder: new_embedder_name.to_string(),
-                new_embedder_digest: String::new(), // resolved in phase 2
+                new_embedder: new_embedder_name_resolved.clone(),
+                new_embedder_digest,
                 old_dim: active_dim,
-                new_dim: active_dim,
+                new_dim,
                 build_hwm: probing_state.covers_through_seq,
                 per_namespace: HashMap::new(),
             });
@@ -697,11 +839,13 @@ impl YantrikDB {
         // detect the in-flight reembed.
         self.write_reembed_state_meta(&serde_json::json!({
             "generation": next_generation,
-            "phase": "Probing",
+            "phase": "Encoding",
             "old_embedder": active_name,
-            "new_embedder_name": new_embedder_name,
+            "new_embedder_name": new_embedder_name_resolved,
             "old_dim": active_dim,
+            "new_dim": new_dim,
             "started_at_unix": probing_event_ts,
+            "total_to_encode": total_to_encode,
             "namespace": options.namespace,
             "write_policy": match options.write_policy {
                 ReembedWritePolicy::Queue => "Queue",
@@ -709,22 +853,174 @@ impl YantrikDB {
             },
         }))?;
 
-        // ── Layer 4 phase 2 boundary ──
-        // Clean abort: clear meta + write Aborted event, return Err.
+        // ── Phase 2: Encoding ──
+        //
+        // Scan all active rows whose embedding_generation is strictly
+        // less than next_generation, re-encode each row's text under
+        // the new embedder, write the result to
+        // memories.embedding_new + memories.embedding_new_model.
+        // The active `embedding` column is NOT touched here — that
+        // happens atomically inside the Swapping SAVEPOINT in the
+        // next checkpoint.
+        //
+        // Defensive idempotency: clear any leftover staging from a
+        // prior interrupted attempt at the same target generation.
+        // Without this, a retry after a partial Encoding could miss
+        // rows that already have stale staging from the prior run.
+        {
+            let conn = self.conn();
+            conn.execute(
+                "UPDATE memories SET embedding_new = NULL, embedding_new_model = NULL \
+                 WHERE embedding_new IS NOT NULL",
+                [],
+            )?;
+        }
+
+        let encoding_start_ts = systime_to_unix_secs(SystemTime::now());
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Encoding,
+            encoding_start_ts,
+            &serde_json::json!({
+                "total": total_to_encode,
+                "batch_size": options.batch_size,
+            }),
+        )?;
+
+        let batch_size = options.batch_size.max(1);
+        let mut processed: u64 = 0;
+        let mut offset: usize = 0;
+
+        loop {
+            // Read the next batch of (rid, encrypted_text).
+            // Holds the read connection briefly; no embedder calls
+            // happen under the conn lock.
+            let batch: Vec<(String, String)> = {
+                let conn = self.read_conn();
+                let mut stmt = conn.prepare(
+                    "SELECT rid, text FROM memories \
+                     WHERE consolidation_status = 'active' \
+                       AND embedding IS NOT NULL \
+                       AND COALESCE(embedding_generation, 0) < ?1 \
+                     ORDER BY rid \
+                     LIMIT ?2 OFFSET ?3",
+                )?;
+                let rows = stmt
+                    .query_map(
+                        params![next_generation as i64, batch_size as i64, offset as i64],
+                        |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+                    )?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                drop(stmt);
+                drop(conn);
+                rows
+            };
+
+            if batch.is_empty() {
+                break;
+            }
+
+            // Re-encode each row's text under the new embedder.
+            // Done OUTSIDE the conn lock — embedder.embed() can be
+            // slow (model inference) and must not bottleneck SQL.
+            let mut encoded_pairs: Vec<(String, Vec<u8>)> =
+                Vec::with_capacity(batch.len());
+            for (rid, stored_text) in &batch {
+                let plain = self.decrypt_text(stored_text)?;
+                let new_emb = new_embedder.embed(&plain).map_err(|e| {
+                    YantrikDbError::Inference(format!(
+                        "reembed: embedder failed on rid {rid:?}: {e}"
+                    ))
+                })?;
+                if new_emb.len() != new_dim {
+                    return Err(YantrikDbError::Inference(format!(
+                        "reembed: embedder returned vector of len {} but reports dim {}; \
+                         engine cannot trust this embedder",
+                        new_emb.len(),
+                        new_dim
+                    )));
+                }
+                let blob = serialize_f32(&new_emb);
+                let encrypted = self.encrypt_embedding(&blob)?;
+                encoded_pairs.push((rid.clone(), encrypted));
+            }
+
+            // Write the batch under one SAVEPOINT so a mid-batch
+            // crash leaves the prior batches' staging visible and
+            // this batch's atomic. Idempotency on retry: the staging
+            // clear at the start of Encoding wipes whatever this
+            // batch wrote on the prior attempt.
+            {
+                let conn = self.conn();
+                conn.execute_batch("SAVEPOINT reembed_encoding_batch")?;
+                let write_result: Result<()> = (|| {
+                    for (rid, encrypted) in &encoded_pairs {
+                        conn.execute(
+                            "UPDATE memories SET embedding_new = ?1, embedding_new_model = ?2 \
+                             WHERE rid = ?3",
+                            params![encrypted, new_embedder_name_resolved.as_str(), rid],
+                        )?;
+                    }
+                    Ok(())
+                })();
+                match write_result {
+                    Ok(()) => {
+                        conn.execute_batch("RELEASE reembed_encoding_batch")?;
+                    }
+                    Err(e) => {
+                        let _ = conn.execute_batch("ROLLBACK TO reembed_encoding_batch");
+                        let _ = conn.execute_batch("RELEASE reembed_encoding_batch");
+                        return Err(e);
+                    }
+                }
+            }
+
+            processed += encoded_pairs.len() as u64;
+            offset += batch.len();
+
+            if let Some(cb) = progress_cb {
+                cb(ReembedProgress {
+                    phase: ReembedPhase::Encoding,
+                    processed,
+                    total: Some(total_to_encode),
+                    elapsed_ms: started_at.elapsed().unwrap_or_default().as_millis() as u64,
+                    namespace: options.namespace.clone(),
+                });
+            }
+        }
+
+        // Encoding phase complete. Audit event records the final count.
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Encoding,
+            systime_to_unix_secs(SystemTime::now()),
+            &serde_json::json!({
+                "encoded_count": processed,
+                "completed": true,
+            }),
+        )?;
+
+        // ── Layer 4 phase 2.5 boundary ──
+        // Rebuilding + Swapping + Verifying are the next checkpoint.
+        // Clean abort: leave embedding_new staged (resume logic on
+        // open() in Layer 7 will decide); clear meta.reembed_state;
+        // write Aborted event.
         self.clear_reembed_state_meta()?;
         self.write_reembed_event(
             next_generation,
             ReembedPhase::Aborted,
             systime_to_unix_secs(SystemTime::now()),
             &serde_json::json!({
-                "reason": "Encoding+Rebuilding+Swapping+Verifying not yet implemented (Layer 4 phase 2)",
+                "reason": "Rebuilding+Swapping+Verifying not yet implemented (Layer 4 phase 2 part B)",
+                "encoded_count": processed,
             }),
         )?;
 
         Err(YantrikDbError::Inference(format!(
-            "db.reembed() Layer 4 phase 1: Probing complete, but Encoding/Rebuilding/\
-             Swapping/Verifying phases are pending implementation (issue #41 Layer 4 phase 2). \
-             Dry-run mode and same-name no-op work; real migration requires the next checkpoint."
+            "db.reembed() Phase 2 part A complete: Encoding wrote {processed} rows to \
+             memories.embedding_new under embedder {new_embedder_name_resolved:?}. \
+             Rebuilding/Swapping/Verifying are the next checkpoint (issue #41 Layer 4 phase 2 part B). \
+             The staged columns persist; the next reembed call will overwrite them."
         )))
     }
 
@@ -1040,11 +1336,23 @@ mod tests {
         }))
         .unwrap();
 
+        // Use the internal entrypoint with an injected synthetic
+        // embedder — the public reembed() resolves through the
+        // embedder-download registry which is feature-gated and
+        // off in default test builds.
+        let synthetic: std::sync::Arc<dyn crate::types::Embedder + Send + Sync> =
+            std::sync::Arc::new(PhaseTestEmbedder {
+                dim: 8,
+                fp: "sha256:target".to_string(),
+                name: "target-model".to_string(),
+            });
         let opts = ReembedOptions {
             dry_run: true,
             ..Default::default()
         };
-        let report = db.reembed("target-model", opts).unwrap();
+        let report = db
+            .reembed_with_embedder("target-model", Some(synthetic), opts)
+            .unwrap();
         assert_eq!(report.old_embedder, "original-model");
         assert_eq!(report.new_embedder, "target-model");
         // Dry-run must NOT leave an in-flight reembed signal.
@@ -1067,12 +1375,15 @@ mod tests {
     }
 
     #[test]
-    fn reembed_non_no_op_fails_at_layer_4_phase_2_boundary_with_clean_state() {
-        // Layer 4 phase 1 boundary check: a real (non-no-op,
-        // non-dry-run) reembed call enters Probing, writes
-        // meta.reembed_state, then aborts at the Encoding boundary
-        // returning Err. CRITICAL: meta.reembed_state must be CLEARED
-        // before the Err is returned so the DB isn't left mid-reembed.
+    fn reembed_phase_2_part_a_runs_encoding_and_aborts_at_part_b_boundary() {
+        // **Checkpoint 16 boundary check.** A real (non-no-op,
+        // non-dry-run) reembed runs Encoding to completion (writing
+        // embedding_new + embedding_new_model on every active row)
+        // and aborts at the new "Phase 2 part A complete" boundary.
+        // Critical:
+        //   - meta.reembed_state MUST be cleared on the way out
+        //   - the Aborted event MUST be in the audit log
+        //   - the staged columns are populated (Encoding wrote them)
         let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
         db.set_embedder(Box::new(PhaseTestEmbedder {
             dim: 8,
@@ -1081,30 +1392,53 @@ mod tests {
         }))
         .unwrap();
 
+        // Plant two rows so Encoding has something to scan.
+        for i in 0..2 {
+            db.record(
+                &format!("row {i}"),
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec![0.1_f32; 8],
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+        }
+
+        let synthetic: std::sync::Arc<dyn crate::types::Embedder + Send + Sync> =
+            std::sync::Arc::new(PhaseTestEmbedder {
+                dim: 8,
+                fp: "sha256:target".to_string(),
+                name: "target-model".to_string(),
+            });
         let err = db
-            .reembed("target-model", ReembedOptions::default())
+            .reembed_with_embedder("target-model", Some(synthetic), ReembedOptions::default())
             .unwrap_err();
-        // Specific error class — layer 4 phase 2 boundary signal.
         match err {
             crate::error::YantrikDbError::Inference(msg) => {
                 assert!(
-                    msg.contains("Layer 4 phase 2"),
-                    "expected layer-4-phase-2 boundary message, got: {msg}"
+                    msg.contains("Phase 2 part A complete") && msg.contains("part B"),
+                    "expected Phase 2 part A boundary message, got: {msg}"
                 );
+                // Locks the encoded_count surfaces in the error.
+                assert!(msg.contains("Encoding wrote 2 rows"), "msg: {msg}");
             }
-            other => panic!("expected Inference error at phase 2 boundary, got {other:?}"),
+            other => panic!("expected Inference at part-A boundary, got {other:?}"),
         }
 
-        // Critical: meta.reembed_state must have been cleared on the
-        // way out. Else the next open() would see an in-flight reembed
-        // and try to resume into an unimplemented phase.
+        // meta.reembed_state cleared (no in-flight signal lingering).
         assert!(
             db.reembed_status().is_none(),
-            "meta.reembed_state must be cleared on layer-4-phase-2 abort"
+            "meta.reembed_state must be cleared on part-A-boundary abort"
         );
 
-        // The Aborted event MUST be in the audit log with the
-        // boundary reason.
+        // Aborted event in audit log.
         let aborted_count: i64 = db
             .conn()
             .query_row(
@@ -1114,6 +1448,171 @@ mod tests {
             )
             .unwrap();
         assert_eq!(aborted_count, 1, "Aborted event must be logged");
+
+        // Encoding event in audit log (separate event from Probing).
+        let encoding_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM reembed_events WHERE phase = 'Encoding'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            encoding_count >= 1,
+            "Encoding event must be in audit log (got {encoding_count})"
+        );
+
+        // The 2 planted rows MUST have embedding_new + embedding_new_model
+        // populated (Encoding wrote them) AND embedding_generation
+        // unchanged (Swapping is what bumps that — pending).
+        let staged_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE embedding_new IS NOT NULL \
+                 AND embedding_new_model = 'target-model'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(staged_count, 2, "Encoding must have populated staging columns");
+
+        // embedding_generation unchanged at 0 (Phase 2 part B will bump).
+        let gen_zero_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE embedding_generation = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(gen_zero_count, 2, "embedding_generation unchanged before swap");
+    }
+
+    #[test]
+    fn reembed_phase_2_rejects_cross_dim_with_clear_error() {
+        // **Phase 2 v1 limitation.** Same-dim reembeds only;
+        // cross-dim requires retiring the engine's standalone
+        // `embedding_dim` field which is its own structural debt.
+        // The error message must point the caller at the
+        // documented escape hatch.
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedder {
+            dim: 8,
+            fp: "sha256:active".to_string(),
+            name: "active".to_string(),
+        }))
+        .unwrap();
+
+        let cross_dim: std::sync::Arc<dyn crate::types::Embedder + Send + Sync> =
+            std::sync::Arc::new(PhaseTestEmbedder {
+                dim: 16, // different from active dim 8
+                fp: "sha256:cross".to_string(),
+                name: "cross-dim-target".to_string(),
+            });
+        let err = db
+            .reembed_with_embedder(
+                "cross-dim-target",
+                Some(cross_dim),
+                ReembedOptions::default(),
+            )
+            .unwrap_err();
+        match err {
+            crate::error::YantrikDbError::Inference(msg) => {
+                assert!(
+                    msg.contains("Cross-dim reembed is not yet supported"),
+                    "expected cross-dim guard message, got: {msg}"
+                );
+                assert!(msg.contains("dim=8") && msg.contains("dim=16"), "msg: {msg}");
+            }
+            other => panic!("expected Inference, got {other:?}"),
+        }
+        // No mid-reembed state leftover.
+        assert!(db.reembed_status().is_none());
+    }
+
+    #[test]
+    fn reembed_phase_2_part_a_with_progress_callback_emits_total() {
+        // **Hermes ask 1 (swarmcode msg 0886504c).** Probing must
+        // emit a progress event with `total` populated (not None),
+        // so CLIs can show "0/N" immediately before Encoding
+        // starts. Locks that the count happens BEFORE the first
+        // progress callback fires.
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedder {
+            dim: 8,
+            fp: "sha256:active".to_string(),
+            name: "active".to_string(),
+        }))
+        .unwrap();
+
+        // Plant 3 rows.
+        for i in 0..3 {
+            db.record(
+                &format!("row {i}"),
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec![0.1_f32; 8],
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+        }
+
+        use std::sync::{Arc, Mutex};
+        let events: Arc<Mutex<Vec<ReembedProgress>>> = Arc::new(Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let progress_cb: Box<dyn Fn(ReembedProgress) + Send + Sync> =
+            Box::new(move |p| events_clone.lock().unwrap().push(p));
+
+        let synthetic: std::sync::Arc<dyn crate::types::Embedder + Send + Sync> =
+            std::sync::Arc::new(PhaseTestEmbedder {
+                dim: 8,
+                fp: "sha256:target".to_string(),
+                name: "target".to_string(),
+            });
+        let opts = ReembedOptions {
+            progress_cb: Some(progress_cb),
+            ..Default::default()
+        };
+        // Encoding+abort path; we only care about progress events.
+        let _ = db.reembed_with_embedder("target", Some(synthetic), opts);
+
+        let captured = events.lock().unwrap().clone();
+        assert!(!captured.is_empty(), "at least one progress event fired");
+        // First event must be Probing with total=Some(3).
+        let first = &captured[0];
+        assert!(
+            matches!(first.phase, ReembedPhase::Probing),
+            "first event must be Probing, got {:?}",
+            first.phase
+        );
+        assert_eq!(
+            first.total,
+            Some(3),
+            "Probing must populate total so CLIs show 0/N immediately (hermes ask 1)"
+        );
+        assert_eq!(first.processed, 0, "Probing fires with processed=0");
+
+        // Subsequent Encoding events must have monotonic processed
+        // and the same total.
+        let encoding_events: Vec<&ReembedProgress> = captured
+            .iter()
+            .filter(|e| matches!(e.phase, ReembedPhase::Encoding))
+            .collect();
+        for e in &encoding_events {
+            assert_eq!(e.total, Some(3));
+            assert!(e.processed <= 3);
+        }
+        if let Some(last) = encoding_events.last() {
+            assert_eq!(last.processed, 3, "final Encoding event reflects all rows");
+        }
     }
 
     #[test]

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -547,6 +547,294 @@ impl fmt::Debug for SearchState {
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// db.reembed() — engine entry point (Layer 4 phase 1)
+// ─────────────────────────────────────────────────────────────────────
+
+use crate::error::{Result, YantrikDbError};
+use crate::YantrikDB;
+
+impl YantrikDB {
+    /// **Issue #41 layer 4 — in-place embedder migration.**
+    ///
+    /// Re-encodes every memory under a new embedder and atomically
+    /// swaps the active SearchState to the new generation. Concurrent
+    /// recall traffic continues throughout (against the old generation
+    /// until Swap completes); concurrent writes follow the policy in
+    /// `ReembedOptions::write_policy` (default `Queue`).
+    ///
+    /// ## Layer 4 phase 1 scope (this commit)
+    ///
+    /// - Probing phase (resolve embedder name → same-name no-op check)
+    /// - Dry-run path (Probing only, no state mutations beyond audit
+    ///   event)
+    /// - Same-name no-op detection (returns `Ok(report)` immediately
+    ///   without touching anything)
+    /// - `reembed_status()` API reading meta.reembed_state
+    ///
+    /// ## Layer 4 phase 2 (next checkpoint)
+    ///
+    /// - Encoding phase (batch iterate memories, encode under new
+    ///   embedder via embedder-download resolver, write to staging
+    ///   columns embedding_new + embedding_new_model)
+    /// - Rebuilding phase (build new HNSW from staging columns)
+    /// - Swapping phase (atomic ArcSwap + UPDATE memories.embedding =
+    ///   embedding_new inside one transaction)
+    /// - Verifying phase (sanity check + staging cleanup)
+    /// - Crash recovery on open()
+    ///
+    /// Currently returns `Err` at the Encoding phase boundary if the
+    /// call would proceed past Probing for a non-no-op reembed. The
+    /// boundary is clean — meta.reembed_state is cleared on the way
+    /// out so the DB is not left mid-reembed.
+    pub fn reembed(
+        &self,
+        new_embedder_name: &str,
+        options: ReembedOptions,
+    ) -> Result<ReembedReport> {
+        let started_at = SystemTime::now();
+        let progress_cb = options.progress_cb.as_ref();
+        let on_phase_complete = options.on_phase_complete.as_ref();
+
+        // Acquire index_write_lock for the full reembed duration.
+        // Serializes against concurrent set_embedder + other reembed
+        // calls (single-job invariant from brainstorm-3).
+        let _index_guard = self.index_write_lock.lock();
+
+        // ── Phase 1: Probing ──
+        let probing_state = self.search_state.load_full();
+        let active_dim = probing_state.dim();
+        let active_digest = probing_state.runtime_embedder_digest.clone();
+        let active_name = probing_state
+            .runtime_embedder_name
+            .clone()
+            .unwrap_or_default();
+
+        let same_name = active_name == new_embedder_name;
+        if same_name {
+            // No-op: caller asked for the embedder already loaded.
+            // Brainstorm-3 same-digest no-op rule. No generation bump,
+            // no covers_through_seq change, no meta.reembed_state
+            // write — fully transparent to crash recovery.
+            let duration = started_at.elapsed().unwrap_or_default();
+            let _ = progress_cb;
+            let _ = on_phase_complete;
+            return Ok(ReembedReport {
+                generation: probing_state.generation,
+                encoded_count: 0,
+                skipped_count: 0,
+                duration,
+                old_embedder: active_name.clone(),
+                old_embedder_digest: active_digest.clone().unwrap_or_default(),
+                new_embedder: active_name,
+                new_embedder_digest: active_digest.unwrap_or_default(),
+                old_dim: active_dim,
+                new_dim: active_dim,
+                build_hwm: probing_state.covers_through_seq,
+                per_namespace: HashMap::new(),
+            });
+        }
+
+        let next_generation = probing_state.generation + 1;
+        let probing_event_ts = systime_to_unix_secs(started_at);
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Probing,
+            probing_event_ts,
+            &serde_json::json!({
+                "old_embedder": active_name,
+                "new_embedder_name": new_embedder_name,
+                "old_dim": active_dim,
+                "namespace": options.namespace,
+            }),
+        )?;
+
+        if let Some(cb) = progress_cb {
+            cb(ReembedProgress {
+                phase: ReembedPhase::Probing,
+                processed: 0,
+                total: None,
+                elapsed_ms: 0,
+                namespace: options.namespace.clone(),
+            });
+        }
+
+        // Dry-run path: Probing completed, return predicted shape.
+        // The Probing audit event is permanent (intentional — dry-runs
+        // are observable in the event log).
+        if options.dry_run {
+            let duration = started_at.elapsed().unwrap_or_default();
+            return Ok(ReembedReport {
+                generation: probing_state.generation,
+                encoded_count: 0,
+                skipped_count: 0,
+                duration,
+                old_embedder: active_name.clone(),
+                old_embedder_digest: active_digest.clone().unwrap_or_default(),
+                new_embedder: new_embedder_name.to_string(),
+                new_embedder_digest: String::new(), // resolved in phase 2
+                old_dim: active_dim,
+                new_dim: active_dim,
+                build_hwm: probing_state.covers_through_seq,
+                per_namespace: HashMap::new(),
+            });
+        }
+
+        // Persist meta.reembed_state so crash recovery on open() can
+        // detect the in-flight reembed.
+        self.write_reembed_state_meta(&serde_json::json!({
+            "generation": next_generation,
+            "phase": "Probing",
+            "old_embedder": active_name,
+            "new_embedder_name": new_embedder_name,
+            "old_dim": active_dim,
+            "started_at_unix": probing_event_ts,
+            "namespace": options.namespace,
+            "write_policy": match options.write_policy {
+                ReembedWritePolicy::Queue => "Queue",
+                ReembedWritePolicy::Pause => "Pause",
+            },
+        }))?;
+
+        // ── Layer 4 phase 2 boundary ──
+        // Clean abort: clear meta + write Aborted event, return Err.
+        self.clear_reembed_state_meta()?;
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Aborted,
+            systime_to_unix_secs(SystemTime::now()),
+            &serde_json::json!({
+                "reason": "Encoding+Rebuilding+Swapping+Verifying not yet implemented (Layer 4 phase 2)",
+            }),
+        )?;
+
+        Err(YantrikDbError::Inference(format!(
+            "db.reembed() Layer 4 phase 1: Probing complete, but Encoding/Rebuilding/\
+             Swapping/Verifying phases are pending implementation (issue #41 Layer 4 phase 2). \
+             Dry-run mode and same-name no-op work; real migration requires the next checkpoint."
+        )))
+    }
+
+    /// **Issue #41 — read-only status of an in-flight reembed.**
+    /// Returns `None` if no reembed is active. Reads from
+    /// `meta.reembed_state` (the durable summary row).
+    ///
+    /// Layer 4 phase 1: returns minimal status (phase + old/new names
+    /// + start time + write policy). Phase 2 will populate the
+    /// memories_total / memories_encoded counts once Encoding is
+    /// implemented.
+    pub fn reembed_status(&self) -> Option<ReembedStatus> {
+        let conn = self.read_conn();
+        let payload_json: Option<String> = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'reembed_state'",
+                [],
+                |row| row.get(0),
+            )
+            .ok();
+        let payload: serde_json::Value = serde_json::from_str(&payload_json?).ok()?;
+
+        let generation = payload.get("generation")?.as_u64()?;
+        let phase = ReembedPhase::parse(payload.get("phase")?.as_str()?)?;
+        let old_name = payload
+            .get("old_embedder")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let new_name = payload
+            .get("new_embedder_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let old_dim = payload
+            .get("old_dim")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let started_at_unix = payload
+            .get("started_at_unix")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let started_at = std::time::UNIX_EPOCH
+            + std::time::Duration::from_secs_f64(started_at_unix.max(0.0));
+        let write_policy = match payload.get("write_policy").and_then(|v| v.as_str()) {
+            Some("Pause") => ReembedWritePolicy::Pause,
+            _ => ReembedWritePolicy::Queue,
+        };
+
+        Some(ReembedStatus {
+            generation,
+            phase,
+            old_embedder: old_name,
+            old_embedder_digest: String::new(),
+            new_embedder: new_name,
+            new_embedder_digest: String::new(),
+            old_dim,
+            new_dim: old_dim,
+            memories_total: 0,
+            memories_encoded: 0,
+            queued_writes: 0,
+            checkpoint_rid: None,
+            started_at,
+            last_event_at: started_at,
+            last_error: None,
+            write_policy,
+        })
+    }
+
+    /// Write a row to `reembed_events` (durable audit log). Called at
+    /// each phase transition.
+    pub(crate) fn write_reembed_event(
+        &self,
+        generation: u64,
+        phase: ReembedPhase,
+        timestamp_unix_secs: f64,
+        payload: &serde_json::Value,
+    ) -> Result<()> {
+        use rusqlite::params;
+        let payload_str = serde_json::to_string(payload)?;
+        let conn = self.conn();
+        conn.execute(
+            "INSERT INTO reembed_events (generation, phase, timestamp, payload_json) \
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                generation as i64,
+                phase.as_str(),
+                timestamp_unix_secs,
+                payload_str
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Write `meta.reembed_state` with the current job summary JSON.
+    pub(crate) fn write_reembed_state_meta(
+        &self,
+        state_json: &serde_json::Value,
+    ) -> Result<()> {
+        use rusqlite::params;
+        let s = serde_json::to_string(state_json)?;
+        let conn = self.conn();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('reembed_state', ?1)",
+            params![s],
+        )?;
+        Ok(())
+    }
+
+    /// Clear `meta.reembed_state`, signaling no in-flight reembed.
+    pub(crate) fn clear_reembed_state_meta(&self) -> Result<()> {
+        let conn = self.conn();
+        conn.execute("DELETE FROM meta WHERE key = 'reembed_state'", [])?;
+        Ok(())
+    }
+}
+
+fn systime_to_unix_secs(t: SystemTime) -> f64 {
+    t.duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────
 
@@ -663,6 +951,148 @@ mod tests {
         assert_eq!(s.hnsw_m, 16);
         assert_eq!(s.hnsw_ef_construction, 200);
         assert_eq!(s.hnsw_ef_search, 50);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Layer 4 phase 1: db.reembed() entry-point tests
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Helper Embedder for reembed phase-1 tests — has a fingerprint
+    /// so the engine's set_embedder can attach it as Known provenance.
+    struct PhaseTestEmbedder {
+        pub dim: usize,
+        pub fp: String,
+        pub name: String,
+    }
+
+    impl crate::types::Embedder for PhaseTestEmbedder {
+        fn embed(
+            &self,
+            _text: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>>
+        {
+            Ok(vec![0.1_f32; self.dim])
+        }
+        fn dim(&self) -> usize {
+            self.dim
+        }
+        fn fingerprint(&self) -> Option<String> {
+            Some(self.fp.clone())
+        }
+        fn name(&self) -> Option<String> {
+            Some(self.name.clone())
+        }
+    }
+
+    #[test]
+    fn reembed_same_name_is_no_op() {
+        // Caller asks for the embedder already loaded — must short-
+        // circuit immediately without writing meta.reembed_state or
+        // even a Probing audit event, and return encoded_count=0.
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedder {
+            dim: 8,
+            fp: "sha256:same".to_string(),
+            name: "model-x".to_string(),
+        }))
+        .unwrap();
+
+        let report = db.reembed("model-x", ReembedOptions::default()).unwrap();
+        assert_eq!(report.encoded_count, 0, "same-name no-op encodes 0");
+        assert_eq!(report.skipped_count, 0);
+        assert_eq!(report.old_embedder, "model-x");
+        assert_eq!(report.new_embedder, "model-x");
+        // No meta.reembed_state row written — confirms full no-op shape.
+        assert!(db.reembed_status().is_none(), "no-op must not leave reembed_status");
+    }
+
+    #[test]
+    fn reembed_dry_run_returns_predicted_report_and_clears_state() {
+        // Dry-run: Probing event is written (audit trail), but
+        // meta.reembed_state is NOT (no in-flight signal), and the
+        // call returns the predicted ReembedReport.
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedder {
+            dim: 8,
+            fp: "sha256:original".to_string(),
+            name: "original-model".to_string(),
+        }))
+        .unwrap();
+
+        let opts = ReembedOptions {
+            dry_run: true,
+            ..Default::default()
+        };
+        let report = db.reembed("target-model", opts).unwrap();
+        assert_eq!(report.old_embedder, "original-model");
+        assert_eq!(report.new_embedder, "target-model");
+        // Dry-run must NOT leave an in-flight reembed signal.
+        assert!(
+            db.reembed_status().is_none(),
+            "dry-run must NOT write meta.reembed_state"
+        );
+
+        // The Probing audit event IS in reembed_events (dry-runs are
+        // observable in the event log — intentional design choice).
+        let event_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM reembed_events WHERE phase = 'Probing'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(event_count >= 1, "Probing event must be in audit log even for dry-run");
+    }
+
+    #[test]
+    fn reembed_non_no_op_fails_at_layer_4_phase_2_boundary_with_clean_state() {
+        // Layer 4 phase 1 boundary check: a real (non-no-op,
+        // non-dry-run) reembed call enters Probing, writes
+        // meta.reembed_state, then aborts at the Encoding boundary
+        // returning Err. CRITICAL: meta.reembed_state must be CLEARED
+        // before the Err is returned so the DB isn't left mid-reembed.
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedder {
+            dim: 8,
+            fp: "sha256:original".to_string(),
+            name: "original-model".to_string(),
+        }))
+        .unwrap();
+
+        let err = db
+            .reembed("target-model", ReembedOptions::default())
+            .unwrap_err();
+        // Specific error class — layer 4 phase 2 boundary signal.
+        match err {
+            crate::error::YantrikDbError::Inference(msg) => {
+                assert!(
+                    msg.contains("Layer 4 phase 2"),
+                    "expected layer-4-phase-2 boundary message, got: {msg}"
+                );
+            }
+            other => panic!("expected Inference error at phase 2 boundary, got {other:?}"),
+        }
+
+        // Critical: meta.reembed_state must have been cleared on the
+        // way out. Else the next open() would see an in-flight reembed
+        // and try to resume into an unimplemented phase.
+        assert!(
+            db.reembed_status().is_none(),
+            "meta.reembed_state must be cleared on layer-4-phase-2 abort"
+        );
+
+        // The Aborted event MUST be in the audit log with the
+        // boundary reason.
+        let aborted_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM reembed_events WHERE phase = 'Aborted'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(aborted_count, 1, "Aborted event must be logged");
     }
 
     #[test]

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -567,7 +567,8 @@ impl fmt::Debug for SearchState {
 use rusqlite::params;
 
 use crate::error::{Result, YantrikDbError};
-use crate::serde_helpers::serialize_f32;
+use crate::serde_helpers::{deserialize_f32, serialize_f32};
+use crate::vector::hnsw::HnswIndex;
 use crate::YantrikDB;
 
 impl YantrikDB {
@@ -1000,28 +1001,425 @@ impl YantrikDB {
             }),
         )?;
 
-        // ── Layer 4 phase 2.5 boundary ──
-        // Rebuilding + Swapping + Verifying are the next checkpoint.
-        // Clean abort: leave embedding_new staged (resume logic on
-        // open() in Layer 7 will decide); clear meta.reembed_state;
-        // write Aborted event.
-        self.clear_reembed_state_meta()?;
+        // ── Phase 2: Rebuilding ──
+        //
+        // Construct a new HnswIndex of size `new_dim` (== `active_dim`
+        // for v1 same-dim reembeds) using the SearchState's HNSW
+        // params (with caller overrides if supplied via options).
+        // Insert every staged embedding_new bytes into it.
+        //
+        // The rebuild happens BEFORE the WriteRouter cutover so the
+        // hot path stays sync-write-friendly while the (potentially
+        // long) rebuild runs. Tail writes that arrive between
+        // Encoding-completion and the cutover-barrier are picked up
+        // in the post-barrier catch-up step below.
+        let new_hnsw_m = options.hnsw_m.unwrap_or(probing_state.hnsw_m);
+        let new_hnsw_efc = options
+            .hnsw_ef_construction
+            .unwrap_or(probing_state.hnsw_ef_construction);
+        let new_hnsw_efs = options
+            .hnsw_ef_search
+            .unwrap_or(probing_state.hnsw_ef_search);
+
+        let rebuilding_start_ts = systime_to_unix_secs(SystemTime::now());
         self.write_reembed_event(
             next_generation,
-            ReembedPhase::Aborted,
+            ReembedPhase::Rebuilding,
+            rebuilding_start_ts,
+            &serde_json::json!({
+                "expected_count": processed,
+                "hnsw_m": new_hnsw_m,
+                "hnsw_ef_construction": new_hnsw_efc,
+                "hnsw_ef_search": new_hnsw_efs,
+            }),
+        )?;
+        self.update_reembed_state_phase("Rebuilding")?;
+
+        if let Some(cb) = progress_cb {
+            cb(ReembedProgress {
+                phase: ReembedPhase::Rebuilding,
+                processed: 0,
+                total: Some(processed),
+                elapsed_ms: started_at.elapsed().unwrap_or_default().as_millis() as u64,
+                namespace: options.namespace.clone(),
+            });
+        }
+
+        let mut new_hnsw = HnswIndex::with_params(
+            new_dim,
+            new_hnsw_m as usize,
+            new_hnsw_efc as usize,
+            new_hnsw_efs as usize,
+        );
+        let mut rebuilt: u64 = 0;
+        let mut rebuild_offset: usize = 0;
+
+        loop {
+            // Read staged embedding_new bytes in batches.
+            let batch: Vec<(String, Vec<u8>)> = {
+                let conn = self.read_conn();
+                let mut stmt = conn.prepare(
+                    "SELECT rid, embedding_new FROM memories \
+                     WHERE consolidation_status = 'active' \
+                       AND embedding_new IS NOT NULL \
+                     ORDER BY rid \
+                     LIMIT ?1 OFFSET ?2",
+                )?;
+                let rows = stmt
+                    .query_map(
+                        params![batch_size as i64, rebuild_offset as i64],
+                        |r| Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?)),
+                    )?
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                drop(stmt);
+                drop(conn);
+                rows
+            };
+
+            if batch.is_empty() {
+                break;
+            }
+
+            for (rid, stored_blob) in &batch {
+                let decrypted = self.decrypt_embedding(stored_blob)?;
+                let vec = deserialize_f32(&decrypted);
+                if vec.len() != new_dim {
+                    return Err(YantrikDbError::Inference(format!(
+                        "reembed Rebuilding: staged embedding_new for rid {rid:?} has len {} \
+                         but expected new_dim {new_dim}",
+                        vec.len()
+                    )));
+                }
+                new_hnsw.insert(rid, &vec)?;
+                rebuilt += 1;
+            }
+            rebuild_offset += batch.len();
+
+            if let Some(cb) = progress_cb {
+                cb(ReembedProgress {
+                    phase: ReembedPhase::Rebuilding,
+                    processed: rebuilt,
+                    total: Some(processed),
+                    elapsed_ms: started_at.elapsed().unwrap_or_default().as_millis() as u64,
+                    namespace: options.namespace.clone(),
+                });
+            }
+        }
+
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Rebuilding,
             systime_to_unix_secs(SystemTime::now()),
             &serde_json::json!({
-                "reason": "Rebuilding+Swapping+Verifying not yet implemented (Layer 4 phase 2 part B)",
-                "encoded_count": processed,
+                "rebuilt_count": rebuilt,
+                "completed": true,
             }),
         )?;
 
-        Err(YantrikDbError::Inference(format!(
-            "db.reembed() Phase 2 part A complete: Encoding wrote {processed} rows to \
-             memories.embedding_new under embedder {new_embedder_name_resolved:?}. \
-             Rebuilding/Swapping/Verifying are the next checkpoint (issue #41 Layer 4 phase 2 part B). \
-             The staged columns persist; the next reembed call will overwrite them."
-        )))
+        // ── Phase 2: Swapping ──
+        //
+        // Cutover sequence (brainstorm-2 §3-§4):
+        // 1. switch_to_queueing — new sync writers route to oplog
+        // 2. wait_for_no_sync_writers — drain in-flight sync writers
+        // 3. capture vec_seq HWM (covers_through_seq for new gen)
+        // 4. tail-catchup: encode any rows that arrived AFTER the
+        //    Encoding scan completed (rows with old gen + NULL
+        //    embedding_new) — they're between [start_of_Encoding,
+        //    cutover-barrier] window
+        // 5. atomic SQL transaction: bump meta.active_generation,
+        //    promote embedding_new -> embedding + stamp
+        //    embedding_generation, clear staging columns
+        // 6. try_publish_search_state(new_state) — the in-memory
+        //    publish. Single atomic point (brainstorm-4 §1).
+        // 7. switch_to_normal — resume sync writes
+        //
+        // Crash recovery (brainstorm-4 §6): if the engine dies
+        // between SQL commit (step 5) and ArcSwap store (step 6),
+        // open() reads meta.active_generation and rebuilds the
+        // SearchState at the new generation. Layer 7 will lift this
+        // out into the open() codepath; for now we rely on a
+        // successful uninterrupted run.
+        let swapping_start_ts = systime_to_unix_secs(SystemTime::now());
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Swapping,
+            swapping_start_ts,
+            &serde_json::json!({}),
+        )?;
+        self.update_reembed_state_phase("Swapping")?;
+
+        if let Some(cb) = progress_cb {
+            cb(ReembedProgress {
+                phase: ReembedPhase::Swapping,
+                processed: 0,
+                total: None,
+                elapsed_ms: started_at.elapsed().unwrap_or_default().as_millis() as u64,
+                namespace: options.namespace.clone(),
+            });
+        }
+
+        // Cutover step 1: flip the WriteRouter to Queueing. New
+        // sync writers will see the gate and route to record_queued.
+        self.write_router.switch_to_queueing();
+
+        // Cutover step 2: drain in-flight sync writers. After this
+        // returns, every committed write under the OLD generation
+        // is durable and visible to our tail-catchup scan below.
+        //
+        // Held within a closure so any of the remaining cutover
+        // steps that fail can flip the router back to Normal —
+        // leaving Queueing on error would block all subsequent
+        // sync writes until process restart.
+        self.write_router.wait_for_no_sync_writers();
+
+        // Cutover step 3: capture vec_seq HWM. This is the
+        // covers_through_seq for the new generation — every write
+        // with vec_seq <= this is durable in the OLD index and now
+        // (after the SQL swap) in the NEW index. Writes past this
+        // seq either are queued in oplog (Queueing) or arrived
+        // post-cutover and will be applied to the new gen directly.
+        let covers_through_seq = self
+            .vec_seq
+            .load(std::sync::atomic::Ordering::Acquire);
+
+        // Cutover step 4: tail-catchup. Encode any rows whose
+        // embedding_generation is still under the new generation
+        // AND embedding_new is NULL (arrived between Encoding scan
+        // and the cutover barrier).
+        let tail_rows: Vec<(String, String)> = {
+            let conn = self.read_conn();
+            let mut stmt = conn.prepare(
+                "SELECT rid, text FROM memories \
+                 WHERE consolidation_status = 'active' \
+                   AND embedding IS NOT NULL \
+                   AND embedding_new IS NULL \
+                   AND COALESCE(embedding_generation, 0) < ?1",
+            )?;
+            let rows = stmt
+                .query_map(params![next_generation as i64], |r| {
+                    Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            drop(stmt);
+            drop(conn);
+            rows
+        };
+
+        for (rid, stored_text) in &tail_rows {
+            let plain = self.decrypt_text(stored_text)?;
+            let new_emb = new_embedder.embed(&plain).map_err(|e| {
+                YantrikDbError::Inference(format!(
+                    "reembed tail-catchup: embedder failed on rid {rid:?}: {e}"
+                ))
+            })?;
+            if new_emb.len() != new_dim {
+                self.write_router.switch_to_normal();
+                return Err(YantrikDbError::Inference(format!(
+                    "reembed tail-catchup: embedder returned vector of len {} but reports dim {}",
+                    new_emb.len(),
+                    new_dim
+                )));
+            }
+            let blob = serialize_f32(&new_emb);
+            let encrypted = self.encrypt_embedding(&blob)?;
+            {
+                let conn = self.conn();
+                conn.execute(
+                    "UPDATE memories SET embedding_new = ?1, embedding_new_model = ?2 \
+                     WHERE rid = ?3",
+                    params![encrypted, new_embedder_name_resolved.as_str(), rid],
+                )?;
+            }
+            new_hnsw.insert(rid, &new_emb)?;
+        }
+        let tail_caught = tail_rows.len() as u64;
+
+        // Cutover step 5: atomic SQL swap. SAVEPOINT so the entire
+        // promotion is one durable unit. If COMMIT succeeds the
+        // engine is durably at the new generation; if it fails the
+        // staging columns are still intact for the next reembed
+        // attempt.
+        let total_swapped: i64 = {
+            let conn = self.conn();
+            conn.execute_batch("SAVEPOINT reembed_swap")?;
+
+            let result: Result<i64> = (|| {
+                conn.execute(
+                    "INSERT OR REPLACE INTO meta (key, value) VALUES ('active_generation', ?1)",
+                    params![next_generation.to_string()],
+                )?;
+                let n = conn.execute(
+                    "UPDATE memories \
+                     SET embedding = embedding_new, \
+                         embedding_generation = ?1, \
+                         embedding_new = NULL, \
+                         embedding_new_model = NULL \
+                     WHERE embedding_new IS NOT NULL",
+                    params![next_generation as i64],
+                )?;
+                Ok(n as i64)
+            })();
+
+            match result {
+                Ok(n) => {
+                    conn.execute_batch("RELEASE reembed_swap")?;
+                    n
+                }
+                Err(e) => {
+                    let _ = conn.execute_batch("ROLLBACK TO reembed_swap");
+                    let _ = conn.execute_batch("RELEASE reembed_swap");
+                    self.write_router.switch_to_normal();
+                    return Err(e);
+                }
+            }
+        };
+
+        // Cutover step 6: in-memory publish. Build a new
+        // SearchState carrying:
+        //   - new index_embedding (Known under the new embedder)
+        //   - the same embedder Arc (we hold one already)
+        //   - the new generation
+        //   - covers_through_seq captured at step 3
+        //   - the new HNSW wrapped in a fresh DeltaIndex
+        //   - HNSW params from options or carried over
+        let new_delta_index = {
+            let delta_max = std::env::var("YANTRIKDB_DELTA_MAX")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(crate::vector::delta_index::DEFAULT_DELTA_MAX);
+            let max_dirty_age = std::env::var("YANTRIKDB_MAX_DIRTY_AGE_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(std::time::Duration::from_secs)
+                .unwrap_or(crate::vector::delta_index::DEFAULT_MAX_DIRTY_AGE);
+            std::sync::Arc::new(
+                crate::vector::delta_index::DeltaIndex::from_cold_with_age(
+                    new_hnsw,
+                    delta_max,
+                    max_dirty_age,
+                ),
+            )
+        };
+
+        let new_search_state = SearchState {
+            index_embedding: EmbeddingProvenance::Known {
+                name: Some(new_embedder_name_resolved.clone()),
+                digest: new_embedder_digest.clone(),
+                dim: new_dim,
+            },
+            embedder: Some(std::sync::Arc::clone(&new_embedder)),
+            runtime_embedder_name: Some(new_embedder_name_resolved.clone()),
+            runtime_embedder_digest: Some(new_embedder_digest.clone()),
+            generation: next_generation,
+            covers_through_seq,
+            hnsw_m: new_hnsw_m,
+            hnsw_ef_construction: new_hnsw_efc,
+            hnsw_ef_search: new_hnsw_efs,
+            vec_index: new_delta_index,
+        };
+        self.try_publish_search_state(new_search_state)?;
+
+        // Cutover step 7: resume sync writes under the new generation.
+        // The standalone WriteRouter state flip is observable to any
+        // record/record_text call that arrives after this point.
+        self.write_router.switch_to_normal();
+
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Swapping,
+            systime_to_unix_secs(SystemTime::now()),
+            &serde_json::json!({
+                "covers_through_seq": covers_through_seq,
+                "tail_caught": tail_caught,
+                "rows_swapped": total_swapped,
+                "completed": true,
+            }),
+        )?;
+
+        // ── Phase 2: Verifying ──
+        //
+        // Sanity check: no rows should remain under the old
+        // generation with NULL embedding_new (everything either got
+        // promoted or was never staged because it was tombstoned/
+        // archived).
+        let verifying_start_ts = systime_to_unix_secs(SystemTime::now());
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Verifying,
+            verifying_start_ts,
+            &serde_json::json!({}),
+        )?;
+        self.update_reembed_state_phase("Verifying")?;
+
+        let stragglers: i64 = {
+            let conn = self.read_conn();
+            conn.query_row(
+                "SELECT COUNT(*) FROM memories \
+                 WHERE consolidation_status = 'active' \
+                   AND embedding IS NOT NULL \
+                   AND COALESCE(embedding_generation, 0) < ?1",
+                params![next_generation as i64],
+                |r| r.get(0),
+            )
+            .unwrap_or(0)
+        };
+
+        if let Some(cb) = progress_cb {
+            cb(ReembedProgress {
+                phase: ReembedPhase::Verifying,
+                processed: total_swapped as u64,
+                total: Some(total_swapped as u64),
+                elapsed_ms: started_at.elapsed().unwrap_or_default().as_millis() as u64,
+                namespace: options.namespace.clone(),
+            });
+        }
+
+        // Stragglers > 0 doesn't necessarily mean failure today —
+        // Layer 5 (post-swap materializer) will drain queued writes
+        // that came in during cutover. But it DOES mean Verifying
+        // is incomplete; surface in the event payload so operators
+        // can decide.
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Verifying,
+            systime_to_unix_secs(SystemTime::now()),
+            &serde_json::json!({
+                "stragglers_under_old_gen": stragglers,
+                "completed": true,
+            }),
+        )?;
+
+        // Final Completed event + clear meta.reembed_state.
+        self.clear_reembed_state_meta()?;
+        self.write_reembed_event(
+            next_generation,
+            ReembedPhase::Completed,
+            systime_to_unix_secs(SystemTime::now()),
+            &serde_json::json!({
+                "encoded_count": processed,
+                "tail_caught": tail_caught,
+                "rows_swapped": total_swapped,
+                "covers_through_seq": covers_through_seq,
+            }),
+        )?;
+
+        let _ = on_phase_complete; // future use for per-phase callback dispatch
+
+        let duration = started_at.elapsed().unwrap_or_default();
+        Ok(ReembedReport {
+            generation: next_generation,
+            encoded_count: processed + tail_caught,
+            skipped_count: 0,
+            duration,
+            old_embedder: active_name,
+            old_embedder_digest: active_digest.unwrap_or_default(),
+            new_embedder: new_embedder_name_resolved,
+            new_embedder_digest,
+            old_dim: active_dim,
+            new_dim,
+            build_hwm: covers_through_seq,
+            per_namespace: HashMap::new(),
+        })
     }
 
     /// **Issue #41 — read-only status of an in-flight reembed.**
@@ -1134,6 +1532,46 @@ impl YantrikDB {
     pub(crate) fn clear_reembed_state_meta(&self) -> Result<()> {
         let conn = self.conn();
         conn.execute("DELETE FROM meta WHERE key = 'reembed_state'", [])?;
+        Ok(())
+    }
+
+    /// **Issue #41 brainstorm-4 Phase 2 helper.** Mutate the `phase`
+    /// field on the durable `meta.reembed_state` row to reflect
+    /// progression through Probing → Encoding → Rebuilding →
+    /// Swapping → Verifying. Other fields (generation, embedder
+    /// names, dims, namespace, write_policy) are preserved.
+    ///
+    /// Used by reembed_with_embedder at each phase transition so
+    /// crash recovery on open() can read the durable phase marker
+    /// and apply the right resume strategy (Layer 7).
+    pub(crate) fn update_reembed_state_phase(&self, new_phase: &str) -> Result<()> {
+        use rusqlite::params;
+        let conn = self.conn();
+        let raw: Option<String> = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'reembed_state'",
+                [],
+                |r| r.get::<_, String>(0),
+            )
+            .ok();
+        let Some(s) = raw else {
+            // No durable row to update — clear-state path took it.
+            return Ok(());
+        };
+        let mut state: serde_json::Value = serde_json::from_str(&s).unwrap_or_else(|_| {
+            serde_json::json!({})
+        });
+        if let Some(map) = state.as_object_mut() {
+            map.insert(
+                "phase".to_string(),
+                serde_json::Value::String(new_phase.to_string()),
+            );
+        }
+        let s_new = serde_json::to_string(&state)?;
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('reembed_state', ?1)",
+            params![s_new],
+        )?;
         Ok(())
     }
 }
@@ -1375,15 +1813,20 @@ mod tests {
     }
 
     #[test]
-    fn reembed_phase_2_part_a_runs_encoding_and_aborts_at_part_b_boundary() {
-        // **Checkpoint 16 boundary check.** A real (non-no-op,
-        // non-dry-run) reembed runs Encoding to completion (writing
-        // embedding_new + embedding_new_model on every active row)
-        // and aborts at the new "Phase 2 part A complete" boundary.
-        // Critical:
-        //   - meta.reembed_state MUST be cleared on the way out
-        //   - the Aborted event MUST be in the audit log
-        //   - the staged columns are populated (Encoding wrote them)
+    fn reembed_phase_2_full_run_promotes_to_new_generation() {
+        // **Checkpoint 17 — Phase 2 full happy path.** Plant rows,
+        // run reembed end-to-end (Probing → Encoding → Rebuilding
+        // → Swapping → Verifying → Completed). Critical contracts:
+        //   - ReembedReport.encoded_count matches planted row count
+        //   - SearchState.generation advanced by exactly 1
+        //   - SearchState.runtime_embedder is the new one
+        //   - meta.active_generation in SQL matches new gen
+        //   - Every active row's embedding_generation = new gen
+        //   - Staging columns (embedding_new + embedding_new_model)
+        //     are cleared post-swap
+        //   - meta.reembed_state is cleared
+        //   - Completed event is in audit log
+        //   - WriteRouter is back in Normal state
         let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
         db.set_embedder(Box::new(PhaseTestEmbedder {
             dim: 8,
@@ -1392,8 +1835,8 @@ mod tests {
         }))
         .unwrap();
 
-        // Plant two rows so Encoding has something to scan.
-        for i in 0..2 {
+        // Plant 3 rows so we exercise batching semantics.
+        for i in 0..3 {
             db.record(
                 &format!("row {i}"),
                 "episodic",
@@ -1417,76 +1860,89 @@ mod tests {
                 fp: "sha256:target".to_string(),
                 name: "target-model".to_string(),
             });
-        let err = db
+        let report = db
             .reembed_with_embedder("target-model", Some(synthetic), ReembedOptions::default())
-            .unwrap_err();
-        match err {
-            crate::error::YantrikDbError::Inference(msg) => {
-                assert!(
-                    msg.contains("Phase 2 part A complete") && msg.contains("part B"),
-                    "expected Phase 2 part A boundary message, got: {msg}"
-                );
-                // Locks the encoded_count surfaces in the error.
-                assert!(msg.contains("Encoding wrote 2 rows"), "msg: {msg}");
-            }
-            other => panic!("expected Inference at part-A boundary, got {other:?}"),
-        }
+            .unwrap();
 
-        // meta.reembed_state cleared (no in-flight signal lingering).
+        // ReembedReport contract.
+        assert_eq!(report.generation, 1, "new generation = 1 (was 0)");
+        assert_eq!(report.encoded_count, 3, "all 3 rows re-encoded");
+        assert_eq!(report.old_embedder, "original-model");
+        assert_eq!(report.new_embedder, "target-model");
+        assert_eq!(report.old_dim, 8);
+        assert_eq!(report.new_dim, 8);
+        assert!(report.build_hwm >= 3, "covers_through_seq covers all writes");
+
+        // In-memory SearchState.
+        let state = db.search_state.load_full();
+        assert_eq!(state.generation, 1, "in-memory generation advanced");
+        assert_eq!(
+            state.runtime_embedder_name.as_deref(),
+            Some("target-model")
+        );
+        assert!(
+            matches!(
+                &state.index_embedding,
+                EmbeddingProvenance::Known { digest, .. } if digest == "sha256:target"
+            ),
+            "provenance is Known under the new embedder digest"
+        );
+
+        // Durable state.
+        let conn = db.conn();
+        let active_gen: String = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'active_generation'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(active_gen, "1", "meta.active_generation bumped in SQL");
+
+        let row_gens: Vec<i64> = conn
+            .prepare(
+                "SELECT embedding_generation FROM memories WHERE consolidation_status = 'active'",
+            )
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(row_gens, vec![1, 1, 1], "every row stamped at new gen");
+
+        let staging_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories \
+                 WHERE embedding_new IS NOT NULL OR embedding_new_model IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(staging_count, 0, "staging columns must be cleared post-swap");
+
+        // No mid-reembed signal lingering.
+        drop(conn);
         assert!(
             db.reembed_status().is_none(),
-            "meta.reembed_state must be cleared on part-A-boundary abort"
+            "meta.reembed_state must be cleared on Completed"
         );
 
-        // Aborted event in audit log.
-        let aborted_count: i64 = db
-            .conn()
+        // Completed event in audit log.
+        let conn = db.conn();
+        let completed_count: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM reembed_events WHERE phase = 'Aborted'",
+                "SELECT COUNT(*) FROM reembed_events WHERE phase = 'Completed'",
                 [],
-                |row| row.get(0),
+                |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(aborted_count, 1, "Aborted event must be logged");
+        assert_eq!(completed_count, 1, "Completed event must be logged");
 
-        // Encoding event in audit log (separate event from Probing).
-        let encoding_count: i64 = db
-            .conn()
-            .query_row(
-                "SELECT COUNT(*) FROM reembed_events WHERE phase = 'Encoding'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
+        // WriteRouter back in Normal state.
         assert!(
-            encoding_count >= 1,
-            "Encoding event must be in audit log (got {encoding_count})"
+            db.write_router.try_enter_sync_writer().is_some(),
+            "WriteRouter must be Normal after reembed completion"
         );
-
-        // The 2 planted rows MUST have embedding_new + embedding_new_model
-        // populated (Encoding wrote them) AND embedding_generation
-        // unchanged (Swapping is what bumps that — pending).
-        let staged_count: i64 = db
-            .conn()
-            .query_row(
-                "SELECT COUNT(*) FROM memories WHERE embedding_new IS NOT NULL \
-                 AND embedding_new_model = 'target-model'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(staged_count, 2, "Encoding must have populated staging columns");
-
-        // embedding_generation unchanged at 0 (Phase 2 part B will bump).
-        let gen_zero_count: i64 = db
-            .conn()
-            .query_row(
-                "SELECT COUNT(*) FROM memories WHERE embedding_generation = 0",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(gen_zero_count, 2, "embedding_generation unchanged before swap");
     }
 
     #[test]

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -93,6 +93,18 @@ impl YantrikDB {
     }
 
     /// Append an operation to the oplog with HLC and optional embedding hash.
+    ///
+    /// **Issue #41 brainstorm-2 §1 / brainstorm-4 §6.** Stamps the
+    /// v27 `applied_generation` column with the active SearchState
+    /// generation. The post-swap materializer (Layer 5) uses this
+    /// column to discriminate ops already applied under generation G
+    /// (skip them — they're durably indexed) from queued-during-
+    /// reembed ops (`applied_generation IS NULL` — need re-encode
+    /// under the new embedder). Sync writers call this AFTER their
+    /// `vec_index.append` so the generation read here is the same
+    /// generation the index entry was written against (the
+    /// `SyncWriteGuard` held by the caller prevents reembed from
+    /// completing its swap while we read).
     pub fn log_op(
         &self,
         op_type: &str,
@@ -104,12 +116,13 @@ impl YantrikDB {
         let hlc_ts = self.tick_hlc();
         let hlc_bytes = hlc_ts.to_bytes().to_vec();
         let payload_str = serde_json::to_string(payload)?;
+        let applied_generation: i64 = self.search_state.load().generation as i64;
 
         let conn = self.conn.lock();
         conn.execute(
             "INSERT INTO oplog (op_id, op_type, timestamp, target_rid, payload, \
-             actor_id, hlc, embedding_hash, origin_actor, applied) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1)",
+             actor_id, hlc, embedding_hash, origin_actor, applied, applied_generation) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10)",
             params![
                 op_id,
                 op_type,
@@ -120,6 +133,7 @@ impl YantrikDB {
                 hlc_bytes,
                 emb_hash,
                 self.actor_id,
+                applied_generation,
             ],
         )?;
         Ok(op_id)

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -487,9 +487,7 @@ impl YantrikDB {
         })?;
 
         let rid = payload.get("rid").and_then(|v| v.as_str()).ok_or_else(|| {
-            crate::error::YantrikDbError::InvalidInput(
-                "Layer 5 record drain: missing rid".into(),
-            )
+            crate::error::YantrikDbError::InvalidInput("Layer 5 record drain: missing rid".into())
         })?;
         let memory_type = payload
             .get("type")
@@ -622,9 +620,7 @@ impl YantrikDB {
             .vec_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             + 1;
-        state
-            .vec_index
-            .append(rid.to_string(), new_emb, seq)?;
+        state.vec_index.append(rid.to_string(), new_emb, seq)?;
 
         // Bump visible_seq for RYW. Layer 6 will refine the
         // generation-aware semantics; for now bump under the

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -86,7 +86,7 @@ impl YantrikDB {
             pending_triggers,
             active_patterns,
             scoring_cache_entries: self.scoring_cache.read().len(),
-            vec_index_entries: self.vec_index.len(),
+            vec_index_entries: self.search_state.load().vec_index.len(),
             graph_index_entities: self.graph_index.read().entity_count(),
             graph_index_edges: self.graph_index.read().edge_count(),
         })

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -292,10 +292,15 @@ impl YantrikDB {
     /// update, graph_index update, scoring_cache insert) — and at that point
     /// foreground record() can stop doing it inline.
     pub fn apply_pending_ops_once(&self, limit: usize) -> Result<usize> {
-        let pending: Vec<(String, String, String)> = {
+        // **Issue #41 Layer 5.** Pull `embedding_model` alongside the
+        // standard tuple so we can dispatch queued-during-reembed
+        // writes through the re-encode path. embedding_model IS NOT
+        // NULL is the v27 signature for record_queued ops (sync
+        // record() leaves it NULL).
+        let pending: Vec<(String, String, String, Option<String>)> = {
             let conn = self.read_conn();
             let mut stmt = conn.prepare(
-                "SELECT op_id, op_type, payload FROM oplog \
+                "SELECT op_id, op_type, payload, embedding_model FROM oplog \
                  WHERE applied = 0 \
                  ORDER BY hlc, op_id \
                  LIMIT ?1",
@@ -305,13 +310,14 @@ impl YantrikDB {
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
                 ))
             })?;
             rows.collect::<std::result::Result<Vec<_>, _>>()?
         };
 
         let mut applied = 0usize;
-        for (op_id, op_type, payload) in &pending {
+        for (op_id, op_type, payload, embedding_model) in &pending {
             match op_type.as_str() {
                 // **Phase 4.3 — saga task 3.** This is the only op_type
                 // whose dispatch is *real* materialization work (the
@@ -366,6 +372,47 @@ impl YantrikDB {
                         }
                     }
                 }
+                // **Issue #41 Layer 5 — Queue-mode record drain.** The
+                // signature embedding_model IS NOT NULL identifies an
+                // op that was queued by `record_queued` during a
+                // reembed cutover. It carries TEXT (not an embedding).
+                // After the swap completes, the materializer drains
+                // these ops by re-encoding the text under the active
+                // generation's embedder + applying directly into the
+                // memories table + new vec_index at the new gen.
+                //
+                // While reembed is still in flight (meta.reembed_state
+                // set), defer: leave applied=0 so the next tick after
+                // completion picks it up. This matches brainstorm-2 §5
+                // "materializer fully PAUSED during reembed" (we pause
+                // only this op class — other op types still drain).
+                "record" if embedding_model.is_some() => {
+                    if self.reembed_status().is_some() {
+                        tracing::trace!(
+                            target: "yantrikdb::ingest::materialize",
+                            op_id = %op_id,
+                            "Layer 5: reembed in flight; deferring queued record"
+                        );
+                        // No mark_op_applied — leave for next tick.
+                        continue;
+                    }
+                    match self.apply_queued_reembed_record(payload) {
+                        Ok(()) => {
+                            if self.mark_op_applied(op_id)? {
+                                applied += 1;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "yantrikdb::ingest::materialize",
+                                op_id = %op_id,
+                                op_type = %op_type,
+                                error = %e,
+                                "Layer 5 queued reembed record apply failed; leaving pending for retry"
+                            );
+                        }
+                    }
+                }
                 "record" | "forget" | "relate" | "correct" | "consolidate" => {
                     tracing::trace!(
                         target: "yantrikdb::ingest::materialize",
@@ -414,6 +461,179 @@ impl YantrikDB {
     ///   "source":    "user"
     /// }
     /// ```
+    /// **Issue #41 Layer 5 — apply a queued-during-reembed record.**
+    ///
+    /// `record_queued` writes oplog rows with applied=0,
+    /// embedding_model=<old_name>, and a payload carrying the
+    /// memory's TEXT (not pre-encoded embedding). After reembed
+    /// completes, this materializer drain re-encodes the text under
+    /// the ACTIVE SearchState's embedder (the new one) and applies
+    /// the row to memories + vec_index at the new generation.
+    ///
+    /// Idempotent: INSERT OR IGNORE on rid + the
+    /// search_state-snapshot-once pattern guarantees a re-apply
+    /// (from worker race or restart) produces identical state.
+    ///
+    /// Caller (apply_pending_ops_once) has already verified the op
+    /// type is "record" AND embedding_model IS NOT NULL AND no
+    /// reembed is in flight.
+    fn apply_queued_reembed_record(&self, payload_json: &str) -> Result<()> {
+        use crate::serde_helpers::serialize_f32;
+
+        let payload: serde_json::Value = serde_json::from_str(payload_json).map_err(|e| {
+            crate::error::YantrikDbError::InvalidInput(format!(
+                "Layer 5 record drain: payload parse failed: {e}"
+            ))
+        })?;
+
+        let rid = payload.get("rid").and_then(|v| v.as_str()).ok_or_else(|| {
+            crate::error::YantrikDbError::InvalidInput(
+                "Layer 5 record drain: missing rid".into(),
+            )
+        })?;
+        let memory_type = payload
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("episodic");
+        let text = payload
+            .get("text")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                crate::error::YantrikDbError::InvalidInput(
+                    "Layer 5 record drain: missing text".into(),
+                )
+            })?;
+        let importance = payload
+            .get("importance")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.5);
+        let valence = payload
+            .get("valence")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let half_life = payload
+            .get("half_life")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(604800.0);
+        let metadata = payload
+            .get("metadata")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        let ts = payload
+            .get("created_at")
+            .and_then(|v| v.as_f64())
+            .unwrap_or_else(super::now);
+        let namespace = payload
+            .get("namespace")
+            .and_then(|v| v.as_str())
+            .unwrap_or("default");
+        let certainty = payload
+            .get("certainty")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.8);
+        let domain = payload
+            .get("domain")
+            .and_then(|v| v.as_str())
+            .unwrap_or("general");
+        let source = payload
+            .get("source")
+            .and_then(|v| v.as_str())
+            .unwrap_or("user");
+        let emotional_state = payload
+            .get("emotional_state")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        // Snapshot the active SearchState. The embedder + generation
+        // here are the post-swap ones (caller verified no reembed in
+        // flight; the in-memory state is durable).
+        let state = self.search_state.load_full();
+        let embedder = state
+            .embedder
+            .as_ref()
+            .ok_or_else(|| {
+                crate::error::YantrikDbError::Inference(
+                    "Layer 5 record drain: active SearchState has no embedder (cannot re-encode)"
+                        .into(),
+                )
+            })?
+            .clone();
+
+        let new_emb = embedder.embed(text).map_err(|e| {
+            crate::error::YantrikDbError::Inference(format!(
+                "Layer 5 record drain: embedder failed on rid {rid:?}: {e}"
+            ))
+        })?;
+        if new_emb.len() != state.dim() {
+            return Err(crate::error::YantrikDbError::Inference(format!(
+                "Layer 5 record drain: embedder returned len {} but SearchState dim {}",
+                new_emb.len(),
+                state.dim(),
+            )));
+        }
+        let emb_blob = serialize_f32(&new_emb);
+        let stored_emb = self.encrypt_embedding(&emb_blob)?;
+
+        // The payload's text/metadata are already in engine-stored
+        // form (record_queued passed them through). Don't double-
+        // encrypt; just hand back as stored.
+        let stored_text = text.to_string();
+        let stored_meta = serde_json::to_string(&metadata)?;
+
+        let embedding_generation: i64 = state.generation as i64;
+
+        // INSERT OR IGNORE on rid for idempotency. If a prior worker
+        // already inserted this row (race + retry), the OR IGNORE
+        // makes this a no-op AND mark_op_applied lets one worker win
+        // the count.
+        {
+            let conn = self.conn();
+            conn.execute(
+                "INSERT OR IGNORE INTO memories \
+                 (rid, type, text, embedding, created_at, updated_at, importance, \
+                  half_life, last_access, valence, metadata, namespace, \
+                  certainty, domain, source, emotional_state, embedding_generation) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+                params![
+                    rid,
+                    memory_type,
+                    stored_text,
+                    stored_emb,
+                    ts,
+                    ts,
+                    importance,
+                    half_life,
+                    ts,
+                    valence,
+                    stored_meta,
+                    namespace,
+                    certainty,
+                    domain,
+                    source,
+                    emotional_state,
+                    embedding_generation,
+                ],
+            )?;
+        }
+
+        // Append into the active vec_index. Idempotent: DeltaIndex
+        // de-dupes on rid+seq.
+        let seq = self
+            .vec_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        state
+            .vec_index
+            .append(rid.to_string(), new_emb, seq)?;
+
+        // Bump visible_seq for RYW. Layer 6 will refine the
+        // generation-aware semantics; for now bump under the
+        // current generation's covers_through_seq logic.
+        self.bump_visible_seq(namespace, seq);
+
+        Ok(())
+    }
+
     fn apply_materialize_record_post(&self, payload_json: &str) -> Result<()> {
         let payload: serde_json::Value = serde_json::from_str(payload_json).map_err(|e| {
             crate::error::YantrikDbError::InvalidInput(format!(

--- a/crates/yantrikdb-core/src/engine/storage.rs
+++ b/crates/yantrikdb-core/src/engine/storage.rs
@@ -43,7 +43,8 @@ impl YantrikDB {
             .vec_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             + 1;
-        self.vec_index.tombstone(rid, seq);
+        // **Issue #41 brainstorm-4 §1.** Snapshot through SearchState.
+        self.search_state.load().vec_index.tombstone(rid, seq);
 
         self.log_op(
             "archive",
@@ -95,7 +96,11 @@ impl YantrikDB {
             .vec_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             + 1;
-        self.vec_index
+        // **Issue #41 brainstorm-4 §1.** Hydration writes land on the
+        // active-generation DeltaIndex via SearchState.
+        self.search_state
+            .load()
+            .vec_index
             .append(rid.to_string(), embedding.clone(), seq)?;
 
         self.log_op(
@@ -138,7 +143,11 @@ impl YantrikDB {
             .vec_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             + 1;
-        self.vec_index
+        // **Issue #41 brainstorm-4 §1.** Replication-backfill writes
+        // route through the active SearchState's DeltaIndex.
+        self.search_state
+            .load()
+            .vec_index
             .append(rid.to_string(), embedding.to_vec(), seq)
             .map(|_| ())
     }

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -9700,11 +9700,16 @@ fn set_embedder_test_6_external_or_unknown_compat_attach_does_not_claim_provenan
 fn set_embedder_test_7_has_embedder_derives_from_search_state() {
     // Locks the brainstorm-3 invariant: has_embedder() reads from
     // search_state, NOT from the (now-retired) legacy embedder slot.
-    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    //
+    // Opens at dim=384 so the bundled-embedder auto-attach (which is
+    // dim=64 and silently fails on dim mismatch) cannot pollute the
+    // "fresh engine, no embedder" precondition. With dim=64 the test
+    // would race against the `bundled-embedder` cargo feature.
+    let mut db = YantrikDB::new(":memory:", 384).unwrap();
     assert!(!db.has_embedder(), "fresh engine: no embedder");
     use mode_test_embedders::FakeEmbedder;
     db.set_embedder(Box::new(FakeEmbedder {
-        dim: 64,
+        dim: 384,
         fp: Some("sha256:x".to_string()),
         name: None,
         sentinel: 0.42,

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -10786,6 +10786,245 @@ fn search_state_publish_is_atomic_under_concurrent_reads() {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────
+// Issue #41 Layer 7 — crash-recovery regression tests. Two branches
+// of the recovery decision on open():
+//   (1) active_generation < in_flight_generation
+//       → SQL swap did NOT commit; discard staging.
+//   (2) active_generation >= in_flight_generation
+//       → SQL swap DID commit; SearchState rebuilds at new gen.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn open_recovery_discards_staging_when_sql_swap_uncommitted() {
+    // **Layer 7 — branch 1.** Simulate a crash during Encoding/
+    // Rebuilding/Swapping BEFORE the SQL swap transaction
+    // committed. Plant: meta.reembed_state with gen=5,
+    // phase='Encoding', AND populated embedding_new columns,
+    // AND meta.active_generation still at '0' (the swap commit
+    // never happened).
+    //
+    // Expected on open():
+    //   - meta.reembed_state cleared
+    //   - embedding_new + embedding_new_model NULLed
+    //   - active_generation unchanged at 0
+    //   - SearchState.generation = 0
+    //   - reembed_events has an Aborted event for gen 5 with
+    //     recovery="discarded_staging"
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+
+    let planted_rid = "01900000-0000-7000-8000-00000000d017";
+    {
+        let db = YantrikDB::new(path, 8).unwrap();
+        db.record(
+            "pre-reembed row",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(0.5, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+        // Plant the staging columns + the in-flight reembed_state
+        // directly so we don't need the full reembed machinery.
+        let conn = db.conn();
+        conn.execute(
+            "UPDATE memories SET embedding_new = X'AABBCCDD', \
+             embedding_new_model = 'simulated-target' WHERE rowid = 1",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('reembed_state', ?1)",
+            params![
+                serde_json::json!({
+                    "generation": 5,
+                    "phase": "Encoding",
+                    "old_embedder": "old",
+                    "new_embedder_name": "simulated-target",
+                })
+                .to_string()
+            ],
+        )
+        .unwrap();
+        // active_generation still '0' (the swap commit never ran).
+        let _ = planted_rid;
+    }
+
+    // Re-open: Layer 7 recovery decides "discard staging".
+    let db = YantrikDB::new(path, 8).unwrap();
+    let conn = db.conn();
+
+    // meta.reembed_state cleared.
+    let still_in_flight: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'reembed_state'",
+            [],
+            |r| r.get(0),
+        )
+        .ok();
+    assert!(
+        still_in_flight.is_none(),
+        "Layer 7 must clear meta.reembed_state on uncommitted-swap recovery; got: {still_in_flight:?}"
+    );
+
+    // Staging NULLed.
+    let staged: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE embedding_new IS NOT NULL OR \
+             embedding_new_model IS NOT NULL",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(staged, 0, "staging columns must be NULL after discard recovery");
+
+    // active_generation unchanged.
+    let active: String = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'active_generation'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(active, "0");
+
+    // SearchState.generation = 0.
+    assert_eq!(db.search_state.load().generation, 0);
+
+    // Aborted recovery event present.
+    let aborted_recovery: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM reembed_events WHERE phase = 'Aborted' AND generation = 5 \
+             AND payload_json LIKE '%discarded_staging%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(aborted_recovery, 1, "Aborted recovery event must be logged");
+}
+
+#[test]
+fn open_recovery_durable_swap_resumes_at_new_generation() {
+    // **Layer 7 — branch 2.** Simulate a crash AFTER the SQL swap
+    // committed but before the in-memory ArcSwap store landed
+    // (the §10.4 case). Plant: meta.active_generation = '3'
+    // (durable swap done) AND meta.reembed_state with gen=3
+    // (the in-flight marker that never got cleared).
+    //
+    // Expected on open():
+    //   - meta.reembed_state cleared
+    //   - SearchState.generation = 3 (durable + rebuilt)
+    //   - active_generation = '3' (unchanged)
+    //   - Staging defensively cleared (should already be empty)
+    //   - reembed_events has a Completed event for gen 3 with
+    //     recovery="completed_durable"
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+
+    {
+        let db = YantrikDB::new(path, 8).unwrap();
+        let _ = db.record(
+            "pre-reembed row",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(0.5, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        );
+        // Simulate: swap COMMITTED (active_generation bumped to 3,
+        // row's embedding_generation stamped 3) but the matching
+        // in-memory publish never landed AND meta.reembed_state
+        // marker still says "we're in flight at gen 3".
+        let conn = db.conn();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('active_generation', '3')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE memories SET embedding_generation = 3 WHERE embedding IS NOT NULL",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('reembed_state', ?1)",
+            params![
+                serde_json::json!({
+                    "generation": 3,
+                    "phase": "Swapping",
+                    "old_embedder": "old",
+                    "new_embedder_name": "new",
+                })
+                .to_string()
+            ],
+        )
+        .unwrap();
+    }
+
+    let db = YantrikDB::new(path, 8).unwrap();
+    let conn = db.conn();
+
+    // meta.reembed_state cleared.
+    let still_in_flight: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'reembed_state'",
+            [],
+            |r| r.get(0),
+        )
+        .ok();
+    assert!(
+        still_in_flight.is_none(),
+        "Layer 7 must clear meta.reembed_state on durable-swap recovery"
+    );
+
+    // SearchState.generation = 3.
+    assert_eq!(
+        db.search_state.load().generation,
+        3,
+        "SearchState rebuilds at durable active generation"
+    );
+
+    // active_generation preserved.
+    let active: String = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'active_generation'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(active, "3");
+
+    // Completed recovery event present.
+    let completed_recovery: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM reembed_events WHERE phase = 'Completed' AND generation = 3 \
+             AND payload_json LIKE '%completed_durable%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        completed_recovery, 1,
+        "Completed recovery event must be logged"
+    );
+}
+
 #[test]
 fn open_with_uncommitted_staging_columns_stays_at_old_generation() {
     // **Brainstorm-4 §10.5 — crash before SQL promotion commit.**

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -9255,6 +9255,172 @@ fn schema_v26_migration_replay_is_idempotent() {
 // ============================================================================
 
 // ============================================================================
+// Issue #41 layer 3: record() routing through WriteRouter
+// ============================================================================
+
+#[test]
+fn record_in_normal_state_takes_sync_path() {
+    // Sanity: default router state is Normal, record() takes the sync
+    // path and the memory is immediately in `memories` + vec_index.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    assert_eq!(
+        db.write_router.state(),
+        crate::engine::write_router::RouterState::Normal
+    );
+    let rid = db
+        .record(
+            "sync path test",
+            "episodic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    // Row immediately visible in memories table (sync path completed).
+    let count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE rid = ?1",
+            params![rid],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1, "sync-path write must land in memories immediately");
+}
+
+#[test]
+fn record_in_queueing_state_routes_to_oplog_does_not_touch_memories() {
+    // Locks the brainstorm-2/3 invariant: when reembed cutover has
+    // flipped the router to Queueing, record() must NOT write to
+    // memories (would mix old+new dim under the rebuild snapshot)
+    // and must NOT call vec_index.append. The op goes to oplog
+    // applied=0 with embedding_model populated for the post-swap
+    // materializer to re-encode under the new embedder.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    // Flip router as reembed cutover would.
+    db.write_router.switch_to_queueing();
+    assert_eq!(
+        db.write_router.state(),
+        crate::engine::write_router::RouterState::Queueing
+    );
+    // Count memories + oplog before the queued record.
+    let mem_before: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
+        .unwrap();
+    let oplog_before: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE applied = 0 AND op_type = 'record'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let rid = db
+        .record(
+            "queued path test",
+            "episodic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    // memories table count must NOT have grown — the queued path
+    // skips the memories INSERT entirely.
+    let mem_after: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        mem_after, mem_before,
+        "queued path must NOT write to memories table during reembed cutover \
+         (brainstorm-2/3 invariant 1: queued-after-barrier writes are replayed \
+         by post-swap materializer, not committed to old generation)"
+    );
+
+    // oplog count must have grown by 1, with applied=0, op_type='record',
+    // target_rid=the new rid, and embedding_model set to whatever the
+    // active runtime embedder was (None here since no embedder is set).
+    let oplog_after: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE applied = 0 AND op_type = 'record' \
+             AND target_rid = ?1",
+            params![rid],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        oplog_after, oplog_before + 1,
+        "queued path must write the record op to oplog with applied=0"
+    );
+
+    // applied_generation must be NULL (this op will be applied to the
+    // new generation by the post-swap materializer; until then it's
+    // not applied to any generation).
+    let applied_gen: Option<i64> = db
+        .conn()
+        .query_row(
+            "SELECT applied_generation FROM oplog WHERE target_rid = ?1",
+            params![rid],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        applied_gen.is_none(),
+        "applied_generation must be NULL for queued ops; got Some({applied_gen:?})"
+    );
+
+    // Restore Normal for any subsequent test in the same DB.
+    db.write_router.switch_to_normal();
+}
+
+#[test]
+fn record_guard_drops_inflight_counter_panic_safe_via_raii() {
+    // Locks brainstorm-2 invariant 2 (no old application after barrier)
+    // by exercising the panic-safety of the SyncWriteGuard. Even if
+    // record() panics mid-write (simulated here by a record_batch
+    // wrapping that panics after the guard is acquired), the inflight
+    // counter must return to 0 via Drop.
+    let db = std::sync::Arc::new(YantrikDB::new(":memory:", 8).unwrap());
+    assert_eq!(db.write_router.inflight(), 0);
+
+    let db_panic = std::sync::Arc::clone(&db);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _guard = db_panic
+            .write_router
+            .try_enter_sync_writer()
+            .expect("Normal state must yield guard");
+        // inflight = 1 here
+        assert_eq!(db_panic.write_router.inflight(), 1);
+        panic!("simulated mid-write panic");
+    }));
+    assert!(result.is_err(), "panic must propagate up");
+    // Guard's Drop ran via panic unwind; inflight back to 0.
+    assert_eq!(
+        db.write_router.inflight(),
+        0,
+        "panic-safe inflight counter (RAII Drop) — required for reembed cutover correctness"
+    );
+}
+
+// ============================================================================
 // Issue #41 layer 2: set_embedder mode-aware regression tests
 // (brainstorm-3 round 2 §11, 8 cases). These lock the brainstorm-3
 // design decisions. Each test names the failure mode it prevents.

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -10697,3 +10697,381 @@ fn set_embedder_routes_through_try_publish_search_state() {
     );
     assert!(db.has_embedder(), "set_embedder must have published");
 }
+
+// ─────────────────────────────────────────────────────────────────
+// Issue #41 brainstorm-4 §10 — remaining regression tests.
+// Items #2, #3, #4, #7, #8 are locked in checkpoints 11-14. The
+// 5 tests below close items #1, #5, #6, plus a meta-test for the
+// boundary audit logic and a Queue-mode round-trip.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn search_state_publish_is_atomic_under_concurrent_reads() {
+    // **Brainstorm-4 §10.1 — no read-side dim split-brain.** Spawn
+    // many reader threads that capture `search_state.load_full()`
+    // and inspect *all* fields of the snapshot. Concurrently, the
+    // main thread publishes N alternating SearchStates. Each
+    // reader's snapshot must be consistent — every field comes
+    // from the same generation. Without SearchState as the single
+    // atomic publication unit (brainstorm-4 §1), readers could
+    // observe new provenance + old embedder + old vec_index. The
+    // ArcSwap guarantees the atomic flip; this test locks the
+    // invariant.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+
+    let db = Arc::new(YantrikDB::new(":memory:", 64).unwrap());
+    let initial = db.search_state.load_full();
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Reader threads — each captures one snapshot per iteration
+    // and asserts the (generation, provenance.dim, hnsw_m) tuple
+    // is one of the published combinations, never a mix.
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let db_c = Arc::clone(&db);
+        let stop_c = Arc::clone(&stop);
+        handles.push(thread::spawn(move || {
+            let mut observations: Vec<(u64, usize, u32)> = Vec::new();
+            while !stop_c.load(Ordering::Relaxed) {
+                let s = db_c.search_state.load_full();
+                observations.push((s.generation, s.dim(), s.hnsw_m));
+            }
+            observations
+        }));
+    }
+
+    // Publish 50 alternating SearchStates, each consistent within
+    // itself. Use try_publish_search_state so generation is
+    // monotonic-advanced (each call bumps by 1).
+    for n in 1..=50u64 {
+        let prev = db.search_state.load_full();
+        let next = crate::engine::reembed::SearchState {
+            index_embedding: prev.index_embedding.clone(),
+            embedder: prev.embedder.clone(),
+            runtime_embedder_name: prev.runtime_embedder_name.clone(),
+            runtime_embedder_digest: prev.runtime_embedder_digest.clone(),
+            generation: prev.generation + 1,
+            covers_through_seq: prev.covers_through_seq + n,
+            // hnsw_m alternates so we can detect a torn read
+            // (would manifest as gen even / hnsw_m odd or vice versa).
+            hnsw_m: if n % 2 == 0 { 16 } else { 32 },
+            hnsw_ef_construction: prev.hnsw_ef_construction,
+            hnsw_ef_search: prev.hnsw_ef_search,
+            vec_index: std::sync::Arc::clone(&prev.vec_index),
+        };
+        db.try_publish_search_state(next).unwrap();
+    }
+
+    stop.store(true, Ordering::Relaxed);
+
+    let baseline = (initial.generation, initial.dim(), initial.hnsw_m);
+    for handle in handles {
+        let observations = handle.join().unwrap();
+        for (gen, dim, hnsw_m) in &observations {
+            // Two valid forms per generation: even-gen → hnsw_m=16,
+            // odd-gen → hnsw_m=32. (Or the initial baseline.)
+            let consistent = (*gen, *dim, *hnsw_m) == baseline
+                || (*gen >= 1
+                    && *dim == initial.dim()
+                    && ((*gen % 2 == 0 && *hnsw_m == 16)
+                        || (*gen % 2 == 1 && *hnsw_m == 32)));
+            assert!(
+                consistent,
+                "torn SearchState observation: gen={gen} dim={dim} hnsw_m={hnsw_m} \
+                 (expected even-gen→16 or odd-gen→32, or baseline)"
+            );
+        }
+    }
+}
+
+#[test]
+fn open_with_uncommitted_staging_columns_stays_at_old_generation() {
+    // **Brainstorm-4 §10.5 — crash before SQL promotion commit.**
+    // Simulate a Phase-2 Encoding run that wrote to
+    // memories.embedding_new BUT crashed before the swap
+    // SAVEPOINT committed (meta.active_generation still records
+    // the old generation). open() must read the OLD generation
+    // and ignore the staged columns — promoting would mix old and
+    // new vector spaces.
+    //
+    // The staged rows themselves are not corrupted because
+    // embedding_new is in its own column; the active `embedding`
+    // column still carries old-generation bytes. A subsequent
+    // reembed call will overwrite embedding_new and run to
+    // completion.
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+
+    // Establish a baseline row + active_generation=0.
+    let planted_rid = {
+        let db = YantrikDB::new(path, 8).unwrap();
+        db.record(
+            "pre-reembed row",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(0.5, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap()
+    };
+
+    // Simulate a partial Phase-2 Encoding: write to embedding_new
+    // and embedding_new_model on the planted row, but do NOT
+    // bump meta.active_generation (the commit never happened).
+    {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute(
+            "UPDATE memories SET embedding_new = X'AABBCCDD', \
+             embedding_new_model = 'simulated-new-embedder' WHERE rid = ?1",
+            params![planted_rid],
+        )
+        .unwrap();
+    }
+
+    // Re-open. SearchState.generation must STILL be 0 (no
+    // promotion happened). The staged columns are present but
+    // not active.
+    let db = YantrikDB::new(path, 8).unwrap();
+    assert_eq!(
+        db.search_state.load().generation,
+        0,
+        "open() must not promote partial staging into the active generation"
+    );
+
+    let conn = db.conn();
+    let staged_present: bool = conn
+        .query_row(
+            "SELECT embedding_new IS NOT NULL FROM memories WHERE rid = ?1",
+            [&planted_rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        staged_present,
+        "staged column survives the open (Phase-2 resume logic decides what to do with it)"
+    );
+
+    // The active embedding column is unchanged — readers see the
+    // pre-reembed bytes (gen 0).
+    let active_present: bool = conn
+        .query_row(
+            "SELECT embedding IS NOT NULL FROM memories WHERE rid = ?1",
+            [&planted_rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(active_present, "pre-reembed active embedding bytes preserved");
+
+    // Row's embedding_generation is the pre-reembed value (0).
+    let row_gen: i64 = conn
+        .query_row(
+            "SELECT embedding_generation FROM memories WHERE rid = ?1",
+            [&planted_rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(row_gen, 0, "row's stamped generation unchanged by partial staging");
+}
+
+#[test]
+fn covers_through_seq_is_durably_carried_on_published_search_state() {
+    // **Brainstorm-4 §10.6 — covers_through_seq invariant.** Phase 2's
+    // cutover captures `vec_seq.load(Acquire)` at the barrier and
+    // stamps it into `SearchState.covers_through_seq` for the new
+    // generation. The post-swap materializer uses this to decide
+    // which oplog ops still need replay (those with seq >
+    // covers_through_seq). Locks the struct-level invariant that
+    // try_publish_search_state preserves the value verbatim.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let initial = db.search_state.load_full();
+    assert_eq!(initial.covers_through_seq, 0, "fresh engine: covers 0");
+
+    // Simulate a Phase-2 cutover that captured vec_seq high-water
+    // mark = 12345 and published a new generation with that
+    // coverage.
+    let next = crate::engine::reembed::SearchState {
+        index_embedding: initial.index_embedding.clone(),
+        embedder: initial.embedder.clone(),
+        runtime_embedder_name: initial.runtime_embedder_name.clone(),
+        runtime_embedder_digest: initial.runtime_embedder_digest.clone(),
+        generation: initial.generation + 1,
+        covers_through_seq: 12345,
+        hnsw_m: initial.hnsw_m,
+        hnsw_ef_construction: initial.hnsw_ef_construction,
+        hnsw_ef_search: initial.hnsw_ef_search,
+        vec_index: std::sync::Arc::clone(&initial.vec_index),
+    };
+    db.try_publish_search_state(next).unwrap();
+    assert_eq!(
+        db.search_state.load().covers_through_seq,
+        12345,
+        "published covers_through_seq must be readable from the active SearchState"
+    );
+
+    // covers_through_seq is independent of generation — verify by
+    // publishing again with a DIFFERENT covers_through_seq at the
+    // SAME generation increment shape (different runtime metadata
+    // but same gen advance pattern).
+    let bumped = crate::engine::reembed::SearchState {
+        index_embedding: initial.index_embedding.clone(),
+        embedder: initial.embedder.clone(),
+        runtime_embedder_name: initial.runtime_embedder_name.clone(),
+        runtime_embedder_digest: initial.runtime_embedder_digest.clone(),
+        generation: initial.generation + 2,
+        covers_through_seq: 98765,
+        hnsw_m: initial.hnsw_m,
+        hnsw_ef_construction: initial.hnsw_ef_construction,
+        hnsw_ef_search: initial.hnsw_ef_search,
+        vec_index: std::sync::Arc::clone(&initial.vec_index),
+    };
+    db.try_publish_search_state(bumped).unwrap();
+    assert_eq!(
+        db.search_state.load().covers_through_seq,
+        98765,
+        "covers_through_seq advances per swap"
+    );
+}
+
+#[test]
+fn record_text_round_trip_through_queue_path_under_reembed() {
+    // **Brainstorm-2 invariant 8 + brainstorm-4 §2 sibling test.**
+    // Full round-trip of the queued write path: record_text with
+    // the WriteRouter in Queueing state stores TEXT in oplog
+    // (applied=0) with embedding_model set to the active runtime
+    // embedder. The pre-computed embedding is intentionally
+    // discarded — when Phase-2 / Layer-5 materializer drains the
+    // op, it re-encodes the text under the NEW embedder.
+    //
+    // This test locks the integration shape end-to-end:
+    //   - record_text → embed → router check → queue path
+    //   - oplog row carries applied=0, applied_generation=NULL,
+    //     embedding_model=<current name>, payload text intact
+    //   - memories table is NOT written (post-swap materializer
+    //     is responsible for that under the new generation)
+    use mode_test_embedders::FakeEmbedder;
+
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:queued-test".to_string()),
+        name: Some("queued-test-embedder".to_string()),
+        sentinel: 0.7,
+    }))
+    .unwrap();
+
+    // Reembed flips router to Queueing during the cutover preamble.
+    db.write_router.switch_to_queueing();
+
+    let rid = db
+        .record_text(
+            "queued-round-trip-text",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({"k": "v"}),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    let conn = db.conn();
+    // memories table NOT written.
+    let mem_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE rid = ?1",
+            [&rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(mem_count, 0, "queued write does not touch memories table");
+
+    // Oplog has the queued record op.
+    let (op_type, applied, applied_generation, embedding_model, payload): (
+        String,
+        i64,
+        Option<i64>,
+        Option<String>,
+        String,
+    ) = conn
+        .query_row(
+            "SELECT op_type, applied, applied_generation, embedding_model, payload \
+             FROM oplog WHERE target_rid = ?1 AND op_type = 'record'",
+            [&rid],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )
+        .unwrap();
+    assert_eq!(op_type, "record");
+    assert_eq!(applied, 0, "queued op is applied=0");
+    assert_eq!(
+        applied_generation, None,
+        "queued op has applied_generation=NULL (post-swap materializer fills under new gen)"
+    );
+    assert_eq!(
+        embedding_model.as_deref(),
+        Some("queued-test-embedder"),
+        "queued op carries the active runtime embedder name"
+    );
+    let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+    assert_eq!(
+        v["text"].as_str(),
+        Some("queued-round-trip-text"),
+        "payload preserves the original text for re-encode"
+    );
+}
+
+#[test]
+fn boundary_audit_pattern_detects_synthetic_violation() {
+    // **Meta-test for the brainstorm-4 §5 boundary audit logic.**
+    // The audit in `engine::durable_embeddings::tests::
+    // recall_rs_has_no_raw_sql_embedding_reads` greps recall.rs at
+    // test-build time. If the pattern logic is broken, the audit
+    // could silently pass even on a violation. This test
+    // exercises the SAME pattern logic against a synthetic
+    // string that DOES contain a forbidden pattern, asserting
+    // the detector catches it.
+    let synthetic_violation =
+        "    let sql = \"SELECT rid, embedding FROM memories WHERE rid = ?1\";";
+    let lower = synthetic_violation.to_ascii_lowercase();
+    let patterns = [
+        "select embedding ",
+        "select embedding,",
+        "select embedding\"",
+        "select embedding\\",
+        ", embedding ",
+        ", embedding,",
+        ", embedding\"",
+        ", embedding\\",
+        ", embedding\n",
+    ];
+    let any_match = patterns.iter().any(|p| lower.contains(p));
+    assert!(
+        any_match,
+        "boundary audit pattern must catch the synthetic raw-SQL-embedding pattern; \
+         if this asserts, the audit in durable_embeddings.rs is letting violations slip"
+    );
+
+    // And the inverse: an allowlist-safe pattern (suffixed name)
+    // does NOT match.
+    let allowlist_safe = "    let sql = \"SELECT rid, embedding_hash FROM memories\";";
+    let lower_safe = allowlist_safe.to_ascii_lowercase();
+    let safe_match = patterns.iter().any(|p| lower_safe.contains(p));
+    assert!(
+        !safe_match,
+        "audit must NOT flag the allowlist-safe `embedding_hash` pattern; \
+         the audit over-rejects which would prevent legitimate refactors"
+    );
+}

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -10295,3 +10295,161 @@ fn schema_v27_migration_replay_is_idempotent() {
     )
     .unwrap();
 }
+
+// ─────────────────────────────────────────────────────────────────
+// Issue #41 brainstorm-4 §3 — monotonic-generation CAS regression
+// tests. Locks try_publish_search_state's two guarantees: stale
+// publishes are rejected, equal-generation publishes are allowed
+// (set_embedder runtime-Arc-swap case).
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn try_publish_search_state_rejects_stale_generation() {
+    // Construct a SearchState at generation N, advance the engine
+    // to generation N+2 via direct store, then attempt to publish
+    // the N-generation state. The helper must reject with
+    // SearchStatePublishStaleGeneration — without this, a stale
+    // compactor/reembed step could ABA-rollback the active
+    // generation.
+    let db = YantrikDB::new(":memory:", 64).unwrap();
+    let initial = db.search_state.load_full();
+    assert_eq!(initial.generation, 0, "fresh engine starts at gen 0");
+
+    // Build a "stale" SearchState replica of gen=0.
+    let stale_proposal = crate::engine::reembed::SearchState {
+        index_embedding: initial.index_embedding.clone(),
+        embedder: initial.embedder.clone(),
+        runtime_embedder_name: initial.runtime_embedder_name.clone(),
+        runtime_embedder_digest: initial.runtime_embedder_digest.clone(),
+        generation: 0,
+        covers_through_seq: 0,
+        hnsw_m: initial.hnsw_m,
+        hnsw_ef_construction: initial.hnsw_ef_construction,
+        hnsw_ef_search: initial.hnsw_ef_search,
+        vec_index: std::sync::Arc::clone(&initial.vec_index),
+    };
+
+    // Manually advance the engine to gen=2 (simulates two
+    // back-to-back reembed Phase-2 swaps).
+    let advanced = crate::engine::reembed::SearchState {
+        index_embedding: initial.index_embedding.clone(),
+        embedder: initial.embedder.clone(),
+        runtime_embedder_name: initial.runtime_embedder_name.clone(),
+        runtime_embedder_digest: initial.runtime_embedder_digest.clone(),
+        generation: 2,
+        covers_through_seq: 0,
+        hnsw_m: initial.hnsw_m,
+        hnsw_ef_construction: initial.hnsw_ef_construction,
+        hnsw_ef_search: initial.hnsw_ef_search,
+        vec_index: std::sync::Arc::clone(&initial.vec_index),
+    };
+    db.search_state.store(std::sync::Arc::new(advanced));
+
+    // Try to publish the stale gen=0 state. Helper must reject.
+    let err = db
+        .try_publish_search_state(stale_proposal)
+        .expect_err("stale-generation publish must be rejected");
+    match err {
+        crate::error::YantrikDbError::SearchStatePublishStaleGeneration {
+            current_generation,
+            attempted_generation,
+        } => {
+            assert_eq!(current_generation, 2);
+            assert_eq!(attempted_generation, 0);
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+
+    // The engine state must still be at gen=2 — the rejected
+    // publish did NOT mutate the ArcSwap.
+    assert_eq!(
+        db.search_state.load().generation,
+        2,
+        "rejected publish must leave search_state untouched"
+    );
+}
+
+#[test]
+fn try_publish_search_state_accepts_equal_generation_publish() {
+    // set_embedder publishes with `new.generation == current.generation`
+    // (runtime-Arc swap, no vector-space change). The CAS helper must
+    // accept this — strict less-than is the only rejection condition.
+    let db = YantrikDB::new(":memory:", 64).unwrap();
+    let initial = db.search_state.load_full();
+    let same_gen = crate::engine::reembed::SearchState {
+        index_embedding: initial.index_embedding.clone(),
+        embedder: initial.embedder.clone(),
+        // Differ in some runtime-only field so the test verifies the
+        // publish actually landed (vs being a silent no-op).
+        runtime_embedder_name: Some("rotated-name".to_string()),
+        runtime_embedder_digest: initial.runtime_embedder_digest.clone(),
+        generation: initial.generation,
+        covers_through_seq: initial.covers_through_seq,
+        hnsw_m: initial.hnsw_m,
+        hnsw_ef_construction: initial.hnsw_ef_construction,
+        hnsw_ef_search: initial.hnsw_ef_search,
+        vec_index: std::sync::Arc::clone(&initial.vec_index),
+    };
+    db.try_publish_search_state(same_gen)
+        .expect("equal-generation publish must be accepted");
+    assert_eq!(
+        db.search_state.load().runtime_embedder_name.as_deref(),
+        Some("rotated-name"),
+        "the equal-generation publish must have landed"
+    );
+}
+
+#[test]
+fn try_publish_search_state_accepts_strictly_advancing_generation() {
+    // Reembed Phase-2 publishes new.generation = current.generation + 1.
+    // Lock the success path so the brainstorm-4 §3 CAS doesn't
+    // accidentally over-reject and break the reembed swap.
+    let db = YantrikDB::new(":memory:", 64).unwrap();
+    let initial = db.search_state.load_full();
+    let advanced = crate::engine::reembed::SearchState {
+        index_embedding: initial.index_embedding.clone(),
+        embedder: initial.embedder.clone(),
+        runtime_embedder_name: initial.runtime_embedder_name.clone(),
+        runtime_embedder_digest: initial.runtime_embedder_digest.clone(),
+        generation: initial.generation + 1,
+        covers_through_seq: initial.covers_through_seq,
+        hnsw_m: initial.hnsw_m,
+        hnsw_ef_construction: initial.hnsw_ef_construction,
+        hnsw_ef_search: initial.hnsw_ef_search,
+        vec_index: std::sync::Arc::clone(&initial.vec_index),
+    };
+    db.try_publish_search_state(advanced)
+        .expect("strictly-advancing-generation publish must be accepted");
+    assert_eq!(
+        db.search_state.load().generation,
+        initial.generation + 1,
+        "the advanced publish must have landed"
+    );
+}
+
+#[test]
+fn set_embedder_routes_through_try_publish_search_state() {
+    // Coverage check: confirm set_embedder calls go through the
+    // CAS helper. Done indirectly by verifying that after
+    // set_embedder, the search_state generation is preserved (the
+    // helper would reject any rogue decrement). This locks the
+    // call-graph routing — if a future refactor reintroduces a
+    // direct `self.search_state.store(...)` from set_embedder, the
+    // brainstorm-4 §3 invariant is no longer load-bearing.
+    use mode_test_embedders::FakeEmbedder;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    let gen_before = db.search_state.load().generation;
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:check".to_string()),
+        name: Some("check".to_string()),
+        sentinel: 0.1,
+    }))
+    .unwrap();
+    let gen_after = db.search_state.load().generation;
+    assert_eq!(
+        gen_before, gen_after,
+        "set_embedder must preserve generation (only Phase-2 reembed advances it)"
+    );
+    assert!(db.has_embedder(), "set_embedder must have published");
+}

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -9461,6 +9461,7 @@ mod mode_test_embedders {
             self.name.clone()
         }
     }
+
 }
 
 #[test]
@@ -9718,6 +9719,340 @@ fn set_embedder_test_7_has_embedder_derives_from_search_state() {
     assert!(db.has_embedder());
     let v = db.embed("anything").unwrap();
     assert!((v[0] - 0.42).abs() < 1e-6);
+}
+
+#[test]
+fn record_text_revalidates_generation_and_retries_after_swap() {
+    // **Issue #41 brainstorm-4 §2 regression test.** Locks the
+    // writer-revalidation invariant: when `record_text`'s engine-side
+    // embed step races a SearchState swap, the writer detects the
+    // generation mismatch under the WriteRouter guard and retries.
+    // Without the loop, the embedding would land in the wrong vector
+    // space (durable silent corruption when dims match).
+    //
+    // Test choreography:
+    //   1. Set up db with BlockingEmbedder. SearchState publishes
+    //      generation G=0 with digest "sha256:initial".
+    //   2. Spawn record_text on a worker thread. It enters embed(),
+    //      signals "started_tx", and blocks on release_rx.
+    //   3. Test thread receives "started" signal. With the worker
+    //      blocked in the embed, the test manually constructs a NEW
+    //      SearchState (generation G=1, digest "sha256:rotated") and
+    //      stores it via `db.search_state.store(...)` — simulating a
+    //      reembed Phase-2 swap completing.
+    //   4. Test thread releases the embedder. record_text returns
+    //      from embed, acquires the sync guard, revalidates
+    //      generation, sees mismatch (0 != 1), drops guard, loops.
+    //   5. Second loop iteration loads the NEW SearchState, embeds
+    //      (now returns immediately — call_count > 0 takes the
+    //      no-block branch), acquires guard, revalidates, MATCH
+    //      (state still G=1), commits.
+    //   6. Assert call_count >= 2 (retry happened) and the recorded
+    //      memory exists in SQL.
+    // Test embedder wraps an Arc<AtomicUsize> so the test thread can
+    // observe call_count after the worker finishes. (The
+    // mode_test_embedders::BlockingEmbedder uses an in-struct
+    // AtomicUsize, which is inaccessible once boxed into Arc<dyn
+    // Embedder> in set_embedder.)
+    use std::sync::mpsc::channel;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    let (started_tx, started_rx) = channel::<()>();
+    let (release_tx, release_rx) = channel::<()>();
+    let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    struct SharedBlocking {
+        dim: usize,
+        fp: Option<String>,
+        name: Option<String>,
+        sentinel: f32,
+        started_tx: Mutex<Option<std::sync::mpsc::Sender<()>>>,
+        release_rx: Mutex<Option<std::sync::mpsc::Receiver<()>>>,
+        call_count: Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl crate::types::Embedder for SharedBlocking {
+        fn embed(
+            &self,
+            _text: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>>
+        {
+            let n = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n == 0 {
+                if let Some(tx) = self.started_tx.lock().unwrap().take() {
+                    let _ = tx.send(());
+                }
+                if let Some(rx) = self.release_rx.lock().unwrap().take() {
+                    let _ = rx.recv();
+                }
+            }
+            let mut v = vec![0.0_f32; self.dim];
+            if !v.is_empty() {
+                v[0] = self.sentinel;
+            }
+            Ok(v)
+        }
+        fn dim(&self) -> usize {
+            self.dim
+        }
+        fn fingerprint(&self) -> Option<String> {
+            self.fp.clone()
+        }
+        fn name(&self) -> Option<String> {
+            self.name.clone()
+        }
+    }
+
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    db.set_embedder(Box::new(SharedBlocking {
+        dim: 64,
+        fp: Some("sha256:initial".to_string()),
+        name: Some("blocking-initial".to_string()),
+        sentinel: 0.42,
+        started_tx: Mutex::new(Some(started_tx)),
+        release_rx: Mutex::new(Some(release_rx)),
+        call_count: Arc::clone(&call_count),
+    }))
+    .unwrap();
+
+    // Snapshot the initial state's generation; capture it for the
+    // post-test assertion below.
+    let gen_before = db.search_state.load().generation;
+    let arc_db = Arc::new(db);
+
+    // Spawn the worker: record_text() runs the revalidation loop.
+    let worker_db = Arc::clone(&arc_db);
+    let worker = std::thread::spawn(move || {
+        worker_db
+            .record_text(
+                "hello",
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap()
+    });
+
+    // Wait for the worker to reach the embed step.
+    started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("embed should have started within 5s");
+
+    // Worker is now blocked in embed(). Simulate a reembed Phase-2
+    // swap: construct a new SearchState with generation+1 and a
+    // different digest, leaving the same vec_index (dim unchanged so
+    // we don't trigger downstream dim checks). The new SearchState
+    // is what reembed Phase-2 would publish; the writer's
+    // revalidation loop must detect the change and re-embed.
+    let old_state = arc_db.search_state.load_full();
+    let new_state = crate::engine::reembed::SearchState {
+        index_embedding: crate::engine::reembed::EmbeddingProvenance::Known {
+            name: Some("blocking-rotated".to_string()),
+            digest: "sha256:rotated".to_string(),
+            dim: 64,
+        },
+        embedder: old_state.embedder.clone(),
+        runtime_embedder_name: Some("blocking-rotated".to_string()),
+        runtime_embedder_digest: Some("sha256:rotated".to_string()),
+        generation: old_state.generation + 1,
+        covers_through_seq: old_state.covers_through_seq,
+        hnsw_m: old_state.hnsw_m,
+        hnsw_ef_construction: old_state.hnsw_ef_construction,
+        hnsw_ef_search: old_state.hnsw_ef_search,
+        vec_index: Arc::clone(&old_state.vec_index),
+    };
+    arc_db.search_state.store(Arc::new(new_state));
+
+    // Release the blocked embed so the worker proceeds: acquire
+    // guard, revalidate, see mismatch, retry. The retry iteration
+    // doesn't block (call_count > 0).
+    release_tx.send(()).unwrap();
+
+    let rid = worker.join().expect("record_text must complete");
+
+    // Locks the revalidation contract:
+    //   1. Embed was called at least twice (first under old state,
+    //      retry under new state).
+    //   2. The recorded memory exists.
+    //   3. The active generation advanced (sanity check).
+    let n_calls = call_count.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        n_calls >= 2,
+        "record_text must re-embed after SearchState swap; got {n_calls} calls"
+    );
+    assert!(!rid.is_empty(), "record_text returns a valid rid");
+    let gen_after = arc_db.search_state.load().generation;
+    assert!(
+        gen_after > gen_before,
+        "test must observe a generation advance: before={gen_before} after={gen_after}"
+    );
+    // Verify the row is durably in SQL.
+    let conn = arc_db.conn();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM memories WHERE rid = ?1", [&rid], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(count, 1, "the retried record_text must be durably stored");
+}
+
+#[test]
+fn record_text_routes_to_queued_when_router_is_queueing() {
+    // **Issue #41 brainstorm-4 §2 sibling case.** When reembed has
+    // flipped the WriteRouter to Queueing BEFORE record_text reaches
+    // the acquire step, the writer must route to the queued path
+    // (which stores text and lets the post-swap materializer
+    // re-encode), not retry-loop forever. Locks the "Queueing →
+    // queued path" branch of the revalidation loop.
+    use mode_test_embedders::FakeEmbedder;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:initial".to_string()),
+        name: Some("initial".to_string()),
+        sentinel: 0.5,
+    }))
+    .unwrap();
+
+    // Flip the router to Queueing — simulates reembed's
+    // switch_to_queueing() during the cutover preamble.
+    db.write_router.switch_to_queueing();
+
+    // record_text must NOT spin in its revalidation loop — the
+    // Queueing branch returns via record_queued.
+    let rid = db
+        .record_text(
+            "hello-queued",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({}),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    assert!(!rid.is_empty());
+
+    // The queued path does NOT write to `memories` (brainstorm-3
+    // invariant 7); it writes an applied=0 op to `oplog` with
+    // `embedding_model = current_runtime_embedder_name`. Verify both
+    // halves of that contract.
+    let conn = db.conn();
+    let memories_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM memories WHERE rid = ?1", [&rid], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        memories_count, 0,
+        "queued path must NOT write to memories table"
+    );
+    let oplog_row: (i64, Option<String>) = conn
+        .query_row(
+            "SELECT applied, embedding_model FROM oplog WHERE target_rid = ?1 AND op_type = 'record'",
+            [&rid],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(oplog_row.0, 0, "queued op must be applied=0");
+    assert_eq!(
+        oplog_row.1.as_deref(),
+        Some("initial"),
+        "queued op carries the current runtime embedder name for post-swap re-encode"
+    );
+}
+
+#[test]
+fn log_op_stamps_applied_generation_from_active_search_state() {
+    // **Issue #41 brainstorm-2 §1 / brainstorm-4 §6 regression test.**
+    // Sync-write paths must stamp `oplog.applied_generation` with the
+    // active SearchState generation. Without this, the post-swap
+    // materializer (Layer 5) cannot discriminate "already applied
+    // under old gen — skip" from "queued during reembed — need
+    // re-encode" (both would show applied=0 NULL or applied=1 NULL
+    // and look identical).
+    let db = YantrikDB::new(":memory:", 64).unwrap();
+    let initial_generation: i64 =
+        db.search_state.load().generation as i64;
+
+    // log_op a synthetic event and assert the column is populated.
+    let op_id = db
+        .log_op(
+            "test_event",
+            None,
+            &serde_json::json!({"x": 1}),
+            None,
+        )
+        .unwrap();
+    // Scope the conn guard tightly — log_op needs the conn lock too,
+    // so don't hold it across the next log_op call (deadlock).
+    let applied_generation: Option<i64> = {
+        let conn = db.conn();
+        conn.query_row(
+            "SELECT applied_generation FROM oplog WHERE op_id = ?1",
+            [&op_id],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        applied_generation,
+        Some(initial_generation),
+        "log_op must stamp applied_generation with the current SearchState generation"
+    );
+
+    // Bump the generation manually (simulates a reembed swap) and
+    // verify a subsequent log_op picks up the new value.
+    let old_state = db.search_state.load_full();
+    let bumped = crate::engine::reembed::SearchState {
+        index_embedding: old_state.index_embedding.clone(),
+        embedder: old_state.embedder.clone(),
+        runtime_embedder_name: old_state.runtime_embedder_name.clone(),
+        runtime_embedder_digest: old_state.runtime_embedder_digest.clone(),
+        generation: old_state.generation + 1,
+        covers_through_seq: old_state.covers_through_seq,
+        hnsw_m: old_state.hnsw_m,
+        hnsw_ef_construction: old_state.hnsw_ef_construction,
+        hnsw_ef_search: old_state.hnsw_ef_search,
+        vec_index: std::sync::Arc::clone(&old_state.vec_index),
+    };
+    db.search_state.store(std::sync::Arc::new(bumped));
+
+    let op_id2 = db
+        .log_op(
+            "test_event_after_bump",
+            None,
+            &serde_json::json!({"x": 2}),
+            None,
+        )
+        .unwrap();
+    let applied_generation2: Option<i64> = {
+        let conn = db.conn();
+        conn.query_row(
+            "SELECT applied_generation FROM oplog WHERE op_id = ?1",
+            [&op_id2],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        applied_generation2,
+        Some(initial_generation + 1),
+        "log_op picks up the new generation after search_state.store"
+    );
 }
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -10427,6 +10427,250 @@ fn try_publish_search_state_accepts_strictly_advancing_generation() {
     );
 }
 
+// ─────────────────────────────────────────────────────────────────
+// Issue #41 brainstorm-4 §6 — v28 durable-linearization regression
+// tests. Locks (a) fresh install + migration both produce the v28
+// surfaces, (b) record/record_batch/record_with_rid stamp the new
+// column with state.generation, (c) open() reads the durable
+// meta.active_generation back into SearchState.
+// ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn schema_v28_fresh_install_has_embedding_generation_and_active_generation() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let conn = db.conn();
+
+    let cols = table_columns(&conn, "memories");
+    assert!(
+        cols.iter().any(|c| c == "embedding_generation"),
+        "v28: fresh install must add memories.embedding_generation column, got: {cols:?}"
+    );
+
+    assert!(
+        index_exists(&conn, "idx_memories_embedding_generation"),
+        "v28: fresh install must create idx_memories_embedding_generation"
+    );
+
+    let active_gen: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'active_generation'",
+            [],
+            |r| r.get(0),
+        )
+        .ok();
+    assert_eq!(
+        active_gen.as_deref(),
+        Some("0"),
+        "v28: fresh install must seed meta.active_generation = '0'"
+    );
+
+    // Schema version stamp is at v28.
+    let schema_version: String = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'schema_version'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(schema_version, "28", "fresh install stamps SCHEMA_VERSION = 28");
+}
+
+#[test]
+fn schema_v28_migration_from_v27_is_additive_and_idempotent() {
+    // Plant a row under v28 schema, then rewind meta.schema_version to 27
+    // and re-open to trigger MIGRATE_V27_TO_V28. Verify:
+    //   - existing row untouched (additive migration)
+    //   - embedding_generation column still present (won't error on duplicate)
+    //   - meta.active_generation still '0' (INSERT OR IGNORE preserves)
+    //   - re-open succeeds (the run_migration_idempotent runner swallows
+    //     "duplicate column name" on the ALTER TABLE ADD COLUMN)
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+
+    let planted_rid = "01900000-0000-7000-8000-00000000c028";
+    {
+        let db = YantrikDB::new(path, 8).unwrap();
+        let conn = db.conn();
+        conn.execute(
+            "INSERT INTO memories (rid, type, text, embedding, created_at, updated_at, last_access, source, embedding_generation) \
+             VALUES (?1, 'episodic', 'planted under v28 schema', X'01020304', 0.0, 0.0, 0.0, 'user', 42)",
+            params![planted_rid],
+        )
+        .unwrap();
+    }
+
+    // Rewind meta to 27 to force the v27 -> v28 migration replay path.
+    {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '27')",
+            [],
+        )
+        .unwrap();
+    }
+
+    // Re-open — runner must heal idempotently.
+    let db = YantrikDB::new(path, 8)
+        .expect("v28 migration runner must heal rewound-meta deployments");
+    let conn = db.conn();
+
+    // Planted row still there with original generation stamp.
+    let (text, gen): (String, i64) = conn
+        .query_row(
+            "SELECT text, embedding_generation FROM memories WHERE rid = ?1",
+            [&planted_rid],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(text, "planted under v28 schema");
+    assert_eq!(gen, 42, "migration must not mutate existing row data");
+
+    // Schema version stamped back to v28.
+    let schema_version: String = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'schema_version'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(schema_version, "28");
+
+    // meta.active_generation preserved (INSERT OR IGNORE didn't clobber).
+    let active_gen: String = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'active_generation'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(active_gen, "0");
+}
+
+#[test]
+fn record_stamps_embedding_generation_from_search_state() {
+    // **Brainstorm-4 §6 row-level invariant.** Every sync-path insert
+    // stamps memories.embedding_generation = state.generation. Phase-2
+    // swap (when it lands) advances state.generation, and the post-swap
+    // materializer's scan uses this column to find rows that need
+    // re-encode. If the stamp is wrong, the scan returns the wrong
+    // population.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rid = db
+        .record(
+            "stamped",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    let conn = db.conn();
+    let stamped: i64 = conn
+        .query_row(
+            "SELECT embedding_generation FROM memories WHERE rid = ?1",
+            [&rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(stamped, 0, "fresh engine: state.generation = 0, stamp = 0");
+
+    drop(conn);
+
+    // Manually advance the engine SearchState to gen=7 (simulates a
+    // future Phase-2 swap publishing). Subsequent record must stamp 7.
+    let old_state = db.search_state.load_full();
+    let advanced = crate::engine::reembed::SearchState {
+        index_embedding: old_state.index_embedding.clone(),
+        embedder: old_state.embedder.clone(),
+        runtime_embedder_name: old_state.runtime_embedder_name.clone(),
+        runtime_embedder_digest: old_state.runtime_embedder_digest.clone(),
+        generation: 7,
+        covers_through_seq: old_state.covers_through_seq,
+        hnsw_m: old_state.hnsw_m,
+        hnsw_ef_construction: old_state.hnsw_ef_construction,
+        hnsw_ef_search: old_state.hnsw_ef_search,
+        vec_index: std::sync::Arc::clone(&old_state.vec_index),
+    };
+    db.try_publish_search_state(advanced).unwrap();
+
+    let rid2 = db
+        .record(
+            "stamped at gen 7",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(2.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    let conn = db.conn();
+    let stamped2: i64 = conn
+        .query_row(
+            "SELECT embedding_generation FROM memories WHERE rid = ?1",
+            [&rid2],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stamped2, 7,
+        "record after generation advance must stamp the new generation"
+    );
+}
+
+#[test]
+fn open_reads_durable_active_generation_into_search_state() {
+    // **Brainstorm-4 §6 durable linearization point.** open() must
+    // read meta.active_generation and initialize SearchState.generation
+    // from it. Without this, crash recovery between Phase-2's SQL
+    // swap-commit and the ArcSwap store would leave the in-memory
+    // SearchState at the OLD generation while SQL claims the NEW
+    // generation — split-brain on restart.
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+
+    // First open at fresh install — initial gen = 0.
+    {
+        let db = YantrikDB::new(path, 8).unwrap();
+        assert_eq!(db.search_state.load().generation, 0);
+    }
+
+    // Simulate Phase-2's SQL commit (without the matching in-memory
+    // store) by manually updating meta.active_generation = 3 in SQL.
+    {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('active_generation', '3')",
+            [],
+        )
+        .unwrap();
+    }
+
+    // Re-open. SearchState.generation must come back as 3.
+    let db = YantrikDB::new(path, 8).unwrap();
+    assert_eq!(
+        db.search_state.load().generation,
+        3,
+        "open() must read meta.active_generation into SearchState.generation"
+    );
+}
+
 #[test]
 fn set_embedder_routes_through_try_publish_search_state() {
     // Coverage check: confirm set_embedder calls go through the

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -9292,7 +9292,10 @@ fn record_in_normal_state_takes_sync_path() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(count, 1, "sync-path write must land in memories immediately");
+    assert_eq!(
+        count, 1,
+        "sync-path write must land in memories immediately"
+    );
 }
 
 #[test]
@@ -9367,7 +9370,8 @@ fn record_in_queueing_state_routes_to_oplog_does_not_touch_memories() {
         )
         .unwrap();
     assert_eq!(
-        oplog_after, oplog_before + 1,
+        oplog_after,
+        oplog_before + 1,
         "queued path must write the record op to oplog with applied=0"
     );
 
@@ -9461,7 +9465,6 @@ mod mode_test_embedders {
             self.name.clone()
         }
     }
-
 }
 
 #[test]
@@ -9694,7 +9697,10 @@ fn set_embedder_test_6_external_or_unknown_compat_attach_does_not_claim_provenan
         s.index_embedding
     );
     assert!(s.has_runtime_embedder());
-    assert_eq!(s.runtime_embedder_digest.as_deref(), Some("sha256:attached"));
+    assert_eq!(
+        s.runtime_embedder_digest.as_deref(),
+        Some("sha256:attached")
+    );
 }
 
 #[test]
@@ -9775,8 +9781,7 @@ fn record_text_revalidates_generation_and_retries_after_swap() {
         fn embed(
             &self,
             _text: &str,
-        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>>
-        {
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
             let n = self
                 .call_count
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -9898,9 +9903,11 @@ fn record_text_revalidates_generation_and_retries_after_swap() {
     // Verify the row is durably in SQL.
     let conn = arc_db.conn();
     let count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM memories WHERE rid = ?1", [&rid], |r| {
-            r.get(0)
-        })
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE rid = ?1",
+            [&rid],
+            |r| r.get(0),
+        )
         .unwrap();
     assert_eq!(count, 1, "the retried record_text must be durably stored");
 }
@@ -9952,9 +9959,11 @@ fn record_text_routes_to_queued_when_router_is_queueing() {
     // halves of that contract.
     let conn = db.conn();
     let memories_count: i64 = conn
-        .query_row("SELECT COUNT(*) FROM memories WHERE rid = ?1", [&rid], |r| {
-            r.get(0)
-        })
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE rid = ?1",
+            [&rid],
+            |r| r.get(0),
+        )
         .unwrap();
     assert_eq!(
         memories_count, 0,
@@ -9985,17 +9994,11 @@ fn log_op_stamps_applied_generation_from_active_search_state() {
     // re-encode" (both would show applied=0 NULL or applied=1 NULL
     // and look identical).
     let db = YantrikDB::new(":memory:", 64).unwrap();
-    let initial_generation: i64 =
-        db.search_state.load().generation as i64;
+    let initial_generation: i64 = db.search_state.load().generation as i64;
 
     // log_op a synthetic event and assert the column is populated.
     let op_id = db
-        .log_op(
-            "test_event",
-            None,
-            &serde_json::json!({"x": 1}),
-            None,
-        )
+        .log_op("test_event", None, &serde_json::json!({"x": 1}), None)
         .unwrap();
     // Scope the conn guard tightly — log_op needs the conn lock too,
     // so don't hold it across the next log_op call (deadlock).
@@ -10204,7 +10207,8 @@ fn schema_v27_migration_from_v26_is_additive_only() {
             [],
         )
         .unwrap();
-        conn.execute("DROP TABLE IF EXISTS reembed_events", []).unwrap();
+        conn.execute("DROP TABLE IF EXISTS reembed_events", [])
+            .unwrap();
         conn.execute("DROP INDEX IF EXISTS idx_reembed_events_generation", [])
             .unwrap();
         // Can't easily drop ALTER-added columns in SQLite without table
@@ -10252,7 +10256,10 @@ fn schema_v27_migration_from_v26_is_additive_only() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(count, 1, "reembed_events table must be writable post-migration");
+    assert_eq!(
+        count, 1,
+        "reembed_events table must be writable post-migration"
+    );
 }
 
 #[test]
@@ -10472,7 +10479,10 @@ fn schema_v28_fresh_install_has_embedding_generation_and_active_generation() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(schema_version, "28", "fresh install stamps SCHEMA_VERSION = 28");
+    assert_eq!(
+        schema_version, "28",
+        "fresh install stamps SCHEMA_VERSION = 28"
+    );
 }
 
 #[test]
@@ -10511,8 +10521,8 @@ fn schema_v28_migration_from_v27_is_additive_and_idempotent() {
     }
 
     // Re-open — runner must heal idempotently.
-    let db = YantrikDB::new(path, 8)
-        .expect("v28 migration runner must heal rewound-meta deployments");
+    let db =
+        YantrikDB::new(path, 8).expect("v28 migration runner must heal rewound-meta deployments");
     let conn = db.conn();
 
     // Planted row still there with original generation stamp.
@@ -10775,8 +10785,7 @@ fn search_state_publish_is_atomic_under_concurrent_reads() {
             let consistent = (*gen, *dim, *hnsw_m) == baseline
                 || (*gen >= 1
                     && *dim == initial.dim()
-                    && ((*gen % 2 == 0 && *hnsw_m == 16)
-                        || (*gen % 2 == 1 && *hnsw_m == 32)));
+                    && ((*gen % 2 == 0 && *hnsw_m == 16) || (*gen % 2 == 1 && *hnsw_m == 32)));
             assert!(
                 consistent,
                 "torn SearchState observation: gen={gen} dim={dim} hnsw_m={hnsw_m} \
@@ -10844,15 +10853,13 @@ fn open_recovery_discards_staging_when_sql_swap_uncommitted() {
         .unwrap();
         conn.execute(
             "INSERT OR REPLACE INTO meta (key, value) VALUES ('reembed_state', ?1)",
-            params![
-                serde_json::json!({
-                    "generation": 5,
-                    "phase": "Encoding",
-                    "old_embedder": "old",
-                    "new_embedder_name": "simulated-target",
-                })
-                .to_string()
-            ],
+            params![serde_json::json!({
+                "generation": 5,
+                "phase": "Encoding",
+                "old_embedder": "old",
+                "new_embedder_name": "simulated-target",
+            })
+            .to_string()],
         )
         .unwrap();
         // active_generation still '0' (the swap commit never ran).
@@ -10885,7 +10892,10 @@ fn open_recovery_discards_staging_when_sql_swap_uncommitted() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(staged, 0, "staging columns must be NULL after discard recovery");
+    assert_eq!(
+        staged, 0,
+        "staging columns must be NULL after discard recovery"
+    );
 
     // active_generation unchanged.
     let active: String = conn
@@ -10964,15 +10974,13 @@ fn open_recovery_durable_swap_resumes_at_new_generation() {
         .unwrap();
         conn.execute(
             "INSERT OR REPLACE INTO meta (key, value) VALUES ('reembed_state', ?1)",
-            params![
-                serde_json::json!({
-                    "generation": 3,
-                    "phase": "Swapping",
-                    "old_embedder": "old",
-                    "new_embedder_name": "new",
-                })
-                .to_string()
-            ],
+            params![serde_json::json!({
+                "generation": 3,
+                "phase": "Swapping",
+                "old_embedder": "old",
+                "new_embedder_name": "new",
+            })
+            .to_string()],
         )
         .unwrap();
     }
@@ -11109,7 +11117,10 @@ fn open_with_uncommitted_staging_columns_stays_at_old_generation() {
             |r| r.get(0),
         )
         .unwrap();
-    assert!(active_present, "pre-reembed active embedding bytes preserved");
+    assert!(
+        active_present,
+        "pre-reembed active embedding bytes preserved"
+    );
 
     // Row's embedding_generation is the pre-reembed value (0).
     let row_gen: i64 = conn
@@ -11119,7 +11130,10 @@ fn open_with_uncommitted_staging_columns_stays_at_old_generation() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(row_gen, 0, "row's stamped generation unchanged by partial staging");
+    assert_eq!(
+        row_gen, 0,
+        "row's stamped generation unchanged by partial staging"
+    );
 }
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -9224,3 +9224,198 @@ fn schema_v26_migration_replay_is_idempotent() {
     )
     .unwrap();
 }
+
+// ============================================================================
+// v0.8.x — schema v27 reembed-operation foundation
+// (issue yantrikos/yantrikdb#41).
+//
+// v27 introduces:
+//   - `memories.embedding_new` BLOB + `memories.embedding_new_model` TEXT
+//     staging columns for the `db.reembed()` Encoding phase.
+//   - `oplog.embedding_model` TEXT to discriminate pre-reembed pending ops
+//     (where oplog.embedding is trustworthy) from post-reembed-queued ops
+//     (where the materializer must re-encode from text under the new
+//     embedder after the SearchState swap).
+//   - `reembed_events` audit-log table with `(generation, phase,
+//     timestamp, payload_json)` rows. Authoritative source for crash
+//     recovery on open().
+//
+// Tests cover three paths:
+//   1. Fresh install: all v27 surfaces exist (columns + table + index).
+//   2. Pre-v27 migration: upgrade cleanly from v26, additive only, no
+//      data touched on existing rows.
+//   3. Replay-resilience: rewinding meta to 26 on an already-v27 DB
+//      doesn't break the second open (per v0.7.3 idempotent runner).
+// ============================================================================
+
+#[test]
+fn schema_v27_fresh_install_has_reembed_surfaces() {
+    // Fresh DB takes the SCHEMA_SQL path. Locks the invariant that
+    // SCHEMA_SQL stays in sync with MIGRATE_V26_TO_V27. If someone adds
+    // a column to one but not the other, this test catches the drift
+    // before it ships (same shape as the v26 fresh-install test).
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let conn = db.conn();
+
+    let memories_cols = table_columns(&conn, "memories");
+    for required in ["embedding_new", "embedding_new_model"] {
+        assert!(
+            memories_cols.iter().any(|c| c == required),
+            "v27: fresh-install memories table missing column {required}, got: {memories_cols:?}"
+        );
+    }
+
+    let oplog_cols = table_columns(&conn, "oplog");
+    assert!(
+        oplog_cols.iter().any(|c| c == "embedding_model"),
+        "v27: fresh-install oplog table missing column embedding_model, got: {oplog_cols:?}"
+    );
+    assert!(
+        oplog_cols.iter().any(|c| c == "applied_generation"),
+        "v27: fresh-install oplog table missing column applied_generation \
+         (brainstorm-2 correction \u{2014} per-generation application tracking \
+         replaces boolean `applied` as truth), got: {oplog_cols:?}"
+    );
+
+    // reembed_events table exists with the right shape
+    let events_cols = table_columns(&conn, "reembed_events");
+    for required in ["generation", "phase", "timestamp", "payload_json"] {
+        assert!(
+            events_cols.iter().any(|c| c == required),
+            "v27: fresh-install reembed_events missing column {required}, got: {events_cols:?}"
+        );
+    }
+
+    for required_idx in [
+        "idx_reembed_events_generation",
+        "idx_oplog_applied_generation",
+    ] {
+        assert!(
+            index_exists(&conn, required_idx),
+            "v27: fresh-install missing index {required_idx}"
+        );
+    }
+}
+
+#[test]
+fn schema_v27_migration_from_v26_is_additive_only() {
+    // Plant a row under v27 schema, then manually rewind meta to 26 and
+    // re-open to trigger MIGRATE_V26_TO_V27. Verify:
+    //   - the row is untouched (additive migration, no data mutation)
+    //   - new columns appear as NULL
+    //   - new table exists + is writable
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+
+    let planted_rid = "01900000-0000-7000-8000-00000000c027";
+    {
+        let db = YantrikDB::new(path, 8).unwrap();
+        let conn = db.conn();
+        conn.execute(
+            "INSERT INTO memories (rid, type, text, embedding, created_at, updated_at, last_access, source) \
+             VALUES (?1, 'episodic', 'planted under v27 schema', X'01020304', 0.0, 0.0, 0.0, 'user')",
+            params![planted_rid],
+        )
+        .unwrap();
+    }
+
+    // Rewind meta + drop v27 surfaces so the migration recreates them.
+    {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '26')",
+            [],
+        )
+        .unwrap();
+        conn.execute("DROP TABLE IF EXISTS reembed_events", []).unwrap();
+        conn.execute("DROP INDEX IF EXISTS idx_reembed_events_generation", [])
+            .unwrap();
+        // Can't easily drop ALTER-added columns in SQLite without table
+        // rebuild; the idempotent runner swallows the duplicate-column
+        // errors on the ALTER re-run instead.
+    }
+
+    let db = YantrikDB::new(path, 8)
+        .expect("v27 migration must run cleanly against a rewound-meta v26 DB");
+    let conn = db.conn();
+
+    // Row preserved untouched (the migration must not touch existing data)
+    let (preserved_text, embedding_new): (String, Option<Vec<u8>>) = conn
+        .query_row(
+            "SELECT text, embedding_new FROM memories WHERE rid = ?1",
+            params![planted_rid],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<Vec<u8>>>(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        preserved_text, "planted under v27 schema",
+        "v27 migration must NOT mutate existing memory data"
+    );
+    assert!(
+        embedding_new.is_none(),
+        "v27 migration must leave embedding_new as NULL on pre-existing rows"
+    );
+
+    assert!(
+        index_exists(&conn, "idx_reembed_events_generation"),
+        "v27 migration must recreate idx_reembed_events_generation"
+    );
+
+    // Verify the reembed_events table is writable + readable end-to-end
+    conn.execute(
+        "INSERT INTO reembed_events (generation, phase, timestamp, payload_json) \
+         VALUES (?1, ?2, ?3, ?4)",
+        params![1_i64, "Probing", 0.0_f64, "{}"],
+    )
+    .unwrap();
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM reembed_events WHERE generation = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1, "reembed_events table must be writable post-migration");
+}
+
+#[test]
+fn schema_v27_migration_replay_is_idempotent() {
+    // Same shape as the v26 replay test. Rewind meta to 26 on an
+    // already-v27 DB and verify the second open heals cleanly. The
+    // idempotent runner swallows the duplicate-column errors that the
+    // ALTER TABLE statements would raise on the second pass.
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+
+    {
+        let _db = YantrikDB::new(path, 8).unwrap();
+    }
+    {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '26')",
+            [],
+        )
+        .unwrap();
+    }
+    let db = YantrikDB::new(path, 8)
+        .expect("v27 migration runner must heal rewound-meta deployments on a v27-schema DB");
+
+    db.record(
+        "post-v27-heal smoke",
+        "episodic",
+        0.5,
+        0.0,
+        604800.0,
+        &empty_meta(),
+        &vec_seed(1.0, 8),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap();
+}

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -8775,7 +8775,13 @@ fn explicit_set_embedder_overrides_bundled() {
 
     let mut db = YantrikDB::with_default(":memory:").unwrap();
     assert!(db.has_embedder(), "starts with bundled");
-    db.set_embedder(Box::new(DummyEmbedder));
+    // Issue #41 layer 2 / brainstorm-3: set_embedder is now mode-aware
+    // and returns Result. For an empty DB (no memories indexed yet)
+    // the call accepts ANY embedder regardless of fingerprint match,
+    // updating provenance based on candidate.fingerprint().
+    // DummyEmbedder returns None from fingerprint() so provenance
+    // stays ExternalOrUnknown; runtime_embedder slot updates.
+    db.set_embedder(Box::new(DummyEmbedder)).unwrap();
     let v = db.embed("anything").unwrap();
     assert!(
         (v[0] - 0.7777).abs() < 1e-6,
@@ -9247,6 +9253,344 @@ fn schema_v26_migration_replay_is_idempotent() {
 //   3. Replay-resilience: rewinding meta to 26 on an already-v27 DB
 //      doesn't break the second open (per v0.7.3 idempotent runner).
 // ============================================================================
+
+// ============================================================================
+// Issue #41 layer 2: set_embedder mode-aware regression tests
+// (brainstorm-3 round 2 §11, 8 cases). These lock the brainstorm-3
+// design decisions. Each test names the failure mode it prevents.
+// ============================================================================
+
+/// Helper Embedder impls for the mode-table tests. Each provides a
+/// distinct fingerprint so the mode logic can discriminate.
+mod mode_test_embedders {
+    use crate::types::Embedder;
+
+    pub struct FakeEmbedder {
+        pub dim: usize,
+        pub fp: Option<String>,
+        pub name: Option<String>,
+        /// Sentinel byte returned in vec[0] so tests can verify
+        /// "which embedder produced this vector".
+        pub sentinel: f32,
+    }
+
+    impl Embedder for FakeEmbedder {
+        fn embed(
+            &self,
+            _text: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+            let mut v = vec![0.0_f32; self.dim];
+            if !v.is_empty() {
+                v[0] = self.sentinel;
+            }
+            Ok(v)
+        }
+        fn dim(&self) -> usize {
+            self.dim
+        }
+        fn fingerprint(&self) -> Option<String> {
+            self.fp.clone()
+        }
+        fn name(&self) -> Option<String> {
+            self.name.clone()
+        }
+    }
+}
+
+#[test]
+fn set_embedder_test_1_same_dim_different_digest_on_populated_db_rejected() {
+    // Locks the silent-corruption-prevention invariant. The pre-#41
+    // engine accepted this case silently and produced garbage scores.
+    // After #41 it must return ChangeEmbedderDigestRequiresReembed.
+    use mode_test_embedders::FakeEmbedder;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:embedder_A".to_string()),
+        name: Some("embedder_A".to_string()),
+        sentinel: 1.0,
+    }))
+    .unwrap();
+    let _ = db
+        .record(
+            "first memory",
+            "semantic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(1.0, 64),
+            "default",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    let err = db
+        .set_embedder(Box::new(FakeEmbedder {
+            dim: 64,
+            fp: Some("sha256:embedder_B".to_string()),
+            name: Some("embedder_B".to_string()),
+            sentinel: 2.0,
+        }))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::ChangeEmbedderDigestRequiresReembed { .. }
+        ),
+        "same-dim-different-digest on Known-provenance populated DB must \
+         return ChangeEmbedderDigestRequiresReembed (silent-corruption \
+         prevention invariant from brainstorm-3); got {err:?}"
+    );
+}
+
+#[test]
+fn set_embedder_test_2_different_dim_on_populated_db_rejected() {
+    use mode_test_embedders::FakeEmbedder;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:fp64".to_string()),
+        name: None,
+        sentinel: 1.0,
+    }))
+    .unwrap();
+    let _ = db
+        .record(
+            "m",
+            "semantic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(1.0, 64),
+            "default",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    let err = db
+        .set_embedder(Box::new(FakeEmbedder {
+            dim: 128,
+            fp: Some("sha256:fp128".to_string()),
+            name: None,
+            sentinel: 2.0,
+        }))
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::ChangeEmbedderDimensionRequiresReembed { .. }
+        ),
+        "dim change on populated DB must return \
+         ChangeEmbedderDimensionRequiresReembed; got {err:?}"
+    );
+}
+
+#[test]
+fn set_embedder_test_3_empty_db_with_fingerprint_upgrades_provenance_to_known() {
+    // Empty DB + candidate has fingerprint → provenance upgrades to
+    // Known(fp). Locks the initial-attach upgrade path.
+    use mode_test_embedders::FakeEmbedder;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    assert!(matches!(
+        db.search_state.load().index_embedding,
+        crate::engine::reembed::EmbeddingProvenance::ExternalOrUnknown { .. }
+    ));
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:initial".to_string()),
+        name: Some("initial".to_string()),
+        sentinel: 1.0,
+    }))
+    .unwrap();
+    let s = db.search_state.load_full();
+    match &s.index_embedding {
+        crate::engine::reembed::EmbeddingProvenance::Known { name, digest, dim } => {
+            assert_eq!(name.as_deref(), Some("initial"));
+            assert_eq!(digest, "sha256:initial");
+            assert_eq!(*dim, 64);
+        }
+        other => panic!("expected Known provenance after attach on empty DB, got {other:?}"),
+    }
+}
+
+#[test]
+fn set_embedder_test_4_empty_db_no_fingerprint_stays_external_or_unknown() {
+    // Empty DB + candidate fingerprint is None → provenance stays
+    // ExternalOrUnknown. We cannot claim a digest we don't have.
+    use mode_test_embedders::FakeEmbedder;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: None,
+        name: None,
+        sentinel: 1.0,
+    }))
+    .unwrap();
+    let s = db.search_state.load_full();
+    assert!(
+        matches!(
+            s.index_embedding,
+            crate::engine::reembed::EmbeddingProvenance::ExternalOrUnknown { dim: 64 }
+        ),
+        "no-fingerprint embedder on empty DB must keep ExternalOrUnknown provenance, \
+         got {:?}",
+        s.index_embedding
+    );
+    assert!(s.has_runtime_embedder());
+}
+
+#[test]
+fn set_embedder_test_5_same_digest_replacement_does_not_bump_generation() {
+    // Replacing a runtime embedder with one that has the SAME digest is
+    // a same-model swap. Generation must NOT bump (index + provenance
+    // unchanged; only the runtime Arc was replaced).
+    use mode_test_embedders::FakeEmbedder;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:same".to_string()),
+        name: Some("same".to_string()),
+        sentinel: 1.0,
+    }))
+    .unwrap();
+    let gen_before = db.search_state.load().generation;
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:same".to_string()),
+        name: Some("same".to_string()),
+        sentinel: 2.0,
+    }))
+    .unwrap();
+    let gen_after = db.search_state.load().generation;
+    assert_eq!(
+        gen_after, gen_before,
+        "same-digest replacement must NOT bump generation (no coherent-bundle change)"
+    );
+    let v = db.embed("anything").unwrap();
+    assert!(
+        (v[0] - 2.0).abs() < 1e-6,
+        "runtime Arc must have been replaced; expected sentinel 2.0, got {}",
+        v[0]
+    );
+}
+
+#[test]
+fn set_embedder_test_6_external_or_unknown_compat_attach_does_not_claim_provenance() {
+    // ExternalOrUnknown-provenance populated DB + candidate with
+    // matching dim → compat attach. Runtime embedder is set, but
+    // index_embedding stays ExternalOrUnknown.
+    use mode_test_embedders::FakeEmbedder;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    // Populate DB without setting an embedder — vectors come from
+    // external source. Provenance stays ExternalOrUnknown.
+    let _ = db
+        .record(
+            "external vec",
+            "semantic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(1.0, 64),
+            "default",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    assert!(matches!(
+        db.search_state.load().index_embedding,
+        crate::engine::reembed::EmbeddingProvenance::ExternalOrUnknown { .. }
+    ));
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:attached".to_string()),
+        name: Some("attached".to_string()),
+        sentinel: 1.0,
+    }))
+    .unwrap();
+    let s = db.search_state.load_full();
+    assert!(
+        matches!(
+            s.index_embedding,
+            crate::engine::reembed::EmbeddingProvenance::ExternalOrUnknown { .. }
+        ),
+        "compat-attach must NOT upgrade ExternalOrUnknown provenance to Known; \
+         existing vectors weren't built with this embedder. Got {:?}",
+        s.index_embedding
+    );
+    assert!(s.has_runtime_embedder());
+    assert_eq!(s.runtime_embedder_digest.as_deref(), Some("sha256:attached"));
+}
+
+#[test]
+fn set_embedder_test_7_has_embedder_derives_from_search_state() {
+    // Locks the brainstorm-3 invariant: has_embedder() reads from
+    // search_state, NOT from the (now-retired) legacy embedder slot.
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    assert!(!db.has_embedder(), "fresh engine: no embedder");
+    use mode_test_embedders::FakeEmbedder;
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:x".to_string()),
+        name: None,
+        sentinel: 0.42,
+    }))
+    .unwrap();
+    assert!(db.has_embedder());
+    let v = db.embed("anything").unwrap();
+    assert!((v[0] - 0.42).abs() < 1e-6);
+}
+
+#[test]
+fn set_embedder_test_8_atomic_publication_no_partial_state() {
+    // Locks the brainstorm-3 atomic-publication invariant: a concurrent
+    // load of search_state must see either the OLD state or the NEW
+    // state, never a mix. With ArcSwap, this is automatic; the test
+    // exercises the property as a regression guard.
+    use mode_test_embedders::FakeEmbedder;
+    use std::sync::Arc;
+    let mut db = YantrikDB::new(":memory:", 64).unwrap();
+    db.set_embedder(Box::new(FakeEmbedder {
+        dim: 64,
+        fp: Some("sha256:initial".to_string()),
+        name: None,
+        sentinel: 1.0,
+    }))
+    .unwrap();
+    // Self-consistency invariant: if embedder is Some, digest is also Some
+    // for FakeEmbedder which always provides a fingerprint.
+    let state = db.search_state.load_full();
+    assert_eq!(
+        state.embedder.is_some(),
+        state.runtime_embedder_digest.is_some(),
+        "embedder Some <=> digest Some must hold for any consistent snapshot"
+    );
+    // Multiple same-digest replacements; each load must be consistent.
+    for sentinel in [2.0_f32, 3.0, 4.0, 5.0] {
+        db.set_embedder(Box::new(FakeEmbedder {
+            dim: 64,
+            fp: Some("sha256:initial".to_string()),
+            name: None,
+            sentinel,
+        }))
+        .unwrap();
+        let s = db.search_state.load_full();
+        assert_eq!(
+            s.embedder.is_some(),
+            s.runtime_embedder_digest.is_some(),
+            "consistency must hold across replacements (no partial state)"
+        );
+        let _arc_held: Arc<crate::engine::reembed::SearchState> = s;
+    }
+}
 
 #[test]
 fn search_state_initial_on_fresh_engine() {

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -9249,6 +9249,32 @@ fn schema_v26_migration_replay_is_idempotent() {
 // ============================================================================
 
 #[test]
+fn search_state_initial_on_fresh_engine() {
+    // Issue #41 layer 2: fresh engine must initialize a SearchState with
+    // provenance=ExternalOrUnknown(embedding_dim) and no runtime embedder.
+    // The standalone embedding_dim field is still source of truth at THIS
+    // layer (retired in a later checkpoint); we only verify here that the
+    // new search_state field is initialized with the expected initial shape.
+    let db = YantrikDB::new(":memory:", 384).unwrap();
+    let state = db.search_state.load_full();
+    assert_eq!(
+        state.dim(),
+        384,
+        "initial dim must match constructor parameter"
+    );
+    assert!(matches!(
+        state.index_embedding,
+        crate::engine::reembed::EmbeddingProvenance::ExternalOrUnknown { dim: 384 }
+    ));
+    assert!(
+        !state.has_runtime_embedder(),
+        "fresh engine must have no runtime embedder until set_embedder*"
+    );
+    assert_eq!(state.generation, 0);
+    assert_eq!(state.covers_through_seq, 0);
+}
+
+#[test]
 fn schema_v27_fresh_install_has_reembed_surfaces() {
     // Fresh DB takes the SCHEMA_SQL path. Locks the invariant that
     // SCHEMA_SQL stays in sync with MIGRATE_V26_TO_V27. If someone adds

--- a/crates/yantrikdb-core/src/engine/write_router.rs
+++ b/crates/yantrikdb-core/src/engine/write_router.rs
@@ -1,0 +1,423 @@
+//! Synchronized write-routing barrier for reembed (issue #41).
+//!
+//! ## Why this exists
+//!
+//! Without a real synchronization primitive, the reembed operation has
+//! a window where in-flight synchronous writes can commit to the
+//! about-to-be-discarded old HNSW after the rebuild snapshot was
+//! taken — and never reach the new index. Brainstorm-2 gpt-5.5
+//! caught this; see yantrikos/yantrikdb#41 comment chain for the bad
+//! interleaving timeline.
+//!
+//! `WriteRouter` provides the cutover gate: writers acquire a
+//! `SyncWriteGuard` for the full duration of a synchronous write
+//! (memories INSERT + vec_index.append + oplog write all under the
+//! guard). Reembed flips the router state to Queueing, waits for
+//! `inflight == 0`, and then can safely capture `build_hwm` knowing
+//! no synchronous writer can still commit to the old generation.
+//!
+//! ## Invariants enforced
+//!
+//! From brainstorm-2 §8:
+//! - **Single classification** of every write into pre-barrier-sync OR
+//!   post-barrier-queued — no middle state.
+//! - **No old application after barrier** — once `wait_for_no_sync_writers()`
+//!   returns, no `applied_generation = old_generation` writes can
+//!   appear (because sync writers all left and queued writers don't
+//!   apply directly).
+//!
+//! ## Implementation choice
+//!
+//! mutex/condvar + RAII guard instead of atomic counter. The atomic
+//! version drafted in brainstorm-2 round 2 had too many opportunities
+//! for missing-decrement bugs on error / panic paths. The RAII guard
+//! is panic-safe by construction via `Drop`.
+
+use std::sync::Arc;
+
+use parking_lot::{Condvar, Mutex};
+
+/// State machine of the write-routing gate.
+///
+/// Transitions:
+/// - `Normal` → `Queueing`   (reembed cutover start)
+/// - `Queueing` → `Normal`   (reembed completed or aborted)
+///
+/// There is no separate "Draining" state in the final design; the
+/// `Queueing` state both rejects new sync writers AND waits for
+/// in-flight ones to leave (callers use `wait_for_no_sync_writers`
+/// explicitly). This keeps the state space minimal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouterState {
+    /// `try_enter_sync_writer()` returns Some(guard); writes take the
+    /// synchronous path (record memories table + vec_index + oplog
+    /// applied=1).
+    Normal,
+    /// `try_enter_sync_writer()` returns None; writes must take the
+    /// queued path (log_op_pending with applied=0 +
+    /// embedding_model=current_embedder_name).
+    Queueing,
+}
+
+/// Shared inner state behind the router. Locked by a single mutex; the
+/// state field is small + writes are rare (only on reembed cutover) so
+/// the lock is not a contention point.
+struct RouterInner {
+    state: RouterState,
+    inflight: u64,
+}
+
+/// Synchronized write-routing barrier.
+///
+/// One instance per engine. Construct via [`WriteRouter::new()`]
+/// (defaults to `Normal` state, 0 inflight). Wrap in `Arc` if you need
+/// to share across threads; the implementation is `Send + Sync` via
+/// the `parking_lot` primitives.
+pub struct WriteRouter {
+    inner: Mutex<RouterInner>,
+    /// Notified when `inflight` decrements to 0 (waking
+    /// `wait_for_no_sync_writers`).
+    drained: Condvar,
+    /// Notified when `state` changes (currently unused externally; held
+    /// in case a future async API wants to wake on state transitions
+    /// without polling).
+    #[allow(dead_code)]
+    state_changed: Condvar,
+}
+
+/// RAII guard held by an in-flight synchronous writer. Drop decrements
+/// the inflight counter and notifies the cutover-drain condvar if the
+/// counter reached zero.
+///
+/// Panic-safe: even if the writer's record/append/log_op chain panics,
+/// the guard's Drop still runs and the counter stays coherent.
+pub struct SyncWriteGuard<'a> {
+    router: &'a WriteRouter,
+}
+
+impl<'a> Drop for SyncWriteGuard<'a> {
+    fn drop(&mut self) {
+        let mut g = self.router.inner.lock();
+        debug_assert!(g.inflight > 0, "SyncWriteGuard drop on zero inflight");
+        g.inflight -= 1;
+        if g.inflight == 0 {
+            // Wake any waiter inside wait_for_no_sync_writers.
+            self.router.drained.notify_all();
+        }
+    }
+}
+
+impl WriteRouter {
+    /// Construct a new router in `Normal` state with 0 inflight writers.
+    pub fn new() -> Self {
+        WriteRouter {
+            inner: Mutex::new(RouterInner {
+                state: RouterState::Normal,
+                inflight: 0,
+            }),
+            drained: Condvar::new(),
+            state_changed: Condvar::new(),
+        }
+    }
+
+    /// Current state. Mainly for tests + observability; do NOT use this
+    /// for routing decisions on the write path (use
+    /// `try_enter_sync_writer` which atomically checks + increments).
+    pub fn state(&self) -> RouterState {
+        self.inner.lock().state
+    }
+
+    /// Current in-flight synchronous-writer count. Tests +
+    /// observability.
+    pub fn inflight(&self) -> u64 {
+        self.inner.lock().inflight
+    }
+
+    /// Try to enter the synchronous write path. Returns `Some(guard)`
+    /// if the router is in `Normal` state (writer must hold the guard
+    /// for the full sync-write duration). Returns `None` if the router
+    /// is in `Queueing` state (writer must take the queued path
+    /// instead).
+    ///
+    /// The state check + inflight increment happen atomically under
+    /// the inner mutex, so there is no TOCTOU window between "saw
+    /// Normal" and "counted as in-flight." That property is what makes
+    /// the cutover safe.
+    pub fn try_enter_sync_writer(&self) -> Option<SyncWriteGuard<'_>> {
+        let mut g = self.inner.lock();
+        if g.state == RouterState::Normal {
+            g.inflight += 1;
+            Some(SyncWriteGuard { router: self })
+        } else {
+            None
+        }
+    }
+
+    /// Flip state to `Queueing`. New sync writers will see `None` from
+    /// `try_enter_sync_writer` from now on. Already-acquired guards
+    /// continue executing; cutover must call
+    /// `wait_for_no_sync_writers` to drain them.
+    pub fn switch_to_queueing(&self) {
+        let mut g = self.inner.lock();
+        g.state = RouterState::Queueing;
+        self.state_changed.notify_all();
+    }
+
+    /// Flip state back to `Normal`. Reembed calls this at completion
+    /// (or abort) to restore the synchronous write path. Inflight
+    /// queued writes continue draining via the materializer; this only
+    /// affects classification of NEW writes.
+    pub fn switch_to_normal(&self) {
+        let mut g = self.inner.lock();
+        g.state = RouterState::Normal;
+        self.state_changed.notify_all();
+    }
+
+    /// Block until `inflight == 0`. Reembed cutover calls this AFTER
+    /// `switch_to_queueing()` to ensure all in-flight synchronous
+    /// writers have left before capturing `build_hwm` and starting
+    /// Encoding.
+    ///
+    /// Returns immediately if `inflight` is already 0.
+    pub fn wait_for_no_sync_writers(&self) {
+        let mut g = self.inner.lock();
+        while g.inflight > 0 {
+            self.drained.wait(&mut g);
+        }
+    }
+
+    /// Block until `inflight == 0` OR `timeout` elapses. Returns `true`
+    /// if drained, `false` if timed out. Useful for tests that don't
+    /// want to hang.
+    pub fn wait_for_no_sync_writers_timeout(&self, timeout: std::time::Duration) -> bool {
+        use std::time::Instant;
+        let deadline = Instant::now() + timeout;
+        let mut g = self.inner.lock();
+        while g.inflight > 0 {
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let remaining = deadline - now;
+            // wait_for returns a WaitTimeoutResult-like guard plus a
+            // timed_out indicator; we just loop and check inflight.
+            let _ = self.drained.wait_for(&mut g, remaining);
+        }
+        true
+    }
+}
+
+impl Default for WriteRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// `Arc<WriteRouter>` is the expected shape for callers. WriteRouter
+// itself is Send + Sync via the parking_lot primitives.
+pub type SharedWriteRouter = Arc<WriteRouter>;
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn new_router_is_normal_with_zero_inflight() {
+        let r = WriteRouter::new();
+        assert_eq!(r.state(), RouterState::Normal);
+        assert_eq!(r.inflight(), 0);
+    }
+
+    #[test]
+    fn enter_sync_writer_in_normal_returns_guard_and_increments() {
+        let r = WriteRouter::new();
+        let g = r.try_enter_sync_writer().expect("Normal must yield guard");
+        assert_eq!(r.inflight(), 1);
+        drop(g);
+        assert_eq!(r.inflight(), 0);
+    }
+
+    #[test]
+    fn enter_sync_writer_in_queueing_returns_none() {
+        let r = WriteRouter::new();
+        r.switch_to_queueing();
+        assert!(
+            r.try_enter_sync_writer().is_none(),
+            "Queueing state must reject sync writers — this is the cutover invariant"
+        );
+        assert_eq!(r.inflight(), 0);
+    }
+
+    #[test]
+    fn inflight_counter_correct_under_multiple_concurrent_writers() {
+        let r = Arc::new(WriteRouter::new());
+        let mut handles = vec![];
+        // Spawn 10 writers; each holds its guard for ~50ms then drops.
+        for _ in 0..10 {
+            let r_clone = Arc::clone(&r);
+            handles.push(thread::spawn(move || {
+                let g = r_clone
+                    .try_enter_sync_writer()
+                    .expect("Normal must yield guard");
+                thread::sleep(Duration::from_millis(50));
+                drop(g);
+            }));
+        }
+        // Give threads a moment to all acquire their guards.
+        thread::sleep(Duration::from_millis(10));
+        let observed = r.inflight();
+        assert!(
+            observed > 0 && observed <= 10,
+            "expected 1..=10 concurrent inflight writers, got {observed}"
+        );
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(r.inflight(), 0, "all writers must have released guards");
+    }
+
+    #[test]
+    fn wait_for_drain_blocks_until_inflight_zero() {
+        // Spawn a writer holding a guard, then call wait_for from main
+        // thread. wait must return only after the guard is dropped.
+        let r = Arc::new(WriteRouter::new());
+        let writer_done = Arc::new(parking_lot::Mutex::new(false));
+
+        let r_clone = Arc::clone(&r);
+        let done_clone = Arc::clone(&writer_done);
+        let writer = thread::spawn(move || {
+            let g = r_clone
+                .try_enter_sync_writer()
+                .expect("Normal must yield guard");
+            thread::sleep(Duration::from_millis(100));
+            *done_clone.lock() = true;
+            drop(g);
+        });
+
+        // Give writer time to acquire.
+        thread::sleep(Duration::from_millis(20));
+        // Should be inflight=1 right now.
+        assert_eq!(r.inflight(), 1);
+        // wait must block until the writer drops the guard.
+        r.wait_for_no_sync_writers();
+        assert!(
+            *writer_done.lock(),
+            "wait_for_no_sync_writers returned before writer set done flag"
+        );
+        writer.join().unwrap();
+    }
+
+    #[test]
+    fn wait_for_drain_returns_immediately_when_already_zero() {
+        let r = WriteRouter::new();
+        let start = std::time::Instant::now();
+        r.wait_for_no_sync_writers();
+        assert!(
+            start.elapsed() < Duration::from_millis(50),
+            "wait_for must short-circuit when inflight=0"
+        );
+    }
+
+    #[test]
+    fn wait_for_timeout_returns_false_when_writers_dont_drain() {
+        let r = Arc::new(WriteRouter::new());
+        let _g = r.try_enter_sync_writer().unwrap();
+        let drained = r.wait_for_no_sync_writers_timeout(Duration::from_millis(50));
+        assert!(
+            !drained,
+            "timeout must return false when writers never drain"
+        );
+    }
+
+    #[test]
+    fn cutover_sequence_serializes_writers_and_reembed() {
+        // The headline correctness scenario: simulate the brainstorm-2
+        // bad interleaving and confirm the router prevents it.
+        //
+        // Steps:
+        //   1. Writer A enters Normal, acquires sync guard.
+        //   2. Reembed starts: switch_to_queueing.
+        //   3. Writer B tries to enter; gets None (must take queued path).
+        //   4. Reembed waits for no sync writers (blocks on A's guard).
+        //   5. Writer A finishes, drops guard.
+        //   6. Reembed unblocks, proceeds with rebuild snapshot.
+        //   7. After reembed, switch_to_normal.
+        //   8. Writer C enters Normal again, gets guard.
+        let r = Arc::new(WriteRouter::new());
+
+        // Writer A: holds guard for 200ms.
+        let r_a = Arc::clone(&r);
+        let a_handle = thread::spawn(move || {
+            let g = r_a.try_enter_sync_writer().expect("A: Normal yields guard");
+            thread::sleep(Duration::from_millis(200));
+            drop(g);
+        });
+        // Let A acquire.
+        thread::sleep(Duration::from_millis(20));
+        assert_eq!(r.inflight(), 1);
+
+        // Reembed cutover: flip state.
+        r.switch_to_queueing();
+        assert_eq!(r.state(), RouterState::Queueing);
+
+        // Writer B: must get None.
+        assert!(
+            r.try_enter_sync_writer().is_none(),
+            "B: Queueing must reject sync writers"
+        );
+
+        // Reembed waits for A to drain.
+        let drain_start = std::time::Instant::now();
+        r.wait_for_no_sync_writers();
+        let drain_dur = drain_start.elapsed();
+        assert!(
+            drain_dur >= Duration::from_millis(100),
+            "wait_for should have blocked >=100ms waiting for A (took {drain_dur:?})"
+        );
+        assert_eq!(r.inflight(), 0);
+
+        // Reembed completes; switch back to Normal.
+        r.switch_to_normal();
+        assert_eq!(r.state(), RouterState::Normal);
+
+        // Writer C: Normal again, gets guard.
+        let g_c = r
+            .try_enter_sync_writer()
+            .expect("C: post-reembed Normal must yield guard");
+        assert_eq!(r.inflight(), 1);
+        drop(g_c);
+        assert_eq!(r.inflight(), 0);
+
+        a_handle.join().unwrap();
+    }
+
+    #[test]
+    fn guard_drop_is_panic_safe() {
+        // If a sync writer panics while holding the guard, Drop must
+        // still run and the counter must stay coherent. This is the
+        // key reason we use RAII instead of atomic-counter +
+        // explicit-decrement.
+        let r = Arc::new(WriteRouter::new());
+
+        let r_clone = Arc::clone(&r);
+        let panicker = thread::spawn(move || {
+            let _g = r_clone.try_enter_sync_writer().unwrap();
+            panic!("simulated writer panic mid-write");
+        });
+        // We expect the thread to panic; suppress the propagated
+        // panic + verify inflight returned to 0.
+        let res = panicker.join();
+        assert!(res.is_err(), "writer thread should have panicked");
+        assert_eq!(
+            r.inflight(),
+            0,
+            "guard Drop must run even on panic — RAII invariant"
+        );
+    }
+}

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -222,7 +222,9 @@ impl PyYantrikDB {
             // set_embedder returns Result post-#41 (mode-aware refactor).
             // On a freshly-constructed engine (no memories yet) this can
             // only fail on dim mismatch — surface that as a Python error.
-            inner.set_embedder(Box::new(candle_embedder)).map_err(map_err)?;
+            inner
+                .set_embedder(Box::new(candle_embedder))
+                .map_err(map_err)?;
         }
 
         #[cfg(not(feature = "candle"))]

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -219,7 +219,10 @@ impl PyYantrikDB {
                 .map_err(|e| {
                 PyRuntimeError::new_err(format!("Failed to load candle embedder: {e}"))
             })?;
-            inner.set_embedder(Box::new(candle_embedder));
+            // set_embedder returns Result post-#41 (mode-aware refactor).
+            // On a freshly-constructed engine (no memories yet) this can
+            // only fail on dim mismatch — surface that as a Python error.
+            inner.set_embedder(Box::new(candle_embedder)).map_err(map_err)?;
         }
 
         #[cfg(not(feature = "candle"))]


### PR DESCRIPTION
## Summary

Implements `db.reembed(new_embedder_name, options)` — engine-side embedder migration that re-encodes every memory under a new embedder + atomically swaps the active HNSW index while concurrent recalls continue serving and concurrent writes queue rather than block. Closes #41. Unblocks the `yantrikdb-hermes embedder migrate` CLI for downstream user wysie (potion-base-2M → potion-base-32M migration).

20 commits across 12 substantive checkpoints. 1492 tests passing (default), 1481 slim, 1499 with `embedder-download` feature. 0 regressions.

## Design provenance

Four narrow-scope brainstorm sessions with gpt-5.5 caught 10+ critical correctness bugs across the design space before any of them shipped:

- **Brainstorm 1** (session `3929a962`): full design lock
- **Brainstorm 2** (session `1c908602`, 2 rounds) — caught the **phase-flag-isn't-synchronization** race: writer could mark `applied=1` against an old HNSW between snapshot and swap, durable RYW violation. Forced the cutover-barrier redesign.
- **Brainstorm 3** (session `a6f77e50`) — caught two pre-existing latent bugs in `set_embedder` (same-dim-different-digest silent corruption, empty-DB-doesn't-reset-physical-HNSW) and locked the mode-aware decision table.
- **Brainstorm 4** (session `182ab107`) — caught six correctness bugs in the originally-planned "wrap vec_index in ArcSwap<DeltaIndex>" refactor. Forced the SearchState-as-single-publication-unit pivot.

All four brainstorms are linked from issue #41 comment chain.

## 5-phase state machine

```
Probing -> Encoding -> Rebuilding -> Swapping -> Verifying -> Completed
```

- **Probing**: count rows-to-encode under `embedding_generation < next_gen`; populate `ReembedProgress { total: Some(N), processed: 0 }` so CLIs render "0/N memories" immediately (hermes ask #1).
- **Encoding**: scan stale-gen rows in batches; embed text outside conn lock; batch-write to `memories.embedding_new` + `embedding_new_model` under SAVEPOINTs. Defensive idempotent clear at start.
- **Rebuilding**: construct a fresh `HnswIndex` (same-dim for v1; cross-dim deferred — see Limitations); insert from staged bytes.
- **Swapping**: the 7-step cutover under `index_write_lock`:
  1. `write_router.switch_to_queueing()` — new sync writers route to `record_queued`
  2. `wait_for_no_sync_writers()` — drain in-flight
  3. Capture `vec_seq.load(Acquire)` as `covers_through_seq`
  4. Tail-catchup: encode rows that arrived between Encoding scan and cutover barrier
  5. Atomic SQL SAVEPOINT { `UPDATE meta active_generation`, `UPDATE memories SET embedding=embedding_new + embedding_generation=new_gen`, clear staging } COMMIT — on rollback the router flips back to Normal and staging persists for retry
  6. `try_publish_search_state(new_state)` — single atomic ArcSwap publication
  7. `switch_to_normal` — resume sync writes
- **Verifying**: stragglers count; Layer 5 materializer drains queued writes that arrived during cutover.
- **Completed**: meta.reembed_state cleared, full audit event in `reembed_events`.

## Structural primitives

1. **SearchState** (`engine/reembed.rs`) — single atomic publication unit carrying `(provenance, embedder, dim, generation, covers_through_seq, hnsw params, vec_index)`. ArcSwap-wrapped. The standalone `vec_index` field on YantrikDB was retired; everything reads through `search_state.load().vec_index`.

2. **WriteRouter** (`engine/write_router.rs`) — cutover barrier. RAII `SyncWriteGuard` via Drop (mutex+condvar, not atomic counter — panic-safe). Atomic state-check + inflight-increment, so no TOCTOU between "saw Normal" and "counted as in-flight."

3. **try_publish_search_state CAS** (`engine/mod.rs`) — single chokepoint for SearchState mutation. `ArcSwap::compare_and_swap` loop with strict generation-monotonicity check. Rejects strictly-lesser-generation publishes (`SearchStatePublishStaleGeneration` error variant).

4. **Writer revalidation loop** (`engine/mod.rs::record_text`) — embed outside the WriteRouter guard (slow step); acquire guard; reload SearchState; if `(gen, digest)` changed under us, drop guard and retry the embed. Closes the stale-writer-commit race brainstorm-4 §2 caught.

5. **v28 schema migration** (`base/schema.rs`) — `memories.embedding_generation INTEGER` + `meta.active_generation` row + `idx_memories_embedding_generation`. Together they're the durable linearization point: `open()` reads `meta.active_generation` and rebuilds SearchState at that gen, so a crash between SQL swap commit and ArcSwap store resolves correctly.

6. **DurableEmbeddingStore** (`engine/durable_embeddings.rs`) — typed boundary for SQL `SELECT embedding FROM memories` reads. Every result carries `EmbeddingWithGeneration { bytes, generation }`. A compile-test (`recall_rs_has_no_raw_sql_embedding_reads`) `include_str!`s recall.rs at test time and fails the build if a future refactor reintroduces raw SQL embedding access in the hot recall path.

7. **Layer 5 materializer drain** (`engine/stats.rs::apply_pending_ops_once`) — new dispatch arm for `op_type='record' AND embedding_model IS NOT NULL` (the `record_queued` signature). If reembed in flight, defer (pause-during-reembed per brainstorm-2 §5). Else re-encode text under active SearchState's embedder + apply to memories at new gen.

8. **Layer 7 crash recovery** (`engine/mod.rs::new`) — inspects `meta.reembed_state`. If `active_generation < in_flight_gen`: discard staging + clear marker + log Aborted recovery event. If `active_generation >= in_flight_gen`: SearchState rebuilds at new gen + defensive staging clear + log Completed recovery event.

## brainstorm-4 §10 invariant coverage

All 8 §10 invariants locked with regression tests:

| § | Test |
|---|---|
| 10.1 no read-side dim split-brain | `search_state_publish_is_atomic_under_concurrent_reads` |
| 10.2 stale writer retry | `record_text_revalidates_generation_and_retries_after_swap` |
| 10.3 compactor cannot roll back generation | `try_publish_search_state_rejects_stale_generation` |
| 10.4 crash between SQL commit and ArcSwap | `open_reads_durable_active_generation_into_search_state` |
| 10.5 crash before SQL promotion commit | `open_recovery_discards_staging_when_sql_swap_uncommitted` |
| 10.6 covers_through_seq durable | `covers_through_seq_is_durably_carried_on_published_search_state` |
| 10.7 SQL embedding access audit | `recall_rs_has_no_raw_sql_embedding_reads` |
| 10.8 module-boundary audit | same + `boundary_audit_pattern_detects_synthetic_violation` (meta-test) |

Plus 5 Layer 8 functional integration tests including the headline end-to-end recall correctness proof (`reembed_post_swap_recall_returns_rows_under_new_embedder` — plant rows under E0 sentinel 0.42, reembed to E1 sentinel 0.99, recall under E1 vector space, all rows return).

## Limitations / deferred (documented)

- **Cross-dim reembed**: same-dim only in v1. The engine's standalone `embedding_dim` field still gates ~7 sites (`engine/conflict.rs`, `engine/indices.rs`, `engine/record.rs`, `distributed/replication.rs`); retiring it is a separate structural increment. Cross-dim returns a typed error pointing at the documented escape hatch ("open new DB at new dim, copy memories"). Same-dim covers the primary hermes use case (model upgrade within vector space).
- **Layer 6 visible_seq generation-aware init**: strict-RYW edge case where `visible_seq[ns]` should be initialized to `covers_through_seq` post-swap. Today the visible_seq just advances naturally as Layer 5's drain bumps seqs; strict-RYW followups bundle with a future user report.
- **Large-DB scaling/perf bench**: hardware-dependent. Can be added as a `#[ignore]`-gated test or a separate criterion bench at release time if you want quantitative scaling data.
- **HTTP backend**: this PR is the engine primitive (`yantrikdb-core`). The corresponding `yantrikdb-server` REST endpoint + cluster-mode reembed (openraft applier semantics) is a downstream PR. `yantrikdb-hermes-plugin` embedded mode is unblocked by this PR; HTTP-mode plugin users wait for the server PR.

## Test counts

| Build | Tests passing |
|---|---|
| `cargo test --lib --release` (default) | 1492 |
| `cargo test --lib --no-default-features --release` (slim) | 1481 (11 fewer due to bundled-embedder-gated tests) |
| `cargo test --lib --features embedder-download --release` | 1499 |
| `cargo fmt --check` | clean |

`cargo clippy` reports one pre-existing error in `cognition/benchmark_ck4.rs:456` (`enforcement.items_affected >= 0` on u64, always-true comparison; last touched in `b84f6de`, unrelated to this PR).

## Commits

20 commits ce58d6a -> 02e2ded. Each checkpoint is its own atomic commit with full commentary on what landed and why. See `git log feature/issue-41-reembed-operation ^main` for the structured progression.

## Closes

Closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
