### PR TITLE
feat(links): recall_with_links + python bindings (#48 part 2/3)

### DIFF
--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -26,9 +26,17 @@
 use rusqlite::params;
 
 use crate::error::{Result, YantrikDbError};
-use crate::types::{LinkDirection, LinkType, LinkedRecord, RecordLink};
+use crate::types::{
+    LinkDirection, LinkType, LinkedRecord, RecallResult, RecordLink, ScoreBreakdown,
+    ScoreContributions,
+};
 
 use super::{now, YantrikDB};
+
+/// Shared candidate-budget cap for link expansion at recall time (RFC §3):
+/// `expand_links` and `expand_entities` together must not add more than
+/// this many candidates, bounding worst-case fan-out.
+const LINK_EXPANSION_BUDGET: usize = 50;
 
 impl YantrikDB {
     /// Record a memory and atomically(-ish; see module docs) attach
@@ -224,6 +232,172 @@ impl YantrikDB {
             created += 1;
         }
         Ok(created)
+    }
+
+    /// Issue #48 — recall with record-link expansion.
+    ///
+    /// Additive sibling of `recall()` (NOT a signature change to it — same
+    /// call-site-cascade rationale as `record_with_links`). `expand_links`
+    /// is the hop budget; `0` makes this identical to `recall()`.
+    ///
+    /// **Design — isolated post-pass, not a weave into the recall core.**
+    /// Runs the standard `recall()` for a slightly larger base pool, then
+    /// applies two link-aware transforms:
+    /// 1. **Supersedes demotion** — any base result that is the TARGET of
+    ///    an active `supersedes` link is multiplied by its
+    ///    `demote_self_as_target` factor (0.5). This is the half of the
+    ///    fix that stops a stale, superseded record from dominating.
+    /// 2. **Neighbor surfacing** — for each base result, active outbound
+    ///    links (and symmetric `contradicts`) surface the linked record
+    ///    (if active + not already present), scored at
+    ///    `seed.score * neighbor_factor / 4` (1-hop decay mirroring the
+    ///    entity graph's `4^hops`). This is the half that pulls the
+    ///    superseder/contradictor in even when it isn't semantically near
+    ///    the query. Budget-capped at [`LINK_EXPANSION_BUDGET`].
+    ///
+    /// Then re-sort by score and truncate to `top_k`.
+    ///
+    /// **Tradeoff (documented):** surfaced neighbors do NOT pass through
+    /// MMR diversity (the post-pass runs after `recall()`'s MMR). For v1
+    /// this is acceptable — the link set is small and intentional, unlike
+    /// the entity graph. A future revision can move expansion pre-MMR by
+    /// weaving into the recall core if diversity over linked records
+    /// proves to matter empirically.
+    #[allow(clippy::too_many_arguments)]
+    pub fn recall_with_links(
+        &self,
+        query_embedding: &[f32],
+        top_k: usize,
+        time_window: Option<(f64, f64)>,
+        memory_type: Option<&str>,
+        include_consolidated: bool,
+        expand_entities: bool,
+        query_text: Option<&str>,
+        skip_reinforce: bool,
+        namespace: Option<&str>,
+        domain: Option<&str>,
+        source: Option<&str>,
+        certainty_min: Option<f64>,
+        order: Option<&str>,
+        expand_links: usize,
+    ) -> Result<Vec<RecallResult>> {
+        // Larger base pool when expanding so demotion/expansion has room
+        // to reorder before the final truncate.
+        let base_k = if expand_links == 0 {
+            top_k
+        } else {
+            top_k.saturating_add(LINK_EXPANSION_BUDGET)
+        };
+
+        let mut base = self.recall(
+            query_embedding,
+            base_k,
+            time_window,
+            memory_type,
+            include_consolidated,
+            expand_entities,
+            query_text,
+            skip_reinforce,
+            namespace,
+            domain,
+            source,
+            certainty_min,
+            order,
+        )?;
+
+        if expand_links == 0 {
+            base.truncate(top_k);
+            return Ok(base);
+        }
+
+        let mut present: std::collections::HashSet<String> =
+            base.iter().map(|r| r.rid.clone()).collect();
+
+        // Phase 1: supersedes demotion.
+        let demote = LinkType::Supersedes.recall_polarity().demote_self_as_target;
+        for r in base.iter_mut() {
+            let superseded_by =
+                self.linked_records(&r.rid, LinkDirection::Inbound, Some(&LinkType::Supersedes))?;
+            if !superseded_by.is_empty() {
+                r.score *= demote;
+                r.why_retrieved
+                    .push("demoted: superseded by a newer record".to_string());
+            }
+        }
+
+        // Phase 2: neighbor surfacing (budget-capped).
+        let mut added: Vec<RecallResult> = Vec::new();
+        let mut budget = LINK_EXPANSION_BUDGET;
+        let seeds: Vec<(String, f64)> = base.iter().map(|r| (r.rid.clone(), r.score)).collect();
+        'seeds: for (seed_rid, seed_score) in &seeds {
+            if budget == 0 {
+                break;
+            }
+            let links = self.linked_records(seed_rid, LinkDirection::Outbound, None)?;
+            for l in links {
+                if budget == 0 {
+                    break 'seeds;
+                }
+                if present.contains(&l.rid) {
+                    continue;
+                }
+                let lt = LinkType::from_str_lenient(&l.link_type);
+                let pol = lt.recall_polarity();
+                if pol.neighbor_factor <= 0.0 {
+                    continue;
+                }
+                let Some(mem) = self.get(&l.rid)? else {
+                    continue;
+                };
+                if mem.consolidation_status != "active" {
+                    continue;
+                }
+                // 1-hop proximity decay mirrors the entity graph's 4^hops.
+                let nscore = seed_score * pol.neighbor_factor / 4.0;
+                present.insert(l.rid.clone());
+                budget -= 1;
+                added.push(RecallResult {
+                    rid: mem.rid,
+                    memory_type: mem.memory_type,
+                    text: mem.text,
+                    created_at: mem.created_at,
+                    importance: mem.importance,
+                    valence: mem.valence,
+                    score: nscore,
+                    scores: ScoreBreakdown {
+                        similarity: 0.0,
+                        decay: 0.0,
+                        recency: 0.0,
+                        importance: mem.importance,
+                        graph_proximity: nscore,
+                        contributions: ScoreContributions {
+                            similarity: 0.0,
+                            decay: 0.0,
+                            recency: 0.0,
+                            importance: 0.0,
+                            graph_proximity: nscore,
+                        },
+                        valence_multiplier: 1.0,
+                    },
+                    why_retrieved: vec![format!("linked via {} from {}", l.link_type, seed_rid)],
+                    metadata: mem.metadata,
+                    namespace: mem.namespace,
+                    certainty: mem.certainty,
+                    domain: mem.domain,
+                    source: mem.source,
+                    emotional_state: mem.emotional_state,
+                });
+            }
+        }
+
+        base.extend(added);
+        base.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        base.truncate(top_k);
+        Ok(base)
     }
 
     /// Traverse links from `rid`. Only `status='active'` links are
@@ -608,6 +782,166 @@ mod tests {
             .linked_records(&new, LinkDirection::Outbound, Some(&LinkType::Supersedes))
             .unwrap();
         assert_eq!(out2.len(), 1, "reify is idempotent");
+    }
+
+    #[test]
+    fn expand_links_demotes_superseded_and_surfaces_superseder() {
+        // The redteam's motivating correctness scenario. A supersedes B.
+        // A query close to B should, with expand_links, demote B and
+        // surface A above it.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        // B and the query are near-identical; A is also near but we rely
+        // on the link, not similarity, to rank it.
+        let b = rec(&db, "old fact about widgets", 5.0);
+        let a = rec(&db, "corrected fact about widgets", 5.05);
+        db.link(
+            &a,
+            &RecordLink {
+                target_rid: b.clone(),
+                link_type: LinkType::Supersedes,
+            },
+        )
+        .unwrap();
+
+        let query = vec_seed(5.0, 8); // closest to B
+
+        // Baseline (expand_links=0): B is present, not demoted.
+        let base = db
+            .recall_with_links(
+                &query, 5, None, None, false, false, None, true, None, None, None, None, None, 0,
+            )
+            .unwrap();
+        let base_b = base.iter().find(|r| r.rid == b).expect("B in baseline");
+        let base_b_score = base_b.score;
+
+        // With expansion: B is demoted (score strictly lower than baseline)
+        // and A is present.
+        let expanded = db
+            .recall_with_links(
+                &query, 5, None, None, false, false, None, true, None, None, None, None, None, 1,
+            )
+            .unwrap();
+        let exp_b = expanded
+            .iter()
+            .find(|r| r.rid == b)
+            .expect("B still present");
+        assert!(
+            exp_b.score < base_b_score,
+            "superseded B must be demoted: baseline={base_b_score}, expanded={}",
+            exp_b.score
+        );
+        assert!(
+            expanded.iter().any(|r| r.rid == a),
+            "superseder A must be present in expanded results"
+        );
+        // A should rank above B after demotion.
+        let pos_a = expanded.iter().position(|r| r.rid == a).unwrap();
+        let pos_b = expanded.iter().position(|r| r.rid == b).unwrap();
+        assert!(pos_a < pos_b, "A (superseder) must rank above demoted B");
+    }
+
+    #[test]
+    fn expand_links_zero_is_identical_to_recall() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let _a = rec(&db, "alpha", 1.0);
+        let _b = rec(&db, "beta", 2.0);
+        let query = vec_seed(1.0, 8);
+        let via_links = db
+            .recall_with_links(
+                &query, 5, None, None, false, false, None, true, None, None, None, None, None, 0,
+            )
+            .unwrap();
+        let direct = db
+            .recall(
+                &query, 5, None, None, false, false, None, true, None, None, None, None, None,
+            )
+            .unwrap();
+        assert_eq!(
+            via_links.iter().map(|r| &r.rid).collect::<Vec<_>>(),
+            direct.iter().map(|r| &r.rid).collect::<Vec<_>>(),
+            "expand_links=0 must match recall() exactly"
+        );
+    }
+
+    #[test]
+    fn expand_links_surfaces_neighbor_excluded_from_base_pool() {
+        // B supports A. A is in a different domain, so a domain-filtered
+        // recall excludes A from the base pool entirely — yet expand_links
+        // must still surface A via B's outbound support link, labelled as
+        // link-sourced. (In a tiny DB without the filter, A would already
+        // be in the base pool; the domain filter is what forces the
+        // genuine neighbor-surfacing path.)
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let b = db
+            .record(
+                "matches query in default domain",
+                "semantic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(3.0, 8),
+                "default",
+                0.8,
+                "default", // domain
+                "user",
+                None,
+            )
+            .unwrap();
+        let a = db
+            .record(
+                "supporting evidence in a hidden domain",
+                "semantic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(3.05, 8),
+                "default",
+                0.8,
+                "hidden", // different domain -> excluded by the filter below
+                "user",
+                None,
+            )
+            .unwrap();
+        db.link(
+            &b,
+            &RecordLink {
+                target_rid: a.clone(),
+                link_type: LinkType::Supports,
+            },
+        )
+        .unwrap();
+
+        let query = vec_seed(3.0, 8);
+        // domain="default" excludes A from the base recall pool.
+        let expanded = db
+            .recall_with_links(
+                &query,
+                5,
+                None,
+                None,
+                false,
+                false,
+                None,
+                true,
+                None,
+                Some("default"),
+                None,
+                None,
+                None,
+                1,
+            )
+            .unwrap();
+        let a_res = expanded
+            .iter()
+            .find(|r| r.rid == a)
+            .expect("linked supporter A must surface even though excluded from base pool");
+        assert!(
+            a_res.why_retrieved.iter().any(|w| w.contains("linked via")),
+            "surfaced neighbor must be labelled as link-sourced, got {:?}",
+            a_res.why_retrieved
+        );
     }
 
     #[test]

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -552,6 +552,182 @@ impl PyYantrikDB {
             .collect()
     }
 
+    // ── Issue #48 — record-to-record links ──
+
+    /// Record a memory and atomically attach record-to-record links.
+    /// `links` is a list of dicts: `{"target_rid": "...", "link_type": "supersedes"}`.
+    /// link_type is one of advances/supersedes/contradicts/supports/
+    /// questions/derived_from, or "custom:<name>".
+    #[pyo3(signature = (text, links, memory_type="episodic", importance=0.5, valence=0.0, half_life=604800.0, metadata=None, embedding=None, namespace="default", certainty=0.8, domain="general", source="user", emotional_state=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn record_with_links(
+        &self,
+        py: Python<'_>,
+        text: &str,
+        links: Vec<Bound<'_, PyDict>>,
+        memory_type: &str,
+        importance: f64,
+        valence: f64,
+        half_life: f64,
+        metadata: Option<&Bound<'_, PyDict>>,
+        embedding: Option<Vec<f32>>,
+        namespace: &str,
+        certainty: f64,
+        domain: &str,
+        source: &str,
+        emotional_state: Option<&str>,
+    ) -> PyResult<String> {
+        let db = self.get_inner()?;
+        let emb = match embedding {
+            Some(e) => e,
+            None => self.embed_text(py, text)?,
+        };
+        let meta = match metadata {
+            Some(d) => py_to_json(&d.as_any())?,
+            None => serde_json::json!({}),
+        };
+        let parsed = parse_links(&links)?;
+        db.record_with_links(
+            text,
+            memory_type,
+            importance,
+            valence,
+            half_life,
+            &meta,
+            &emb,
+            namespace,
+            certainty,
+            domain,
+            source,
+            emotional_state,
+            &parsed,
+        )
+        .map_err(map_err)
+    }
+
+    /// Add a single record-to-record link. Returns the link_id.
+    fn link(&self, source_rid: &str, target_rid: &str, link_type: &str) -> PyResult<String> {
+        let db = self.get_inner()?;
+        let rl = yantrikdb_core::RecordLink {
+            target_rid: target_rid.to_string(),
+            link_type: yantrikdb_core::LinkType::from_str_lenient(link_type),
+        };
+        db.link(source_rid, &rl).map_err(map_err)
+    }
+
+    /// Remove a single link. Returns True if a row was deleted.
+    fn unlink(&self, source_rid: &str, target_rid: &str, link_type: &str) -> PyResult<bool> {
+        let db = self.get_inner()?;
+        db.unlink(
+            source_rid,
+            target_rid,
+            &yantrikdb_core::LinkType::from_str_lenient(link_type),
+        )
+        .map_err(map_err)
+    }
+
+    /// Traverse links from `rid`. `direction` is "outbound" | "inbound" |
+    /// "both"; `link_type` filters to one type (None = all). Returns a list
+    /// of dicts {rid, link_type, created_at, direction}.
+    #[pyo3(signature = (rid, direction="both", link_type=None))]
+    fn linked_records(
+        &self,
+        py: Python<'_>,
+        rid: &str,
+        direction: &str,
+        link_type: Option<&str>,
+    ) -> PyResult<Vec<PyObject>> {
+        let db = self.get_inner()?;
+        let dir = match direction {
+            "outbound" => yantrikdb_core::LinkDirection::Outbound,
+            "inbound" => yantrikdb_core::LinkDirection::Inbound,
+            "both" => yantrikdb_core::LinkDirection::Both,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "linked_records: invalid direction {other:?}; expected \
+                     \"outbound\" | \"inbound\" | \"both\""
+                )))
+            }
+        };
+        let lt = link_type.map(yantrikdb_core::LinkType::from_str_lenient);
+        let out = db.linked_records(rid, dir, lt.as_ref()).map_err(map_err)?;
+        out.iter()
+            .map(|l| {
+                let d = PyDict::new(py);
+                d.set_item("rid", &l.rid)?;
+                d.set_item("link_type", &l.link_type)?;
+                d.set_item("created_at", l.created_at)?;
+                d.set_item("direction", &l.direction)?;
+                Ok::<PyObject, pyo3::PyErr>(d.into())
+            })
+            .collect()
+    }
+
+    /// Recall with record-link expansion. `expand_links` is the hop budget
+    /// (0 = identical to recall()). Mirrors `recall()` args otherwise.
+    #[pyo3(signature = (query=None, query_embedding=None, top_k=10, expand_links=1, time_window=None, memory_type=None, include_consolidated=false, expand_entities=true, skip_reinforce=false, namespace=None, domain=None, source=None, certainty_min=None, order=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn recall_with_links(
+        &self,
+        py: Python<'_>,
+        query: Option<&str>,
+        query_embedding: Option<Vec<f32>>,
+        top_k: usize,
+        expand_links: usize,
+        time_window: Option<(f64, f64)>,
+        memory_type: Option<&str>,
+        include_consolidated: bool,
+        expand_entities: bool,
+        skip_reinforce: bool,
+        namespace: Option<&str>,
+        domain: Option<&str>,
+        source: Option<&str>,
+        certainty_min: Option<f64>,
+        order: Option<&str>,
+    ) -> PyResult<Vec<PyObject>> {
+        let db = self.get_inner()?;
+        let emb = match query_embedding {
+            Some(e) => e,
+            None => match query {
+                Some(q) => self.embed_text(py, q)?,
+                None => {
+                    return Err(PyValueError::new_err(
+                        "Must provide either query or query_embedding",
+                    ))
+                }
+            },
+        };
+        let results = db
+            .recall_with_links(
+                &emb,
+                top_k,
+                time_window,
+                memory_type,
+                include_consolidated,
+                expand_entities,
+                query,
+                skip_reinforce,
+                namespace,
+                domain,
+                source,
+                certainty_min,
+                order,
+                expand_links,
+            )
+            .map_err(map_err)?;
+        results
+            .iter()
+            .map(|r| recall_result_to_dict(py, r))
+            .collect()
+    }
+
+    /// One-shot reification of legacy `metadata.supersedes` strings into
+    /// Supersedes links. Returns the count created. Idempotent.
+    fn reify_supersedes_links(&self) -> PyResult<usize> {
+        let db = self.get_inner()?;
+        db.reify_supersedes_links().map_err(map_err)
+    }
+
     fn record_batch(
         &self,
         py: Python<'_>,
@@ -696,4 +872,25 @@ impl PyYantrikDB {
     fn embed(&self, py: Python<'_>, text: &str) -> PyResult<Vec<f32>> {
         self.embed_text(py, text)
     }
+}
+
+/// Parse a Python list of `{"target_rid": str, "link_type": str}` dicts
+/// into `Vec<RecordLink>` for `record_with_links`. (Issue #48.)
+fn parse_links(links: &[Bound<'_, PyDict>]) -> PyResult<Vec<yantrikdb_core::RecordLink>> {
+    let mut out = Vec::with_capacity(links.len());
+    for d in links {
+        let target_rid: String = d
+            .get_item("target_rid")?
+            .ok_or_else(|| PyValueError::new_err("each link must have a 'target_rid' key"))?
+            .extract()?;
+        let link_type: String = d
+            .get_item("link_type")?
+            .ok_or_else(|| PyValueError::new_err("each link must have a 'link_type' key"))?
+            .extract()?;
+        out.push(yantrikdb_core::RecordLink {
+            target_rid,
+            link_type: yantrikdb_core::LinkType::from_str_lenient(&link_type),
+        });
+    }
+    Ok(out)
 }


### PR DESCRIPTION
Part 2 of 3 for the record-link RFC (#48). Rebased onto `main` after the substrate (#53) merged; supersedes the auto-closed #54.

## What's here
- **`recall_with_links()`** — link-aware recall as an isolated post-pass over `recall()`'s result set (supersedes-demotion + budget-capped neighbor surfacing via part 1's `LinkType::recall_polarity()` map). Additive sibling, not a `recall()` signature change (avoids the cascade that bit #46/#47/#50).
- **Python bindings** for all 6 new methods: `record_with_links`, `link`, `unlink`, `linked_records`, `recall_with_links`, `reify_supersedes_links`. `LinkType` surfaced as strings; `LinkDirection` as "outbound"/"inbound"/"both".

## Verification
- **1530/1530 lib tests pass** (16 in the links module incl. the stale-recall correctness scenario: A supersedes B → B demoted, A surfaces above it).
- `fmt --check --all` + `clippy --all-targets` clean.
- **Python binding compiled + clippy-clean locally** via `PYO3_PYTHON=C:\Python313\python.exe` — the broken-default-interpreter blind spot that caused #46/#47/#50's CI-only failures is now closed; these bindings were verified here, not shipped blind.

## Design notes (carried from the RFC)
- Recall integration is an isolated post-pass, not a weave into the 3700-line recall core — testable + low-blast-radius. Tradeoff: surfaced neighbors skip MMR diversity (acceptable for v1; link sets are small/intentional).
- No feature flag: additive-method design means existing paths are byte-identical until a `*_with_links` method is called.
- Ships in **0.7.x** (likely v0.7.21+), consistent with v0.7.20's breaking-change-as-patch precedent.

## Remaining for the link model
- Part 3: `relate()` phantom-entity prerequisite (separate bugfix PR)
- Then: soak v0.7.20 → rc build for algo → cut v0.7.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)