### PR TITLE
feat(links+audit): record_with_links_partial + windowed leak audit (v0.7.22)

### DIFF
--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -550,6 +550,58 @@ pub struct LinkedRecord {
     pub direction: String,
 }
 
+/// Per-link outcome from `record_with_links_partial` (issue #48). The
+/// record always commits first (durable via the oplog); each link is
+/// then attempted independently — a `Failed` on one does not abort the
+/// others or fail the call. Callers get the rid + a full per-link vec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LinkResult {
+    /// Link row was newly inserted.
+    Inserted {
+        target_rid: String,
+        link_type: String,
+    },
+    /// Link already existed (UNIQUE(source,target,type) hit; INSERT OR
+    /// IGNORE was a no-op). Retry-safe; algo treats it like `Inserted`
+    /// but it's distinguished for telemetry.
+    AlreadyExists {
+        target_rid: String,
+        link_type: String,
+    },
+    /// Link insert failed; the record itself is still durable.
+    Failed {
+        target_rid: String,
+        link_type: String,
+        error: String,
+    },
+}
+
+/// Result of [`YantrikDB::audit_leak_candidates`] (issue #48 follow-up).
+///
+/// Replaces the broken "orphan" metric (memories lacking oplog presence),
+/// which the trader postmortem proved is a benign **oplog-compaction
+/// artifact**, not a leak: locally-originated memories whose oplog rows
+/// aged out of the retention window look orphan-shaped but are healthy.
+///
+/// The windowed check only flags memories created *within* the surviving
+/// oplog window (`created_at >= window_floor`, where `window_floor =
+/// MIN(oplog.timestamp)`) that nonetheless have no oplog op and no
+/// `replication_apply_log` entry. Inside the window the oplog row SHOULD
+/// still exist, so its absence is a genuine signal (write-path bug /
+/// direct-SQL injection). Outside the window, absence is expected
+/// compaction and is NOT counted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LeakAuditReport {
+    /// `MIN(oplog.timestamp)` — the compaction boundary. `None` if the
+    /// oplog is empty (no window can be established; `candidate_count` 0).
+    pub window_floor: Option<f64>,
+    /// Exact count of in-window leak candidates.
+    pub candidate_count: usize,
+    /// Up to `max_rids` candidate rids (the count is exact; this is a
+    /// bounded sample for investigation).
+    pub candidate_rids: Vec<String>,
+}
+
 // ── Cognition types (V3) ──
 
 /// Trigger type classification.

--- a/crates/yantrikdb-core/src/engine/audit.rs
+++ b/crates/yantrikdb-core/src/engine/audit.rs
@@ -1,0 +1,227 @@
+//! Issue #48 follow-up — windowed leak-candidate audit.
+//!
+//! Background: the trader postmortem (2026-05-29) found 107k `memories`
+//! rows with no oplog `record`/`record_with_rid` op. The naive "orphan"
+//! definition (`in memories AND not in oplog AND not in
+//! replication_apply_log`) treated these as suspicious — but they are a
+//! benign **oplog-compaction artifact**: the oplog is a transient,
+//! compactable change-log, so locally-originated memories whose oplog
+//! rows aged out of the retention window look orphan-shaped while being
+//! perfectly healthy. The metric was measuring the wrong thing.
+//!
+//! The correct, zero-extra-storage detector is **windowed**: only flag
+//! memories created within the surviving oplog window
+//! (`created_at >= MIN(oplog.timestamp)`) that still lack an oplog op and
+//! a `replication_apply_log` entry. Inside the window the oplog row
+//! SHOULD still exist, so its absence is a genuine signal (a live
+//! write-path bug, or a direct-SQL insert that bypassed the engine).
+//! Outside the window, absence is expected compaction — not counted.
+
+use rusqlite::params;
+
+use crate::error::Result;
+use crate::types::LeakAuditReport;
+
+use super::YantrikDB;
+
+impl YantrikDB {
+    /// Windowed leak-candidate audit (issue #48 follow-up). See module
+    /// docs for why this replaces the compaction-confused "orphan" metric.
+    ///
+    /// `max_rids` caps the returned `candidate_rids` sample; the
+    /// `candidate_count` is always exact. A healthy node returns
+    /// `candidate_count == 0` (every in-window memory has its oplog op).
+    pub fn audit_leak_candidates(&self, max_rids: usize) -> Result<LeakAuditReport> {
+        let conn = self.conn();
+
+        // Window floor = the oldest surviving oplog row. Memories created
+        // before this have had their oplog rows compacted (expected);
+        // memories created at/after this should still have them.
+        let window_floor: Option<f64> = conn
+            .query_row("SELECT MIN(timestamp) FROM oplog", [], |r| {
+                r.get::<_, Option<f64>>(0)
+            })
+            .unwrap_or(None);
+
+        let Some(floor) = window_floor else {
+            // Empty oplog — no window to check within. Can't distinguish
+            // compaction from leak; report nothing rather than false-alarm.
+            return Ok(LeakAuditReport {
+                window_floor: None,
+                candidate_count: 0,
+                candidate_rids: Vec::new(),
+            });
+        };
+
+        // Shared predicate: in-window memory with no locally-originated
+        // oplog op AND not received via replication.
+        const PREDICATE: &str = "m.created_at >= ?1 \
+             AND m.rid NOT IN ( \
+                 SELECT target_rid FROM oplog \
+                 WHERE target_rid IS NOT NULL \
+                   AND op_type IN ('record','record_with_rid','consolidate','correct')) \
+             AND m.rid NOT IN (SELECT rid FROM replication_apply_log)";
+
+        let count: i64 = conn.query_row(
+            &format!("SELECT COUNT(*) FROM memories m WHERE {PREDICATE}"),
+            params![floor],
+            |r| r.get(0),
+        )?;
+
+        let candidate_rids: Vec<String> = {
+            let sql = format!(
+                "SELECT m.rid FROM memories m WHERE {PREDICATE} \
+                 ORDER BY m.created_at DESC LIMIT ?2"
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let rows =
+                stmt.query_map(params![floor, max_rids as i64], |r| r.get::<_, String>(0))?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()?
+        };
+
+        Ok(LeakAuditReport {
+            window_floor: Some(floor),
+            candidate_count: count as usize,
+            candidate_rids,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::YantrikDB;
+
+    fn vec_seed(seed: f32, dim: usize) -> Vec<f32> {
+        let raw: Vec<f32> = (0..dim).map(|i| (seed + i as f32) * 0.1).collect();
+        let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt();
+        raw.iter().map(|x| x / norm).collect()
+    }
+
+    #[test]
+    fn healthy_node_has_zero_leak_candidates() {
+        // Every memory written via record() has an oplog op, so within the
+        // window there should be zero leak candidates.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        for i in 0..10 {
+            db.record(
+                &format!("mem {i}"),
+                "semantic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(i as f32, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+        }
+        let report = db.audit_leak_candidates(100).unwrap();
+        assert!(report.window_floor.is_some());
+        assert_eq!(
+            report.candidate_count, 0,
+            "healthy node: every in-window memory has its oplog op"
+        );
+        assert!(report.candidate_rids.is_empty());
+    }
+
+    #[test]
+    fn direct_sql_insert_inside_window_is_flagged() {
+        // A row inserted directly into `memories` (bypassing record(), so
+        // no oplog op) with created_at inside the window IS a real leak
+        // candidate — exactly the write-path-bug / injection case we want.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let anchor = db
+            .record(
+                "anchor establishes the window",
+                "semantic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(1.0, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+        let floor: f64 = db
+            .conn()
+            .query_row("SELECT MIN(timestamp) FROM oplog", [], |r| r.get(0))
+            .unwrap();
+
+        // Inject a memories row with NO oplog op, created_at after the floor.
+        db.conn()
+            .execute(
+                "INSERT INTO memories \
+                 (rid, type, text, embedding, created_at, updated_at, importance, \
+                  half_life, last_access, valence, metadata, namespace, certainty, \
+                  domain, source) \
+                 VALUES ('leaked-rid', 'semantic', 'x', NULL, ?1, ?1, 0.5, 604800.0, \
+                         ?1, 0.0, '{}', 'default', 0.8, 'general', 'user')",
+                params![floor + 1.0],
+            )
+            .unwrap();
+
+        let report = db.audit_leak_candidates(100).unwrap();
+        assert_eq!(
+            report.candidate_count, 1,
+            "injected in-window row must flag"
+        );
+        assert!(report.candidate_rids.contains(&"leaked-rid".to_string()));
+        // The legitimately-recorded anchor is NOT flagged.
+        assert!(!report.candidate_rids.contains(&anchor));
+    }
+
+    #[test]
+    fn pre_window_orphan_is_not_flagged() {
+        // A row with created_at BEFORE the window floor (i.e. its oplog row
+        // would have been compacted) must NOT be flagged — that's the
+        // benign compaction case the postmortem identified.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        db.record(
+            "anchor",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({}),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+        let floor: f64 = db
+            .conn()
+            .query_row("SELECT MIN(timestamp) FROM oplog", [], |r| r.get(0))
+            .unwrap();
+
+        // Inject a row created BEFORE the floor (compaction-aged orphan).
+        db.conn()
+            .execute(
+                "INSERT INTO memories \
+                 (rid, type, text, embedding, created_at, updated_at, importance, \
+                  half_life, last_access, valence, metadata, namespace, certainty, \
+                  domain, source) \
+                 VALUES ('aged-rid', 'semantic', 'x', NULL, ?1, ?1, 0.5, 604800.0, \
+                         ?1, 0.0, '{}', 'default', 0.8, 'general', 'user')",
+                params![floor - 1000.0],
+            )
+            .unwrap();
+
+        let report = db.audit_leak_candidates(100).unwrap();
+        assert!(
+            !report.candidate_rids.contains(&"aged-rid".to_string()),
+            "pre-window compaction-aged row must NOT be flagged as a leak"
+        );
+    }
+}

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -27,7 +27,7 @@ use rusqlite::params;
 
 use crate::error::{Result, YantrikDbError};
 use crate::types::{
-    LinkDirection, LinkType, LinkedRecord, RecallResult, RecordLink, ScoreBreakdown,
+    LinkDirection, LinkResult, LinkType, LinkedRecord, RecallResult, RecordLink, ScoreBreakdown,
     ScoreContributions,
 };
 
@@ -80,6 +80,72 @@ impl YantrikDB {
         Ok(rid)
     }
 
+    /// Like [`Self::record_with_links`] but returns a per-link outcome
+    /// instead of failing fast (issue #48, v0.7.22). The record commits
+    /// first (durable via the oplog); then each link is attempted
+    /// independently — a failing link is captured as
+    /// [`LinkResult::Failed`] and does NOT abort the remaining links or
+    /// fail the call. Returns `(rid, per_link_results)`.
+    ///
+    /// This is the surface the MCP layer wants: it avoids re-querying to
+    /// reconstruct which links landed after a fail-fast `?` short-circuit.
+    /// `AlreadyExists` (the idempotent UNIQUE hit) is distinguished from
+    /// `Inserted` for telemetry; algo's retry path treats them the same.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_with_links_partial(
+        &self,
+        text: &str,
+        memory_type: &str,
+        importance: f64,
+        valence: f64,
+        half_life: f64,
+        metadata: &serde_json::Value,
+        embedding: &[f32],
+        namespace: &str,
+        certainty: f64,
+        domain: &str,
+        source: &str,
+        emotional_state: Option<&str>,
+        links: &[RecordLink],
+    ) -> Result<(String, Vec<LinkResult>)> {
+        let rid = self.record(
+            text,
+            memory_type,
+            importance,
+            valence,
+            half_life,
+            metadata,
+            embedding,
+            namespace,
+            certainty,
+            domain,
+            source,
+            emotional_state,
+        )?;
+
+        let mut results = Vec::with_capacity(links.len());
+        for link in links {
+            let target_rid = link.target_rid.clone();
+            let link_type = link.link_type.as_str();
+            match self.link_core(&rid, link) {
+                Ok((_id, true)) => results.push(LinkResult::Inserted {
+                    target_rid,
+                    link_type,
+                }),
+                Ok((_id, false)) => results.push(LinkResult::AlreadyExists {
+                    target_rid,
+                    link_type,
+                }),
+                Err(e) => results.push(LinkResult::Failed {
+                    target_rid,
+                    link_type,
+                    error: e.to_string(),
+                }),
+            }
+        }
+        Ok((rid, results))
+    }
+
     /// Add a single record-to-record link from `source_rid`.
     ///
     /// Validates: `source_rid` non-empty, `target_rid` non-empty, and
@@ -88,6 +154,17 @@ impl YantrikDB {
     /// `INSERT OR IGNORE`. Returns the `link_id` (freshly minted even if
     /// the row already existed and the insert was ignored).
     pub fn link(&self, source_rid: &str, link: &RecordLink) -> Result<String> {
+        let (link_id, _inserted) = self.link_core(source_rid, link)?;
+        Ok(link_id)
+    }
+
+    /// Core link insert shared by [`Self::link`] and
+    /// [`Self::record_with_links_partial`]. Returns `(link_id, inserted)`
+    /// where `inserted` is `true` if a new row was written and `false` if
+    /// the UNIQUE constraint made the INSERT OR IGNORE a no-op (the link
+    /// already existed). Always logs a `link` oplog op (idempotent on the
+    /// follower via the same UNIQUE constraint).
+    fn link_core(&self, source_rid: &str, link: &RecordLink) -> Result<(String, bool)> {
         if source_rid.is_empty() {
             return Err(YantrikDbError::InvalidInput(
                 "link: source_rid must be non-empty".to_string(),
@@ -109,7 +186,7 @@ impl YantrikDB {
         let ts = now();
         let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
 
-        {
+        let inserted = {
             let conn = self.conn.lock();
             conn.execute(
                 "INSERT OR IGNORE INTO record_links \
@@ -126,7 +203,8 @@ impl YantrikDB {
                     self.actor_id,
                 ],
             )?;
-        }
+            conn.changes() > 0
+        };
 
         self.log_op(
             "link",
@@ -140,7 +218,7 @@ impl YantrikDB {
             None,
         )?;
 
-        Ok(link_id)
+        Ok((link_id, inserted))
     }
 
     /// Remove a single link. Returns `true` if a row was deleted.
@@ -942,6 +1020,74 @@ mod tests {
             "surfaced neighbor must be labelled as link-sourced, got {:?}",
             a_res.why_retrieved
         );
+    }
+
+    #[test]
+    fn record_with_links_partial_reports_per_link_outcomes() {
+        use crate::types::LinkResult;
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let b = rec(&db, "target b", 1.0);
+
+        // links array: valid Advances→b, a DUPLICATE Advances→b (same
+        // source/target/type within the call → AlreadyExists on the
+        // second), and an empty-target link (Failed). The record must
+        // still commit despite the failure.
+        let (rid, results) = db
+            .record_with_links_partial(
+                "partial test",
+                "semantic",
+                0.5,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                &vec_seed(3.0, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+                &[
+                    RecordLink {
+                        target_rid: b.clone(),
+                        link_type: LinkType::Advances,
+                    },
+                    RecordLink {
+                        target_rid: b.clone(),
+                        link_type: LinkType::Advances,
+                    },
+                    RecordLink {
+                        target_rid: String::new(),
+                        link_type: LinkType::Supports,
+                    },
+                ],
+            )
+            .unwrap();
+
+        // Record committed despite the failing link.
+        assert!(db.get(&rid).unwrap().is_some());
+        assert_eq!(results.len(), 3);
+        assert!(
+            matches!(results[0], LinkResult::Inserted { .. }),
+            "first link inserted, got {:?}",
+            results[0]
+        );
+        assert!(
+            matches!(results[1], LinkResult::AlreadyExists { .. }),
+            "duplicate link already-exists, got {:?}",
+            results[1]
+        );
+        assert!(
+            matches!(results[2], LinkResult::Failed { .. }),
+            "empty-target link failed, got {:?}",
+            results[2]
+        );
+
+        // Net effect: exactly one active Advances link to b.
+        let out = db
+            .linked_records(&rid, LinkDirection::Outbound, Some(&LinkType::Advances))
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].rid, b);
     }
 
     #[test]

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1,6 +1,7 @@
 mod action;
 mod agenda;
 mod analogy_engine;
+mod audit;
 mod belief;
 mod belief_network_engine;
 mod cache;

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -728,6 +728,110 @@ impl PyYantrikDB {
         db.reify_supersedes_links().map_err(map_err)
     }
 
+    /// Like `record_with_links` but returns `(rid, [per_link_result])`
+    /// instead of failing fast. Each result dict has `result` in
+    /// {"inserted","already_exists","failed"}, `target_rid`, `link_type`,
+    /// and (for failed) `error`. The record commits even if a link fails.
+    #[pyo3(signature = (text, links, memory_type="episodic", importance=0.5, valence=0.0, half_life=604800.0, metadata=None, embedding=None, namespace="default", certainty=0.8, domain="general", source="user", emotional_state=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn record_with_links_partial(
+        &self,
+        py: Python<'_>,
+        text: &str,
+        links: Vec<Bound<'_, PyDict>>,
+        memory_type: &str,
+        importance: f64,
+        valence: f64,
+        half_life: f64,
+        metadata: Option<&Bound<'_, PyDict>>,
+        embedding: Option<Vec<f32>>,
+        namespace: &str,
+        certainty: f64,
+        domain: &str,
+        source: &str,
+        emotional_state: Option<&str>,
+    ) -> PyResult<(String, Vec<PyObject>)> {
+        let db = self.get_inner()?;
+        let emb = match embedding {
+            Some(e) => e,
+            None => self.embed_text(py, text)?,
+        };
+        let meta = match metadata {
+            Some(d) => py_to_json(&d.as_any())?,
+            None => serde_json::json!({}),
+        };
+        let parsed = parse_links(&links)?;
+        let (rid, results) = db
+            .record_with_links_partial(
+                text,
+                memory_type,
+                importance,
+                valence,
+                half_life,
+                &meta,
+                &emb,
+                namespace,
+                certainty,
+                domain,
+                source,
+                emotional_state,
+                &parsed,
+            )
+            .map_err(map_err)?;
+        let dicts: Vec<PyObject> = results
+            .iter()
+            .map(|r| {
+                let d = PyDict::new(py);
+                use yantrikdb_core::LinkResult::*;
+                match r {
+                    Inserted {
+                        target_rid,
+                        link_type,
+                    } => {
+                        d.set_item("result", "inserted")?;
+                        d.set_item("target_rid", target_rid)?;
+                        d.set_item("link_type", link_type)?;
+                    }
+                    AlreadyExists {
+                        target_rid,
+                        link_type,
+                    } => {
+                        d.set_item("result", "already_exists")?;
+                        d.set_item("target_rid", target_rid)?;
+                        d.set_item("link_type", link_type)?;
+                    }
+                    Failed {
+                        target_rid,
+                        link_type,
+                        error,
+                    } => {
+                        d.set_item("result", "failed")?;
+                        d.set_item("target_rid", target_rid)?;
+                        d.set_item("link_type", link_type)?;
+                        d.set_item("error", error)?;
+                    }
+                }
+                Ok::<PyObject, pyo3::PyErr>(d.into())
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok((rid, dicts))
+    }
+
+    /// Windowed leak-candidate audit (issue #48 follow-up). Returns a dict
+    /// {window_floor, candidate_count, candidate_rids}. Replaces the
+    /// compaction-confused "orphan" metric — only flags in-window memories
+    /// that genuinely lack oplog + replication provenance.
+    #[pyo3(signature = (max_rids=100))]
+    fn audit_leak_candidates(&self, py: Python<'_>, max_rids: usize) -> PyResult<PyObject> {
+        let db = self.get_inner()?;
+        let report = db.audit_leak_candidates(max_rids).map_err(map_err)?;
+        let d = PyDict::new(py);
+        d.set_item("window_floor", report.window_floor)?;
+        d.set_item("candidate_count", report.candidate_count)?;
+        d.set_item("candidate_rids", report.candidate_rids)?;
+        Ok(d.into())
+    }
+
     fn record_batch(
         &self,
         py: Python<'_>,


### PR DESCRIPTION
Two additive engine follow-ups — no schema change, clean patch toward v0.7.22.

## 1. `record_with_links_partial()` (#48)
Per-link-outcome variant of `record_with_links()`, requested by yantrikdb-server for the MCP `remember`-with-links surface. Record commits first (durable); each link attempted independently — a failure is captured, not propagated. Returns `(rid, Vec<LinkResult>)` where `LinkResult` ∈ {`Inserted`, `AlreadyExists`, `Failed{error}`}. Lets the MCP layer report partial success without re-querying after a fail-fast `?`. `link()` refactored to delegate to `link_core()` (returns inserted-bool via `conn.changes()`); public behavior unchanged.

## 2. `audit_leak_candidates()` (#48 follow-up)
Replaces the compaction-confused "orphan" metric. The trader postmortem proved the old definition is a benign **oplog-compaction artifact**, not a leak. The windowed check only flags memories created within the surviving oplog window (`created_at >= MIN(oplog.timestamp)`) that still lack oplog + `replication_apply_log` presence — where the row SHOULD exist, so absence is a genuine signal. Zero new storage. Returns `LeakAuditReport`. Server will wrap it in `/v1/admin/audit/leak_candidates`.

## Test plan
- [x] `record_with_links_partial_reports_per_link_outcomes` — Inserted + AlreadyExists (in-call dup) + Failed (empty target); record commits regardless
- [x] audit: `healthy_node_has_zero_leak_candidates`, `direct_sql_insert_inside_window_is_flagged`, `pre_window_orphan_is_not_flagged`
- [x] **1534/1534 lib tests**; `fmt --check --all` + `clippy --all-targets` clean (core + python binding verified locally via PYO3_PYTHON)

Version bump to 0.7.22 + tag happen after merge (per the version-bump-direct-to-main convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)