### PR TITLE
feat(links): record-to-record link substrate — schema v31 + write/traverse API (#48 part 1/3)

### DIFF
--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -1,4 +1,4 @@
-pub const SCHEMA_VERSION: i32 = 30;
+pub const SCHEMA_VERSION: i32 = 31;
 
 pub const SCHEMA_SQL: &str = "
 -- Memory records: the source of truth
@@ -724,6 +724,29 @@ CREATE TABLE IF NOT EXISTS record_revisions (
 );
 CREATE INDEX IF NOT EXISTS idx_record_revisions_rid
     ON record_revisions(rid, revision_num);
+
+-- v31 (issue #48): record_links — first-class record-to-record links.
+-- Distinct from the entity graph (`claims`): rid-specific semantics, a
+-- small closed set of link_types, and a forget()-aware lifecycle status.
+-- Atomic with the write via record_with_links(). See
+-- docs/record_link_model_rfc.md. Column order/naming deliberately mirror
+-- a future typed graph_edges row so this can fold into a unified graph
+-- later without a semantic rewrite.
+CREATE TABLE IF NOT EXISTS record_links (
+    link_id        TEXT PRIMARY KEY,
+    source_rid     TEXT NOT NULL,
+    target_rid     TEXT NOT NULL,
+    link_type      TEXT NOT NULL,
+    status         TEXT NOT NULL DEFAULT 'active',
+    created_at     REAL NOT NULL,
+    hlc            BLOB NOT NULL,
+    origin_actor   TEXT NOT NULL,
+    UNIQUE(source_rid, target_rid, link_type)
+);
+CREATE INDEX IF NOT EXISTS idx_record_links_source
+    ON record_links(source_rid, link_type, status);
+CREATE INDEX IF NOT EXISTS idx_record_links_target
+    ON record_links(target_rid, link_type, status);
 
 -- Peer tracking for delta sync
 CREATE TABLE IF NOT EXISTS sync_peers (
@@ -2239,4 +2262,31 @@ CREATE TABLE IF NOT EXISTS record_revisions (
 );
 CREATE INDEX IF NOT EXISTS idx_record_revisions_rid
     ON record_revisions(rid, revision_num);
+";
+
+// **Issue #48 — first-class record-to-record links (v0.8.0).**
+//
+// `record_links` is a dedicated table (NOT a reuse of `claims`) so
+// record-to-record relations get rid-specific semantics without
+// polluting the entity graph with phantom `unknown`-typed entity rows
+// (see RFC §"Considered alternatives"). The migration only creates the
+// table + indexes; the metadata.supersedes reification runs in Rust at
+// migration time (it needs the engine HLC clock — pure SQL can't stamp
+// a real HLC). See engine/mod.rs migration registration.
+pub const MIGRATE_V30_TO_V31: &str = "
+CREATE TABLE IF NOT EXISTS record_links (
+    link_id        TEXT PRIMARY KEY,
+    source_rid     TEXT NOT NULL,
+    target_rid     TEXT NOT NULL,
+    link_type      TEXT NOT NULL,
+    status         TEXT NOT NULL DEFAULT 'active',
+    created_at     REAL NOT NULL,
+    hlc            BLOB NOT NULL,
+    origin_actor   TEXT NOT NULL,
+    UNIQUE(source_rid, target_rid, link_type)
+);
+CREATE INDEX IF NOT EXISTS idx_record_links_source
+    ON record_links(source_rid, link_type, status);
+CREATE INDEX IF NOT EXISTS idx_record_links_target
+    ON record_links(target_rid, link_type, status);
 ";

--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -2264,7 +2264,7 @@ CREATE INDEX IF NOT EXISTS idx_record_revisions_rid
     ON record_revisions(rid, revision_num);
 ";
 
-// **Issue #48 — first-class record-to-record links (v0.8.0).**
+// **Issue #48 — first-class record-to-record links (schema v31).**
 //
 // `record_links` is a dedicated table (NOT a reuse of `claims`) so
 // record-to-record relations get rid-specific semantics without

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -402,6 +402,154 @@ pub struct RecordRevision {
     pub origin_actor: String,
 }
 
+// ── Issue #48 — record-to-record link model (v0.8.0) ──
+
+/// Closed set of record-to-record link types + a `Custom` escape hatch.
+///
+/// See docs/record_link_model_rfc.md. The recall-time proximity polarity
+/// (whether surfacing one endpoint should boost or demote the other) is a
+/// pure function of the variant — see [`LinkType::recall_polarity`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkType {
+    /// This record builds on / improves the target (newer is better).
+    Advances,
+    /// This record replaces the target. Does NOT auto-tombstone the
+    /// target (semantic claim, not a lifecycle action). Recall demotes
+    /// the superseded predecessor.
+    Supersedes,
+    /// This record disagrees with the target. Quasi-symmetric — queried
+    /// bidirectionally.
+    Contradicts,
+    /// This record provides evidence for the target.
+    Supports,
+    /// This record raises a question about the target.
+    Questions,
+    /// This record was derived from / inspired by the target (provenance,
+    /// no correctness claim — distinct from Advances).
+    DerivedFrom,
+    /// Extensibility hatch. Stored as `custom:<name>`; engine does not
+    /// interpret the name (treated as a weak positive at recall time).
+    Custom(String),
+}
+
+/// How a link affects recall when traversing from one endpoint to the
+/// other. Multiplier applied to the graph-proximity contribution of the
+/// linked record; <1.0 demotes, >0 with <1 dampens, 1.0 is neutral-positive.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LinkRecallPolarity {
+    /// Multiplier for the LINKED (target/other-endpoint) record's
+    /// proximity contribution.
+    pub neighbor_factor: f64,
+    /// Multiplier applied to the SEED record's own score when it is the
+    /// target of this link type (used by Supersedes to demote a
+    /// superseded predecessor). 1.0 = no self-demotion.
+    pub demote_self_as_target: f64,
+}
+
+impl LinkType {
+    /// Serialize to the canonical string stored in `record_links.link_type`.
+    pub fn as_str(&self) -> String {
+        match self {
+            LinkType::Advances => "advances".to_string(),
+            LinkType::Supersedes => "supersedes".to_string(),
+            LinkType::Contradicts => "contradicts".to_string(),
+            LinkType::Supports => "supports".to_string(),
+            LinkType::Questions => "questions".to_string(),
+            LinkType::DerivedFrom => "derived_from".to_string(),
+            LinkType::Custom(name) => format!("custom:{name}"),
+        }
+    }
+
+    /// Parse from the stored string. `custom:<name>` round-trips to
+    /// `Custom(name)`; any other unrecognized string also becomes
+    /// `Custom(...)` so forward-compat strings from a newer node don't
+    /// hard-error on an older one.
+    pub fn from_str_lenient(s: &str) -> LinkType {
+        match s {
+            "advances" => LinkType::Advances,
+            "supersedes" => LinkType::Supersedes,
+            "contradicts" => LinkType::Contradicts,
+            "supports" => LinkType::Supports,
+            "questions" => LinkType::Questions,
+            "derived_from" => LinkType::DerivedFrom,
+            other => {
+                let name = other.strip_prefix("custom:").unwrap_or(other);
+                LinkType::Custom(name.to_string())
+            }
+        }
+    }
+
+    /// Whether this link type is treated as undirected at traversal /
+    /// recall time. Only `Contradicts` is symmetric.
+    pub fn is_symmetric(&self) -> bool {
+        matches!(self, LinkType::Contradicts)
+    }
+
+    /// Recall-time polarity. Pure function of the variant. See the
+    /// relation-aware-scoring table in the RFC.
+    pub fn recall_polarity(&self) -> LinkRecallPolarity {
+        match self {
+            // Positive: pull the neighbor in at full proximity.
+            LinkType::Supports | LinkType::Advances => LinkRecallPolarity {
+                neighbor_factor: 1.0,
+                demote_self_as_target: 1.0,
+            },
+            // Provenance: weaker positive.
+            LinkType::DerivedFrom => LinkRecallPolarity {
+                neighbor_factor: 0.6,
+                demote_self_as_target: 1.0,
+            },
+            // Supersedes: boost the successor (neighbor) AND demote the
+            // superseded predecessor when IT is the surfaced record.
+            LinkType::Supersedes => LinkRecallPolarity {
+                neighbor_factor: 1.0,
+                demote_self_as_target: 0.5,
+            },
+            // Relevant-but-not-endorsing: surface the contradictor so the
+            // caller sees the conflict, but no positive relevance halo.
+            LinkType::Contradicts => LinkRecallPolarity {
+                neighbor_factor: 0.3,
+                demote_self_as_target: 1.0,
+            },
+            // Weak relevance / uncertainty.
+            LinkType::Questions => LinkRecallPolarity {
+                neighbor_factor: 0.3,
+                demote_self_as_target: 1.0,
+            },
+            // Engine doesn't interpret custom — weak positive.
+            LinkType::Custom(_) => LinkRecallPolarity {
+                neighbor_factor: 0.5,
+                demote_self_as_target: 1.0,
+            },
+        }
+    }
+}
+
+/// A record-to-record link to create alongside (or after) a record write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordLink {
+    pub target_rid: String,
+    pub link_type: LinkType,
+}
+
+/// Direction filter for [`YantrikDB::linked_records`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkDirection {
+    Outbound,
+    Inbound,
+    Both,
+}
+
+/// A single result from a `linked_records` traversal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinkedRecord {
+    pub rid: String,
+    pub link_type: String,
+    pub created_at: f64,
+    /// "outbound" or "inbound" relative to the queried rid.
+    pub direction: String,
+}
+
 // ── Cognition types (V3) ──
 
 /// Trigger type classification.

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -402,7 +402,7 @@ pub struct RecordRevision {
     pub origin_actor: String,
 }
 
-// ── Issue #48 — record-to-record link model (v0.8.0) ──
+// ── Issue #48 — record-to-record link model (schema v31) ──
 
 /// Closed set of record-to-record link types + a `Custom` escape hatch.
 ///

--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -441,6 +441,13 @@ fn materialize_op(db: &YantrikDB, op: &OplogEntry) -> Result<()> {
         "pattern_upsert" => {
             materialize_pattern(&*db.conn(), &op.payload, &op.hlc, &op.origin_actor)?
         }
+        // **Issue #48 — record-to-record links.**
+        "link" => {
+            materialize_link(&*db.conn(), &op.payload, &op.hlc, &op.origin_actor)?;
+        }
+        "unlink" => {
+            materialize_unlink(&*db.conn(), &op.payload)?;
+        }
         "reinforce" | "think" => {
             // Local-only ops; skip during replication
         }
@@ -562,6 +569,19 @@ fn materialize_forget(conn: &Connection, payload: &serde_json::Value) -> Result<
     conn.execute(
         "UPDATE memories SET consolidation_status = 'tombstoned', updated_at = ?1 WHERE rid = ?2",
         params![updated_at, rid],
+    )?;
+
+    // **Issue #48.** Replay the link-status transition the leader applied
+    // in tombstone_inner so followers' record_links stay in lockstep.
+    conn.execute(
+        "UPDATE record_links SET status = 'broken_source_forgotten' \
+         WHERE source_rid = ?1 AND status = 'active'",
+        params![rid],
+    )?;
+    conn.execute(
+        "UPDATE record_links SET status = 'broken_target_forgotten' \
+         WHERE target_rid = ?1 AND status = 'active'",
+        params![rid],
     )?;
 
     // HNSW vec index removal is handled by the materialize_op dispatcher
@@ -891,6 +911,70 @@ fn materialize_correct(
         params![rid, source_actor, applied_at],
     );
 
+    Ok(())
+}
+
+/// Materialize a "link" op (Issue #48) on a replica. Idempotent via the
+/// UNIQUE(source_rid, target_rid, link_type) constraint + INSERT OR
+/// IGNORE — re-applying the same link op across re-syncs is a no-op. The
+/// leader's HLC is carried on the op and stored verbatim so the
+/// follower's link row sorts identically in any HLC-ordered scan.
+fn materialize_link(
+    conn: &Connection,
+    payload: &serde_json::Value,
+    hlc: &[u8],
+    source_actor: &str,
+) -> Result<()> {
+    let source_rid = payload["source_rid"].as_str().unwrap_or_default();
+    let target_rid = payload["target_rid"].as_str().unwrap_or_default();
+    let link_type = payload["link_type"].as_str().unwrap_or_default();
+    if source_rid.is_empty() || target_rid.is_empty() || link_type.is_empty() {
+        return Ok(());
+    }
+    let created_at = payload["created_at"]
+        .as_f64()
+        .unwrap_or_else(crate::time::now_secs);
+    let link_id = crate::id::new_id();
+
+    conn.execute(
+        "INSERT OR IGNORE INTO record_links \
+         (link_id, source_rid, target_rid, link_type, status, created_at, hlc, origin_actor) \
+         VALUES (?1, ?2, ?3, ?4, 'active', ?5, ?6, ?7)",
+        params![
+            link_id,
+            source_rid,
+            target_rid,
+            link_type,
+            created_at,
+            hlc,
+            source_actor
+        ],
+    )?;
+
+    let applied_at = crate::time::now_secs();
+    let _ = conn.execute(
+        "INSERT OR IGNORE INTO replication_apply_log (rid, op_type, source_actor, applied_at) \
+         VALUES (?1, 'link', ?2, ?3)",
+        params![source_rid, source_actor, applied_at],
+    );
+
+    Ok(())
+}
+
+/// Materialize an "unlink" op (Issue #48) on a replica. A user
+/// retraction — hard-deletes the matching active/broken row.
+fn materialize_unlink(conn: &Connection, payload: &serde_json::Value) -> Result<()> {
+    let source_rid = payload["source_rid"].as_str().unwrap_or_default();
+    let target_rid = payload["target_rid"].as_str().unwrap_or_default();
+    let link_type = payload["link_type"].as_str().unwrap_or_default();
+    if source_rid.is_empty() || target_rid.is_empty() || link_type.is_empty() {
+        return Ok(());
+    }
+    conn.execute(
+        "DELETE FROM record_links \
+         WHERE source_rid = ?1 AND target_rid = ?2 AND link_type = ?3",
+        params![source_rid, target_rid, link_type],
+    )?;
     Ok(())
 }
 

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -351,6 +351,29 @@ impl YantrikDB {
         if was_newly_tombstoned {
             self.graph_index.write().unlink_memory(rid);
             self.cache_remove(rid);
+
+            // **Issue #48.** Mark record_links touching this rid as broken
+            // rather than deleting them — the audit trail (this link
+            // existed before the endpoint was forgotten) is retained, and
+            // traversal/recall filter on status='active'. Outbound links
+            // from the forgotten rid => broken_source_forgotten; inbound
+            // links to it => broken_target_forgotten. No oplog op is
+            // emitted: the existing 'forget' op replays this same status
+            // transition on followers via the deterministic SQL below.
+            {
+                let conn = self.conn();
+                conn.execute(
+                    "UPDATE record_links SET status = 'broken_source_forgotten' \
+                     WHERE source_rid = ?1 AND status = 'active'",
+                    params![rid],
+                )?;
+                conn.execute(
+                    "UPDATE record_links SET status = 'broken_target_forgotten' \
+                     WHERE target_rid = ?1 AND status = 'active'",
+                    params![rid],
+                )?;
+            }
+
             self.log_op(
                 "forget",
                 Some(rid),

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -1,4 +1,4 @@
-//! Issue #48 — first-class record-to-record links (v0.8.0).
+//! Issue #48 — first-class record-to-record links (schema v31, 0.7.x series).
 //!
 //! Record links live in their own `record_links` table, distinct from the
 //! entity graph (`claims`), so rids don't pollute the entity classifier
@@ -179,7 +179,7 @@ impl YantrikDB {
     /// for free. `origin_actor` is the calling node's actor (a real
     /// owner) rather than a synthetic 'migration_v31' tag — which is more
     /// correct for replication. Operators run this once during the
-    /// v0.8.0 upgrade. Idempotent: safe to run repeatedly.
+    /// schema-v31 upgrade. Idempotent: safe to run repeatedly.
     ///
     /// Reads metadata via the decrypt path so it works on encrypted DBs.
     pub fn reify_supersedes_links(&self) -> Result<usize> {

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -1,0 +1,632 @@
+//! Issue #48 — first-class record-to-record links (v0.8.0).
+//!
+//! Record links live in their own `record_links` table, distinct from the
+//! entity graph (`claims`), so rids don't pollute the entity classifier
+//! (see RFC §"Considered alternatives"). This module owns the write +
+//! traversal API: [`YantrikDB::record_with_links`],
+//! [`YantrikDB::link`], [`YantrikDB::unlink`],
+//! [`YantrikDB::linked_records`].
+//!
+//! **Atomicity boundary (honest).** The engine's `record()` is decoupled
+//! (oplog → materializer), so there is no single SQLite transaction that
+//! spans "the memories row + the links." `record_with_links` therefore
+//! commits the record first (durable via the oplog), then inserts each
+//! link via [`YantrikDB::link`], which is itself durable + idempotent.
+//! The only non-atomic window is "record committed, a subsequent link
+//! insert failed" — recoverable by re-calling `link()` (idempotent on the
+//! UNIQUE(source_rid, target_rid, link_type) constraint). This is the
+//! same shape as the rest of the decoupled write path and is documented
+//! rather than overclaimed.
+//!
+//! **Replication.** Each link emits a standalone `link` oplog op (and
+//! `unlink` emits `unlink`). They replicate independently and apply
+//! idempotently via `INSERT OR IGNORE`. This is simpler than threading a
+//! links-array through the `record` op payload and is equally correct.
+
+use rusqlite::params;
+
+use crate::error::{Result, YantrikDbError};
+use crate::types::{LinkDirection, LinkType, LinkedRecord, RecordLink};
+
+use super::{now, YantrikDB};
+
+impl YantrikDB {
+    /// Record a memory and atomically(-ish; see module docs) attach
+    /// record-to-record links. `record()`'s signature is intentionally
+    /// left unchanged (100+ call sites); this is the link-aware entry
+    /// point. Callers with no links should just use `record()`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_with_links(
+        &self,
+        text: &str,
+        memory_type: &str,
+        importance: f64,
+        valence: f64,
+        half_life: f64,
+        metadata: &serde_json::Value,
+        embedding: &[f32],
+        namespace: &str,
+        certainty: f64,
+        domain: &str,
+        source: &str,
+        emotional_state: Option<&str>,
+        links: &[RecordLink],
+    ) -> Result<String> {
+        let rid = self.record(
+            text,
+            memory_type,
+            importance,
+            valence,
+            half_life,
+            metadata,
+            embedding,
+            namespace,
+            certainty,
+            domain,
+            source,
+            emotional_state,
+        )?;
+        for link in links {
+            self.link(&rid, link)?;
+        }
+        Ok(rid)
+    }
+
+    /// Add a single record-to-record link from `source_rid`.
+    ///
+    /// Validates: `source_rid` non-empty, `target_rid` non-empty, and
+    /// `source_rid != target_rid` (a record cannot link to itself).
+    /// Idempotent on `UNIQUE(source_rid, target_rid, link_type)` via
+    /// `INSERT OR IGNORE`. Returns the `link_id` (freshly minted even if
+    /// the row already existed and the insert was ignored).
+    pub fn link(&self, source_rid: &str, link: &RecordLink) -> Result<String> {
+        if source_rid.is_empty() {
+            return Err(YantrikDbError::InvalidInput(
+                "link: source_rid must be non-empty".to_string(),
+            ));
+        }
+        if link.target_rid.is_empty() {
+            return Err(YantrikDbError::InvalidInput(
+                "link: target_rid must be non-empty".to_string(),
+            ));
+        }
+        if source_rid == link.target_rid {
+            return Err(YantrikDbError::InvalidInput(
+                "link: a record cannot link to itself".to_string(),
+            ));
+        }
+
+        let link_id = crate::id::new_id();
+        let link_type_str = link.link_type.as_str();
+        let ts = now();
+        let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
+
+        {
+            let conn = self.conn.lock();
+            conn.execute(
+                "INSERT OR IGNORE INTO record_links \
+                 (link_id, source_rid, target_rid, link_type, status, \
+                  created_at, hlc, origin_actor) \
+                 VALUES (?1, ?2, ?3, ?4, 'active', ?5, ?6, ?7)",
+                params![
+                    link_id,
+                    source_rid,
+                    link.target_rid,
+                    link_type_str,
+                    ts,
+                    hlc_bytes,
+                    self.actor_id,
+                ],
+            )?;
+        }
+
+        self.log_op(
+            "link",
+            Some(source_rid),
+            &serde_json::json!({
+                "source_rid": source_rid,
+                "target_rid": link.target_rid,
+                "link_type": link_type_str,
+                "created_at": ts,
+            }),
+            None,
+        )?;
+
+        Ok(link_id)
+    }
+
+    /// Remove a single link. Returns `true` if a row was deleted.
+    ///
+    /// Unlike `forget()` (which marks links broken for audit), explicit
+    /// `unlink()` is a user retraction and hard-deletes the row.
+    pub fn unlink(&self, source_rid: &str, target_rid: &str, link_type: &LinkType) -> Result<bool> {
+        let link_type_str = link_type.as_str();
+        let deleted = {
+            let conn = self.conn.lock();
+            conn.execute(
+                "DELETE FROM record_links \
+                 WHERE source_rid = ?1 AND target_rid = ?2 AND link_type = ?3",
+                params![source_rid, target_rid, link_type_str],
+            )?
+        };
+
+        if deleted > 0 {
+            self.log_op(
+                "unlink",
+                Some(source_rid),
+                &serde_json::json!({
+                    "source_rid": source_rid,
+                    "target_rid": target_rid,
+                    "link_type": link_type_str,
+                }),
+                None,
+            )?;
+        }
+
+        Ok(deleted > 0)
+    }
+
+    /// Issue #48 — one-shot reification of the legacy
+    /// `metadata.supersedes = "<rid>"` string convention into proper
+    /// `Supersedes` record links. Returns the number of links created.
+    ///
+    /// **Why this is an explicit method, not an auto-migration in
+    /// `new()`:** auto-running a data migration that emits oplog ops on
+    /// every engine open is an idempotency hazard, and `new()`'s struct
+    /// construction is not a clean place to thread the HLC clock. Calling
+    /// `self.link()` per row gives a correct `tick_hlc()` HLC + a
+    /// replicating `link` op + idempotency (UNIQUE → INSERT OR IGNORE)
+    /// for free. `origin_actor` is the calling node's actor (a real
+    /// owner) rather than a synthetic 'migration_v31' tag — which is more
+    /// correct for replication. Operators run this once during the
+    /// v0.8.0 upgrade. Idempotent: safe to run repeatedly.
+    ///
+    /// Reads metadata via the decrypt path so it works on encrypted DBs.
+    pub fn reify_supersedes_links(&self) -> Result<usize> {
+        // Pull rid + stored (possibly encrypted) metadata for all active
+        // memories. We decrypt + JSON-parse in Rust rather than relying on
+        // SQLite json_extract, which can't see through encrypted metadata.
+        let rows: Vec<(String, String)> = {
+            let conn = self.conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT rid, metadata FROM memories \
+                 WHERE consolidation_status = 'active'",
+            )?;
+            let mapped = stmt.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            mapped.collect::<std::result::Result<Vec<_>, _>>()?
+        };
+
+        let mut created = 0usize;
+        for (rid, stored_meta) in rows {
+            let meta_str = self.decrypt_text(&stored_meta)?;
+            let Ok(meta) = serde_json::from_str::<serde_json::Value>(&meta_str) else {
+                continue;
+            };
+            let Some(target) = meta.get("supersedes").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            if target.is_empty() || target == rid {
+                continue;
+            }
+            // link() is idempotent on UNIQUE(source,target,type); a
+            // re-run simply INSERT OR IGNOREs. Count only fresh inserts by
+            // checking row presence before/after would be racy under the
+            // lock churn; instead we count attempts that didn't error.
+            self.link(
+                &rid,
+                &RecordLink {
+                    target_rid: target.to_string(),
+                    link_type: LinkType::Supersedes,
+                },
+            )?;
+            created += 1;
+        }
+        Ok(created)
+    }
+
+    /// Traverse links from `rid`. Only `status='active'` links are
+    /// returned. For `Contradicts` (symmetric), `Outbound` and `Inbound`
+    /// both surface the partner; otherwise direction is literal.
+    ///
+    /// `link_type=None` returns all types.
+    pub fn linked_records(
+        &self,
+        rid: &str,
+        direction: LinkDirection,
+        link_type: Option<&LinkType>,
+    ) -> Result<Vec<LinkedRecord>> {
+        let type_filter = link_type.map(|lt| lt.as_str());
+        let mut out: Vec<LinkedRecord> = Vec::new();
+        let conn = self.conn.lock();
+
+        // Outbound: rid is source → return target as the linked record.
+        if matches!(direction, LinkDirection::Outbound | LinkDirection::Both) {
+            let mut stmt = conn.prepare(
+                "SELECT target_rid, link_type, created_at FROM record_links \
+                 WHERE source_rid = ?1 AND status = 'active' \
+                 AND (?2 IS NULL OR link_type = ?2) \
+                 ORDER BY created_at ASC",
+            )?;
+            let rows = stmt.query_map(params![rid, type_filter], |row| {
+                Ok(LinkedRecord {
+                    rid: row.get::<_, String>(0)?,
+                    link_type: row.get::<_, String>(1)?,
+                    created_at: row.get::<_, f64>(2)?,
+                    direction: "outbound".to_string(),
+                })
+            })?;
+            for r in rows {
+                out.push(r?);
+            }
+        }
+
+        // Inbound: rid is target → return source as the linked record.
+        if matches!(direction, LinkDirection::Inbound | LinkDirection::Both) {
+            let mut stmt = conn.prepare(
+                "SELECT source_rid, link_type, created_at FROM record_links \
+                 WHERE target_rid = ?1 AND status = 'active' \
+                 AND (?2 IS NULL OR link_type = ?2) \
+                 ORDER BY created_at ASC",
+            )?;
+            let rows = stmt.query_map(params![rid, type_filter], |row| {
+                Ok(LinkedRecord {
+                    rid: row.get::<_, String>(0)?,
+                    link_type: row.get::<_, String>(1)?,
+                    created_at: row.get::<_, f64>(2)?,
+                    direction: "inbound".to_string(),
+                })
+            })?;
+            for r in rows {
+                out.push(r?);
+            }
+        }
+
+        // Symmetric link types (Contradicts): when querying one
+        // direction, also surface the partner from the OTHER direction so
+        // "A contradicts B" is visible from both A and B regardless of
+        // which way the row was stored. Only do this when not already
+        // querying Both (which covers both directions anyway).
+        if !matches!(direction, LinkDirection::Both) {
+            let want_symmetric = match link_type {
+                Some(lt) => lt.is_symmetric(),
+                None => true, // unfiltered: include symmetric partners
+            };
+            if want_symmetric {
+                let (col_match, col_return, dir_label) = match direction {
+                    LinkDirection::Outbound => ("target_rid", "source_rid", "inbound"),
+                    LinkDirection::Inbound => ("source_rid", "target_rid", "outbound"),
+                    LinkDirection::Both => unreachable!(),
+                };
+                let sql = format!(
+                    "SELECT {col_return}, link_type, created_at FROM record_links \
+                     WHERE {col_match} = ?1 AND status = 'active' \
+                     AND link_type = 'contradicts' \
+                     AND (?2 IS NULL OR link_type = ?2) \
+                     ORDER BY created_at ASC"
+                );
+                let mut stmt = conn.prepare(&sql)?;
+                let rows = stmt.query_map(params![rid, type_filter], |row| {
+                    Ok(LinkedRecord {
+                        rid: row.get::<_, String>(0)?,
+                        link_type: row.get::<_, String>(1)?,
+                        created_at: row.get::<_, f64>(2)?,
+                        direction: dir_label.to_string(),
+                    })
+                })?;
+                for r in rows {
+                    out.push(r?);
+                }
+            }
+        }
+
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::YantrikDB;
+
+    fn vec_seed(seed: f32, dim: usize) -> Vec<f32> {
+        let raw: Vec<f32> = (0..dim).map(|i| (seed + i as f32) * 0.1).collect();
+        let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+        raw.iter().map(|x| x / norm).collect()
+    }
+
+    fn rec(db: &YantrikDB, text: &str, seed: f32) -> String {
+        db.record(
+            text,
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({}),
+            &vec_seed(seed, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn record_with_links_creates_links_atomically() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let b = rec(&db, "target", 1.0);
+        let c = rec(&db, "another", 2.0);
+        let a = db
+            .record_with_links(
+                "source",
+                "semantic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(3.0, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+                &[
+                    RecordLink {
+                        target_rid: b.clone(),
+                        link_type: LinkType::Supersedes,
+                    },
+                    RecordLink {
+                        target_rid: c.clone(),
+                        link_type: LinkType::Supports,
+                    },
+                ],
+            )
+            .unwrap();
+
+        let out = db
+            .linked_records(&a, LinkDirection::Outbound, None)
+            .unwrap();
+        assert_eq!(out.len(), 2);
+        assert!(out
+            .iter()
+            .any(|l| l.rid == b && l.link_type == "supersedes"));
+        assert!(out.iter().any(|l| l.rid == c && l.link_type == "supports"));
+    }
+
+    #[test]
+    fn link_is_idempotent_on_unique() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "a", 1.0);
+        let b = rec(&db, "b", 2.0);
+        let link = RecordLink {
+            target_rid: b.clone(),
+            link_type: LinkType::Advances,
+        };
+        db.link(&a, &link).unwrap();
+        db.link(&a, &link).unwrap(); // second is INSERT OR IGNORE no-op
+        let out = db
+            .linked_records(&a, LinkDirection::Outbound, None)
+            .unwrap();
+        assert_eq!(out.len(), 1, "duplicate link must not create a second row");
+    }
+
+    #[test]
+    fn link_rejects_self_and_empty() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "a", 1.0);
+        assert!(db
+            .link(
+                &a,
+                &RecordLink {
+                    target_rid: a.clone(),
+                    link_type: LinkType::Advances
+                }
+            )
+            .is_err());
+        assert!(db
+            .link(
+                &a,
+                &RecordLink {
+                    target_rid: String::new(),
+                    link_type: LinkType::Advances
+                }
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn unlink_removes_and_reports() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "a", 1.0);
+        let b = rec(&db, "b", 2.0);
+        db.link(
+            &a,
+            &RecordLink {
+                target_rid: b.clone(),
+                link_type: LinkType::Supports,
+            },
+        )
+        .unwrap();
+        assert!(db.unlink(&a, &b, &LinkType::Supports).unwrap());
+        assert!(
+            !db.unlink(&a, &b, &LinkType::Supports).unwrap(),
+            "second unlink is a no-op"
+        );
+        assert!(db
+            .linked_records(&a, LinkDirection::Outbound, None)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn linked_records_inbound_and_typed_filter() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "a", 1.0);
+        let b = rec(&db, "b", 2.0);
+        db.link(
+            &a,
+            &RecordLink {
+                target_rid: b.clone(),
+                link_type: LinkType::Supersedes,
+            },
+        )
+        .unwrap();
+        // Inbound on b finds a.
+        let inbound = db.linked_records(&b, LinkDirection::Inbound, None).unwrap();
+        assert_eq!(inbound.len(), 1);
+        assert_eq!(inbound[0].rid, a);
+        assert_eq!(inbound[0].direction, "inbound");
+        // Typed filter that doesn't match returns empty.
+        let none = db
+            .linked_records(&b, LinkDirection::Inbound, Some(&LinkType::Supports))
+            .unwrap();
+        assert!(none.is_empty());
+    }
+
+    #[test]
+    fn contradicts_is_bidirectional() {
+        // A contradicts B (stored A->B). Querying from B must surface A
+        // even though B is the target, because contradicts is symmetric.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "a", 1.0);
+        let b = rec(&db, "b", 2.0);
+        db.link(
+            &a,
+            &RecordLink {
+                target_rid: b.clone(),
+                link_type: LinkType::Contradicts,
+            },
+        )
+        .unwrap();
+
+        let from_b = db
+            .linked_records(&b, LinkDirection::Outbound, Some(&LinkType::Contradicts))
+            .unwrap();
+        assert!(
+            from_b.iter().any(|l| l.rid == a),
+            "contradicts must be visible from the target endpoint too, got {from_b:?}"
+        );
+    }
+
+    #[test]
+    fn forget_marks_links_broken_not_deleted() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "a", 1.0);
+        let b = rec(&db, "b", 2.0);
+        db.link(
+            &a,
+            &RecordLink {
+                target_rid: b.clone(),
+                link_type: LinkType::Supports,
+            },
+        )
+        .unwrap();
+
+        db.forget(&a).unwrap();
+
+        // Active traversal no longer returns it.
+        assert!(db
+            .linked_records(&a, LinkDirection::Outbound, None)
+            .unwrap()
+            .is_empty());
+        // But the row is retained with a broken status (audit trail).
+        let conn = db.conn();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM record_links WHERE source_rid = ?1 AND target_rid = ?2",
+                rusqlite::params![a, b],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "broken_source_forgotten");
+    }
+
+    #[test]
+    fn correct_preserves_links_via_rid_stability() {
+        // v0.7.20 correct() mutates in place (rid preserved), so links
+        // keyed on rid survive a correction with no special handling.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "a v0", 1.0);
+        let b = rec(&db, "b", 2.0);
+        db.link(
+            &a,
+            &RecordLink {
+                target_rid: b.clone(),
+                link_type: LinkType::Advances,
+            },
+        )
+        .unwrap();
+        db.correct(&a, Some("a v1"), None, None, None, "fix")
+            .unwrap();
+        let out = db
+            .linked_records(&a, LinkDirection::Outbound, None)
+            .unwrap();
+        assert_eq!(
+            out.len(),
+            1,
+            "links survive in-place correction (rid preserved)"
+        );
+        assert_eq!(out[0].rid, b);
+    }
+
+    #[test]
+    fn reify_supersedes_links_from_metadata() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let old = rec(&db, "old wonder", 1.0);
+        // New record carries the legacy metadata.supersedes string.
+        let new = db
+            .record(
+                "new wonder",
+                "semantic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({ "supersedes": old }),
+                &vec_seed(2.0, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+
+        let n = db.reify_supersedes_links().unwrap();
+        assert_eq!(n, 1, "one supersedes link reified");
+        let out = db
+            .linked_records(&new, LinkDirection::Outbound, Some(&LinkType::Supersedes))
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].rid, old);
+
+        // Idempotent: re-running doesn't duplicate.
+        db.reify_supersedes_links().unwrap();
+        let out2 = db
+            .linked_records(&new, LinkDirection::Outbound, Some(&LinkType::Supersedes))
+            .unwrap();
+        assert_eq!(out2.len(), 1, "reify is idempotent");
+    }
+
+    #[test]
+    fn link_type_string_roundtrip() {
+        for lt in [
+            LinkType::Advances,
+            LinkType::Supersedes,
+            LinkType::Contradicts,
+            LinkType::Supports,
+            LinkType::Questions,
+            LinkType::DerivedFrom,
+            LinkType::Custom("my_link".to_string()),
+        ] {
+            assert_eq!(LinkType::from_str_lenient(&lt.as_str()), lt);
+        }
+        // Unknown string is lenient -> Custom.
+        assert_eq!(
+            LinkType::from_str_lenient("future_type"),
+            LinkType::Custom("future_type".to_string())
+        );
+    }
+}

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -24,6 +24,7 @@ mod intent;
 mod introspection;
 mod learning;
 mod lifecycle;
+mod links;
 pub mod materializer;
 mod metacognition;
 pub mod moves;
@@ -83,9 +84,9 @@ use crate::schema::{
     MIGRATE_V18_TO_V19, MIGRATE_V19_TO_V20, MIGRATE_V1_TO_V2, MIGRATE_V20_TO_V21,
     MIGRATE_V21_TO_V22, MIGRATE_V22_TO_V23, MIGRATE_V23_TO_V24, MIGRATE_V24_TO_V25,
     MIGRATE_V25_TO_V26, MIGRATE_V26_TO_V27, MIGRATE_V27_TO_V28, MIGRATE_V28_TO_V29,
-    MIGRATE_V29_TO_V30, MIGRATE_V2_TO_V3, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5, MIGRATE_V5_TO_V6,
-    MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10, SCHEMA_SQL,
-    SCHEMA_VERSION,
+    MIGRATE_V29_TO_V30, MIGRATE_V2_TO_V3, MIGRATE_V30_TO_V31, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5,
+    MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10,
+    SCHEMA_SQL, SCHEMA_VERSION,
 };
 use crate::types::*;
 
@@ -481,6 +482,7 @@ impl YantrikDB {
             (27, MIGRATE_V27_TO_V28),
             (28, MIGRATE_V28_TO_V29),
             (29, MIGRATE_V29_TO_V30),
+            (30, MIGRATE_V30_TO_V31),
         ];
         if let Some(v) = existing_version {
             for &(from_v, sql) in migrations {

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -11819,6 +11819,36 @@ fn schema_v30_fresh_install_has_record_revisions_table() {
     );
 }
 
+#[test]
+fn schema_v31_fresh_install_has_record_links_table() {
+    // Issue #48: fresh install must create record_links + both covering
+    // indexes. Regression guard against forgetting the table in SCHEMA_SQL
+    // alongside MIGRATE_V30_TO_V31.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let conn = db.conn();
+    let table: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master \
+             WHERE type = 'table' AND name = 'record_links'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(table, 1, "record_links table must exist on fresh install");
+
+    let idx: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' \
+             AND name IN ('idx_record_links_source', 'idx_record_links_target')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(idx, 2, "both record_links covering indexes must exist");
+
+    assert!(crate::base::schema::SCHEMA_VERSION >= 31);
+}
+
 // ── Issue #46: confidence first-class on recall ───────────────────────
 
 /// Seed a small DB with N records, each carrying a different `certainty`.


### PR DESCRIPTION
First of three PRs implementing the [record-link RFC](https://github.com/yantrikos/yantrikdb/blob/main/docs/record_link_model_rfc.md) (#48). **Purely additive substrate** — no existing code path changes behavior except `forget()` touching a (empty-until-used) table.

## The three-PR plan
1. **This PR — link substrate**: schema v31 + types + write/traverse API + replication + forget-marks-broken + reify. Additive, no behavior change, no feature flag needed.
2. **Next — `expand_links` recall integration**: the part the redteam proved is *mandatory* (stale-recall correctness bug). Reuses the existing `expand_bfs`/`graph_proximity` machinery with the relation-aware polarity map defined in this PR. Gated behind a `record_links` feature flag + soak because it changes recall behavior.
3. **Next — `relate()` prerequisite**: stop rid endpoints minting phantom `unknown` entities (the bug `consolidate.rs` already triggers in prod) + cleanup migration.

Splitting this way keeps each PR reviewable and avoids re-stacking the `recall()` signature cascade that bit #46/#47 in CI.

## What's here

**Schema v31** — `record_links` table, distinct from `claims` (RFC "Considered alternatives": verified entity pollution, schema mismatch, endpoint ambiguity). Column shape mirrors a future `graph_edges` row for forward-compat to unification. `MIGRATE_V30_TO_V31` + fresh-install SQL + `SCHEMA_VERSION=31`.

**Types** — `LinkType` (6 + `Custom`), string codec (lenient: unknown → `Custom`, forward-compat), `is_symmetric` (Contradicts), and `recall_polarity()` → the relation-aware scoring map part 2 consumes (defined now so the type is stable). `RecordLink` / `LinkDirection` / `LinkedRecord`.

**Write + traverse** — `record_with_links()`, `link()`, `unlink()`, `linked_records()`, `reify_supersedes_links()`. Honest atomicity boundary documented (not overclaimed). `reify` is an explicit one-shot method, not an auto-migration (idempotency hazard + HLC-clock availability — rationale in the doc comment); handles encrypted metadata via the decrypt path.

**Replication** — `link`/`unlink` op kinds; `materialize_link` (idempotent, carries leader HLC, writes `replication_apply_log`); `materialize_unlink` (hard-delete); `materialize_forget` extended to replay the link-status transition.

**forget()** — marks links `broken_source_forgotten` / `broken_target_forgotten`, never deletes (audit-trail bias).

## Test plan
- [x] record_with_links atomicity; link idempotency; self/empty rejection
- [x] unlink; inbound + typed filter; **contradicts bidirectionality**
- [x] **forget marks broken** (row retained, status set, traversal skips it)
- [x] **correct()-rid-preservation synergy** — links survive in-place v0.7.20 correction
- [x] reify + idempotency; LinkType string round-trip; schema_v31 fresh-install table + indexes
- [x] **1527/1527 lib tests pass**; `cargo fmt --check --all` clean; `cargo clippy --all-targets --workspace --exclude yantrikdb-python` clean

No Python bindings here — they land with part 2 once the API surface is confirmed by review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)