### PR TITLE
feat(recall): certainty first-class on remember + recall (closes #46)

### DIFF
--- a/crates/yantrikdb-core/benches/engine_bench.rs
+++ b/crates/yantrikdb-core/benches/engine_bench.rs
@@ -163,6 +163,8 @@ fn bench_recall(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    None,
+                    None,
                 )
                 .unwrap()
             })
@@ -392,6 +394,8 @@ fn bench_recall_scaled(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    None,
+                    None,
                 )
                 .unwrap()
             })
@@ -427,6 +431,8 @@ fn bench_recall_dim_comparison(c: &mut Criterion) {
                             false,
                             None,
                             true,
+                            None,
+                            None,
                             None,
                             None,
                             None,
@@ -469,6 +475,8 @@ fn bench_recall_100k(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    None,
+                    None,
                 )
                 .unwrap()
             })
@@ -502,6 +510,8 @@ fn bench_recall_with_graph(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    None,
+                    None,
                 )
                 .unwrap()
             })
@@ -518,6 +528,8 @@ fn bench_recall_with_graph(c: &mut Criterion) {
                     false,
                     None,
                     true,
+                    None,
+                    None,
                     None,
                     None,
                     None,
@@ -557,6 +569,8 @@ fn bench_reinforce_overhead(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    None,
+                    None,
                 )
                 .unwrap()
         })
@@ -574,6 +588,8 @@ fn bench_reinforce_overhead(c: &mut Criterion) {
                     false,
                     None,
                     true,
+                    None,
+                    None,
                     None,
                     None,
                     None,

--- a/crates/yantrikdb-core/examples/perf_at_scale.rs
+++ b/crates/yantrikdb-core/examples/perf_at_scale.rs
@@ -192,7 +192,7 @@ fn run_one(n: usize) -> Row {
         let q_start = Instant::now();
         let results = db
             .recall(
-                &query, TOP_K, None, None, false, false, None, true, None, None, None,
+                &query, TOP_K, None, None, false, false, None, true, None, None, None, None, None,
             )
             .expect("recall failed");
         let lat_us = q_start.elapsed().as_secs_f64() * 1_000_000.0;

--- a/crates/yantrikdb-core/examples/wedge_repro.rs
+++ b/crates/yantrikdb-core/examples/wedge_repro.rs
@@ -299,7 +299,7 @@ fn run() {
                 let query = vec_seed((q_seed as f32) * 0.71 + 7.0, dim);
                 let t = Instant::now();
                 let _ = db_c.recall(
-                    &query, 10, None, None, false, false, None, false, None, None, None,
+                    &query, 10, None, None, false, false, None, false, None, None, None, None, None,
                 );
                 let dur_ns = t.elapsed().as_nanos() as u64;
                 let bucket = started.elapsed().as_secs();

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -614,6 +614,9 @@ pub struct RecallQuery {
     // V10 filters
     pub domain: Option<String>,
     pub source: Option<String>,
+    // Issue #46: confidence first-class on recall.
+    pub certainty_min: Option<f64>,
+    pub order: Option<String>,
 }
 
 impl RecallQuery {
@@ -631,7 +634,23 @@ impl RecallQuery {
             namespace: None,
             domain: None,
             source: None,
+            certainty_min: None,
+            order: None,
         }
+    }
+
+    /// Issue #46: drop results whose certainty falls below `min`.
+    pub fn certainty_min(mut self, min: f64) -> Self {
+        self.certainty_min = Some(min);
+        self
+    }
+
+    /// Issue #46: re-sort the top_k by `"relevance"` (default),
+    /// `"certainty"`, or `"recency"`. Invalid strings surface as
+    /// `YantrikDbError::InvalidInput` on `execute()`.
+    pub fn order(mut self, order: &str) -> Self {
+        self.order = Some(order.to_string());
+        self
     }
 
     /// Set maximum number of results to return.

--- a/crates/yantrikdb-core/src/distributed/sync.rs
+++ b/crates/yantrikdb-core/src/distributed/sync.rs
@@ -542,7 +542,7 @@ mod tests {
         // A can recall (has vec_memories entries)
         let a_results = a
             .recall(
-                &emb1, 2, None, None, false, false, None, false, None, None, None,
+                &emb1, 2, None, None, false, false, None, false, None, None, None, None, None,
             )
             .unwrap();
         assert!(!a_results.is_empty());

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1549,6 +1549,8 @@ impl YantrikDB {
             None,  // namespace
             None,  // domain
             None,  // source
+            None,  // certainty_min (#46)
+            None,  // order (#46) — relevance
         )
     }
 
@@ -1577,6 +1579,8 @@ impl YantrikDB {
             None,  // namespace
             domain,
             source,
+            None, // certainty_min (#46)
+            None, // order (#46) — relevance
         )
     }
 }

--- a/crates/yantrikdb-core/src/engine/procedural.rs
+++ b/crates/yantrikdb-core/src/engine/procedural.rs
@@ -46,6 +46,8 @@ impl YantrikDB {
             namespace,
             domain,
             None, // no source filter
+            None, // no certainty_min (#46)
+            None, // default relevance order (#46)
         )
     }
 

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -2,11 +2,44 @@ use std::collections::HashMap;
 
 use rusqlite::params;
 
-use crate::error::Result;
+use crate::error::{Result, YantrikDbError};
 use crate::scoring;
 use crate::types::*;
 
 use super::{now, TextMetadataRow, YantrikDB};
+
+/// Issue #46: how the final `recall()` top_k is ordered after MMR.
+///
+/// - `Relevance` (default): the existing behaviour — sort by composite
+///   relevance score descending. This is what users have always seen.
+/// - `Certainty`: re-sort the top_k by `certainty` descending. Useful for
+///   "give me the most-confident matches first" when downstream consumers
+///   want to weight their reasoning toward high-confidence claims.
+/// - `Recency`: re-sort the top_k by `created_at` descending. Useful for
+///   "what did I write about this recently?" The candidate set is still
+///   the MMR-diverse relevance pool, but presentation is recency-first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecallOrder {
+    Relevance,
+    Certainty,
+    Recency,
+}
+
+/// Parse the `order` string from the engine `recall()` surface. Accepts:
+/// `"relevance"`, `"certainty"`, `"recency"`. `None` and `Some("relevance")`
+/// both map to `Relevance` so the default is stable. Unknown strings
+/// return a typed error so callers see the typo immediately.
+pub(crate) fn parse_recall_order(order: Option<&str>) -> Result<RecallOrder> {
+    match order {
+        None | Some("relevance") => Ok(RecallOrder::Relevance),
+        Some("certainty") => Ok(RecallOrder::Certainty),
+        Some("recency") => Ok(RecallOrder::Recency),
+        Some(other) => Err(YantrikDbError::InvalidInput(format!(
+            "recall: invalid `order` value {other:?}; expected one of \
+             \"relevance\" (default) | \"certainty\" | \"recency\""
+        ))),
+    }
+}
 
 /// Simple English suffix stripping for FTS5 query expansion.
 ///
@@ -141,6 +174,7 @@ impl YantrikDB {
     /// Retrieve memories using multi-signal fusion scoring.
     /// When `expand_entities` is true, graph edges are followed to pull in
     /// entity-connected memories that pure vector search would miss.
+    #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip(self, query_embedding), fields(top_k, expand_entities, namespace))]
     pub fn recall(
         &self,
@@ -155,7 +189,21 @@ impl YantrikDB {
         namespace: Option<&str>,
         domain: Option<&str>,
         source: Option<&str>,
+        // Issue #46: confidence first-class on recall.
+        // `certainty_min` filters out candidates whose `certainty < min`
+        // BEFORE scoring (saves work). `order` re-sorts the final top_k
+        // AFTER MMR diversity selection so callers can request "most
+        // recent matches first" or "most confident matches first" without
+        // the engine abandoning its relevance-based candidate retrieval.
+        // Naming note: engine-internal field stays `certainty`; the param
+        // mirrors that. MCP-layer can re-expose as `confidence_min` /
+        // `confidence` order if it wants the user-facing rename.
+        certainty_min: Option<f64>,
+        order: Option<&str>,
     ) -> Result<Vec<RecallResult>> {
+        // Validate `order` upfront so callers get a clear error rather
+        // than silently falling back to relevance when they typo a value.
+        let recall_order = parse_recall_order(order)?;
         let ts = now();
 
         // Load per-database learned weights (falls back to defaults if none learned yet)
@@ -232,6 +280,16 @@ impl YantrikDB {
                 // Filter: source (V10)
                 if let Some(s) = source {
                     if row.source != s {
+                        continue;
+                    }
+                }
+
+                // Filter: certainty_min (Issue #46). Drop candidates whose
+                // stored certainty falls below the requested floor. Done
+                // before scoring so we don't waste work on rows that won't
+                // make the result set.
+                if let Some(min_cert) = certainty_min {
+                    if row.certainty < min_cert {
                         continue;
                     }
                 }
@@ -1776,6 +1834,30 @@ impl YantrikDB {
             scored.truncate(top_k);
         }
 
+        // Issue #46: optional reorder of the final top_k. Candidate
+        // retrieval + MMR still operate on relevance — we re-sort the
+        // selected diverse set here so the caller-requested presentation
+        // order (most-confident-first, most-recent-first) does not
+        // sacrifice diversity. Default (`Relevance`) leaves the existing
+        // score-desc order untouched.
+        match recall_order {
+            RecallOrder::Relevance => {}
+            RecallOrder::Certainty => {
+                scored.sort_by(|a, b| {
+                    b.certainty
+                        .partial_cmp(&a.certainty)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+            }
+            RecallOrder::Recency => {
+                scored.sort_by(|a, b| {
+                    b.created_at
+                        .partial_cmp(&a.created_at)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+            }
+        }
+
         // Step 5: Hydrate final top_k with text + metadata from SQLite
         let final_rids: Vec<&str> = scored.iter().map(|r| r.rid.as_str()).collect();
         let text_meta = {
@@ -1851,6 +1933,8 @@ impl YantrikDB {
             namespace,
             domain,
             source,
+            None, // certainty_min (#46) — recall_with_seq path defers to caller-side filtering
+            None, // order (#46) — default relevance
         )
     }
 
@@ -1876,6 +1960,8 @@ impl YantrikDB {
             q.namespace.as_deref(),
             q.domain.as_deref(),
             q.source.as_deref(),
+            q.certainty_min,
+            q.order.as_deref(),
         )
     }
 
@@ -1909,6 +1995,8 @@ impl YantrikDB {
             namespace,
             domain,
             source,
+            None, // certainty_min (#46) — recall_with_response defers to caller-side filtering
+            None, // order (#46) — default relevance
         )?;
 
         // Determine which retrieval sources were used

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -2388,7 +2388,7 @@ mod tests {
         let query = vec![0.99_f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let results = db
             .recall(
-                &query, 5, None, None, false, true, None, true, None, None, None,
+                &query, 5, None, None, false, true, None, true, None, None, None, None, None,
             )
             .unwrap();
         assert_eq!(

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -292,6 +292,8 @@ fn test_recall_basic() {
             None,
             None,
             None,
+            None,
+            None,
         )
         .unwrap();
     assert_eq!(results.len(), 2);
@@ -310,6 +312,8 @@ fn test_recall_empty() {
             false,
             None,
             false,
+            None,
+            None,
             None,
             None,
             None,
@@ -2966,17 +2970,17 @@ fn test_recall_deterministic_with_skip_reinforce() {
 
     let r1 = db
         .recall(
-            &query, 5, None, None, false, false, None, true, None, None, None,
+            &query, 5, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     let r2 = db
         .recall(
-            &query, 5, None, None, false, false, None, true, None, None, None,
+            &query, 5, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     let r3 = db
         .recall(
-            &query, 5, None, None, false, false, None, true, None, None, None,
+            &query, 5, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
 
@@ -3032,6 +3036,8 @@ fn test_reinforce_mutates_but_skip_does_not() {
         None,
         None,
         None,
+        None,
+        None,
     )
     .unwrap();
     let after_skip = db.get(&rid).unwrap().unwrap().half_life;
@@ -3047,6 +3053,8 @@ fn test_reinforce_mutates_but_skip_does_not() {
         false,
         None,
         false,
+        None,
+        None,
         None,
         None,
         None,
@@ -3106,6 +3114,8 @@ fn test_graph_expansion_off_no_graph_results() {
             false,
             Some("Alice"),
             false,
+            None,
+            None,
             None,
             None,
             None,
@@ -3169,6 +3179,8 @@ fn test_graph_expansion_on_boosts_connected_memory() {
             true,
             Some("What is Alice working on?"),
             true,
+            None,
+            None,
             None,
             None,
             None,
@@ -3277,6 +3289,8 @@ fn test_recall_scores_bounded() {
             false,
             None,
             true,
+            None,
+            None,
             None,
             None,
             None,
@@ -3391,6 +3405,8 @@ fn test_recall_top_k_respected_with_graph_expansion() {
             true,
             Some("Entity0 topic"),
             true,
+            None,
+            None,
             None,
             None,
             None,
@@ -3618,6 +3634,8 @@ fn test_archive_memory() {
             None,
             None,
             None,
+            None,
+            None,
         )
         .unwrap();
     assert!(
@@ -3659,7 +3677,7 @@ fn test_hydrate_memory() {
     // Should be back in recall
     let results = db
         .recall(
-            &emb, 10, None, None, false, false, None, true, None, None, None,
+            &emb, 10, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     assert!(
@@ -3773,6 +3791,8 @@ fn test_evict() {
             false,
             None,
             true,
+            None,
+            None,
             None,
             None,
             None,
@@ -4089,6 +4109,8 @@ fn test_encrypted_recall_roundtrip() {
             None,
             None,
             None,
+            None,
+            None,
         )
         .unwrap();
     assert_eq!(results.len(), 2);
@@ -4165,7 +4187,7 @@ fn test_encrypted_archive_hydrate() {
     // Should be findable in recall after hydration
     let results = db
         .recall(
-            &emb, 10, None, None, false, false, None, true, None, None, None,
+            &emb, 10, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     assert!(results.iter().any(|r| r.rid == rid));
@@ -4458,6 +4480,8 @@ fn test_domain_filter() {
             None,
             Some("work"),
             None,
+            None,
+            None,
         )
         .unwrap();
     assert_eq!(
@@ -4536,6 +4560,8 @@ fn test_source_filter() {
             None,
             None,
             Some("user"),
+            None,
+            None,
         )
         .unwrap();
     assert_eq!(
@@ -4629,6 +4655,8 @@ fn test_domain_and_source_combined_filter() {
             None,
             Some("work"),
             Some("user"),
+            None,
+            None,
         )
         .unwrap();
     assert_eq!(
@@ -4654,6 +4682,8 @@ fn test_domain_and_source_combined_filter() {
             None,
             Some("health"),
             Some("system"),
+            None,
+            None,
         )
         .unwrap();
     assert_eq!(
@@ -4982,6 +5012,8 @@ fn test_recall_refine_excludes_originals() {
             false,
             None,
             true,
+            None,
+            None,
             None,
             None,
             None,
@@ -7405,6 +7437,8 @@ fn test_insert_vector_makes_recall_find_it() {
             None,
             None,
             None,
+            None,
+            None,
         )
         .unwrap();
 
@@ -7732,7 +7766,7 @@ fn record_with_rid_makes_recall_find_it() {
 
     let results = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     assert!(
@@ -7986,7 +8020,7 @@ fn tombstone_with_rid_hides_from_recall() {
     // Sanity: visible before tombstone.
     let r = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     assert!(r.iter().any(|x| x.rid == rid), "visible before tombstone");
@@ -7997,7 +8031,7 @@ fn tombstone_with_rid_hides_from_recall() {
     // Hidden after.
     let r2 = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     assert!(!r2.iter().any(|x| x.rid == rid), "hidden after tombstone");
@@ -8391,7 +8425,7 @@ fn issue_8_tombstoned_memories_excluded_from_recall() {
     // Sanity: visible before forget.
     let before = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     assert!(
@@ -8404,7 +8438,7 @@ fn issue_8_tombstoned_memories_excluded_from_recall() {
     // After forget, should NOT appear in recall.
     let after = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
         )
         .unwrap();
     assert!(
@@ -8448,7 +8482,7 @@ fn issue_8_tombstoned_persists_across_engine_reopen() {
         let db2 = YantrikDB::new(path_str, 64).unwrap();
         let after = db2
             .recall(
-                &emb, 5, None, None, false, false, None, true, None, None, None,
+                &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
             )
             .unwrap();
         assert!(
@@ -11451,3 +11485,239 @@ fn schema_v29_fresh_install_has_replication_apply_log_table() {
 // Note: replication_apply_log audit-row verification lives in
 // distributed/replication.rs's tests module where materialize_record
 // is in scope. See test_materialize_record_writes_audit_log there.
+
+// ── Issue #46: confidence first-class on recall ───────────────────────
+
+/// Seed a small DB with N records, each carrying a different `certainty`.
+/// The i-th record has `certainty = (i + 1) as f64 / N as f64` (so 1..=N
+/// maps to evenly-spaced certainty in (0, 1.0]). Embeddings are nearly
+/// identical (same `vec_seed(1.0, ...)` shape) so that all candidates
+/// survive the HNSW pass and downstream filtering / re-sorting is the
+/// only thing distinguishing them.
+fn seed_for_certainty_test(db: &YantrikDB, n: usize) -> Vec<String> {
+    let mut rids = Vec::with_capacity(n);
+    for i in 0..n {
+        let certainty = (i as f64 + 1.0) / (n as f64);
+        let rid = db
+            .record(
+                &format!("certainty test memory {i}"),
+                "semantic",
+                0.5,
+                0.0,
+                604800.0,
+                &empty_meta(),
+                &vec_seed(1.0 + (i as f32) * 0.001, 8),
+                "default",
+                certainty,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+        rids.push(rid);
+        // Space out created_at so order=recency has a meaningful ranking.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    rids
+}
+
+#[test]
+fn recall_certainty_min_filters_low_certainty() {
+    // Issue #46: candidates whose certainty falls below the requested
+    // floor must NOT appear in results. Seed 5 memories with certainty
+    // 0.2, 0.4, 0.6, 0.8, 1.0; recall with certainty_min=0.5 must
+    // return at most 3 (the 0.6/0.8/1.0 ones).
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let _rids = seed_for_certainty_test(&db, 5);
+
+    let results = db
+        .recall(
+            &vec_seed(1.0, 8),
+            10,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            Some(0.5), // certainty_min
+            None,
+        )
+        .unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "expected at least one high-certainty result"
+    );
+    for r in &results {
+        assert!(
+            r.certainty >= 0.5,
+            "certainty_min=0.5 must filter out cert={}: rid={}",
+            r.certainty,
+            r.rid
+        );
+    }
+}
+
+#[test]
+fn recall_order_certainty_returns_results_in_certainty_desc() {
+    // Issue #46: order="certainty" must re-sort the final top_k by
+    // certainty descending. Seed 5 memories with varying certainty,
+    // recall all 5 with order="certainty", assert the sequence is
+    // monotonically non-increasing.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let _rids = seed_for_certainty_test(&db, 5);
+
+    let results = db
+        .recall(
+            &vec_seed(1.0, 8),
+            10,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            Some("certainty"),
+        )
+        .unwrap();
+
+    assert!(
+        results.len() >= 2,
+        "need at least 2 results to verify ordering, got {}",
+        results.len()
+    );
+    for w in results.windows(2) {
+        assert!(
+            w[0].certainty >= w[1].certainty,
+            "order=certainty must be non-increasing; got [{}, {}]",
+            w[0].certainty,
+            w[1].certainty,
+        );
+    }
+}
+
+#[test]
+fn recall_order_recency_returns_results_in_created_at_desc() {
+    // Issue #46: order="recency" must re-sort the final top_k by
+    // created_at descending (newest first). The seed helper spaces out
+    // writes by 2ms each so created_at has a strict ordering.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let _rids = seed_for_certainty_test(&db, 5);
+
+    let results = db
+        .recall(
+            &vec_seed(1.0, 8),
+            10,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            Some("recency"),
+        )
+        .unwrap();
+
+    assert!(
+        results.len() >= 2,
+        "need at least 2 results to verify ordering, got {}",
+        results.len()
+    );
+    for w in results.windows(2) {
+        assert!(
+            w[0].created_at >= w[1].created_at,
+            "order=recency must be non-increasing on created_at; got [{}, {}]",
+            w[0].created_at,
+            w[1].created_at,
+        );
+    }
+}
+
+#[test]
+fn recall_order_invalid_string_returns_invalid_input_error() {
+    // Issue #46: unknown `order` values must surface as a typed
+    // InvalidInput error rather than silently falling back to relevance.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let _rids = seed_for_certainty_test(&db, 3);
+
+    let err = db
+        .recall(
+            &vec_seed(1.0, 8),
+            10,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            Some("most_relevant"), // typo / not a valid order
+        )
+        .expect_err("invalid order string must return error");
+
+    match err {
+        crate::error::YantrikDbError::InvalidInput(msg) => {
+            assert!(
+                msg.contains("order") && msg.contains("most_relevant"),
+                "error message should name the bad order value, got: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
+}
+
+#[test]
+fn recall_default_order_is_relevance_unchanged() {
+    // Issue #46: passing None for `order` must NOT change the existing
+    // relevance-based behaviour. The first result's score must be >= the
+    // last result's score (monotone non-increasing on score).
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let _rids = seed_for_certainty_test(&db, 5);
+
+    let results = db
+        .recall(
+            &vec_seed(1.0, 8),
+            10,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            None, // default order = relevance
+        )
+        .unwrap();
+
+    assert!(
+        results.len() >= 2,
+        "need at least 2 results to verify default order, got {}",
+        results.len()
+    );
+    for w in results.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "default order must be score-desc (relevance); got [{}, {}]",
+            w[0].score,
+            w[1].score,
+        );
+    }
+}

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -253,6 +253,8 @@ impl PyYantrikDB {
                 namespace,
                 domain,
                 source,
+                None, // certainty_min (#46)
+                None, // order (#46) — relevance default
             )
             .map_err(map_err)?;
 

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -58,7 +58,8 @@ impl PyYantrikDB {
         .map_err(map_err)
     }
 
-    #[pyo3(signature = (query=None, query_embedding=None, top_k=10, time_window=None, memory_type=None, include_consolidated=false, expand_entities=true, skip_reinforce=false, namespace=None, domain=None, source=None))]
+    #[pyo3(signature = (query=None, query_embedding=None, top_k=10, time_window=None, memory_type=None, include_consolidated=false, expand_entities=true, skip_reinforce=false, namespace=None, domain=None, source=None, certainty_min=None, order=None))]
+    #[allow(clippy::too_many_arguments)]
     fn recall(
         &self,
         py: Python<'_>,
@@ -73,6 +74,11 @@ impl PyYantrikDB {
         namespace: Option<&str>,
         domain: Option<&str>,
         source: Option<&str>,
+        // Issue #46: confidence first-class on recall. `certainty_min`
+        // filters candidates whose `certainty < min`. `order` re-sorts
+        // the final top_k: "relevance" (default) | "certainty" | "recency".
+        certainty_min: Option<f64>,
+        order: Option<&str>,
     ) -> PyResult<Vec<PyObject>> {
         let db = self
             .inner
@@ -104,6 +110,8 @@ impl PyYantrikDB {
                 namespace,
                 domain,
                 source,
+                certainty_min,
+                order,
             )
             .map_err(map_err)?;
 


### PR DESCRIPTION
## Summary

Closes #46. Phase 2 Proposal 4 from the yantrikdb-agi gap analysis.

The engine had `certainty` as a `record()` param and as a field on `RecallResult`, but it was structurally invisible on the recall path — no filter, no sort, no surface to use it. This PR makes it first-class on the read side.

### Engine surface changes

- `recall()` gains two trailing params:
  - `certainty_min: Option<f64>` — filters candidates with `certainty < min` BEFORE scoring (saves work, keeps the result set semantically tight)
  - `order: Option<&str>` — re-sorts the final top_k after MMR. Accepts `\"relevance\"` (default) | `\"certainty\"` | `\"recency\"`. Unknown strings surface as `YantrikDbError::InvalidInput`
- New `RecallOrder` enum + `parse_recall_order()` helper centralise string→enum mapping
- `RecallQuery` builder gains `.certainty_min(f64)` and `.order(&str)`
- Python binding (`memory.rs::recall`) threads both params, defaults to `None`

### Naming decision

Kept `certainty` engine-side to match the existing field. No rename, no schema migration. MCP-server can re-expose as `confidence_min` if it wants the user-facing rename — orthogonal to this PR.

### Order semantics

Candidate retrieval still uses HNSW + MMR diversity. `order` only re-sorts the final selected pool. This means \"most recent matches first\" gets the MMR-diverse relevance pool ordered by recency — NOT \"the K most recent memories regardless of relevance.\" That's the production-honest interpretation; the alternative (replacing HNSW with a recency-first index) was out of scope.

### Test plan

- [x] `recall_certainty_min_filters_low_certainty` — `certainty_min=0.5` drops the cert=0.2/0.4 candidates
- [x] `recall_order_certainty_returns_results_in_certainty_desc` — monotone non-increasing certainty
- [x] `recall_order_recency_returns_results_in_created_at_desc` — monotone non-increasing created_at (2ms sleep between seed writes to space them)
- [x] `recall_order_invalid_string_returns_invalid_input_error` — typo'd order surfaces as `InvalidInput` with the bad value in the message
- [x] `recall_default_order_is_relevance_unchanged` — `None` preserves existing score-desc ordering (back-compat guarantee)
- [x] **Full lib sweep: 1502/1502 tests pass locally**
- [x] `cargo fmt --check --all` clean
- [x] No external behaviour change for any existing caller (additive `Option<>` params, defaults match prior behavior)

### Pre-registered impact (from yantrikdb-agi Phase 2)

> \"Enables calibration tracking: over the last week, my predictions at confidence 0.7 had what actual accuracy? Improves recall ranking: high-confidence records should rank above low-confidence ones for the same query. Enables the consolidation pass to distinguish: 'this is a confident claim' vs 'this is speculation'.\"

### Scope discipline

- Engine + Python binding only. No MCP-server changes (server's call whether to re-expose as `confidence_min`).
- No schema migration. `certainty` field has always been on memory rows.
- No version bump. v0.7.20 charter will batch this with #45 / #47 / #48 once those land.

### Files changed

```
crates/yantrikdb-core/src/base/types.rs              | +2 fields on RecallQuery + 2 builder methods
crates/yantrikdb-core/src/distributed/sync.rs        | call site cascade
crates/yantrikdb-core/src/engine/mod.rs              | call site cascade (recall_text, recall_text_filtered)
crates/yantrikdb-core/src/engine/procedural.rs       | call site cascade
crates/yantrikdb-core/src/engine/recall.rs           | signature + filter + order sort + RecallOrder enum
crates/yantrikdb-core/src/engine/reembed.rs          | call site cascade
crates/yantrikdb-core/src/engine/tests.rs            | 5 new tests + ~28 call site cascades
crates/yantrikdb-python/src/py_engine/memory.rs      | binding signature update
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)