### PR TITLE
fix(python): set_embedder_named works with worker pool running (#58)

### DIFF
--- a/crates/yantrikdb-core/src/engine/materializer.rs
+++ b/crates/yantrikdb-core/src/engine/materializer.rs
@@ -410,6 +410,35 @@ mod tests {
     }
 
     #[test]
+    fn workers_weak_refs_block_then_release_exclusive_access() {
+        // **Regression for issue #58.** The pyo3 binding's `set_embedder_named`
+        // reaches the engine via `Arc::get_mut`, which hands out a `&mut` only
+        // when strong count == 1 AND weak count == 0. Worker threads each hold a
+        // `Weak<YantrikDB>`, so while the pool runs, `get_mut` is blocked — which
+        // is exactly why the v0.9.0 constructor change (spawning workers) broke
+        // `set_embedder_named`. The binding's fix stops the pool (dropping the
+        // guards JOINs the threads, releasing their weak refs) before the swap,
+        // then respawns. This test locks the invariant that fix depends on: a
+        // running pool blocks exclusive access, and stopping it restores it. If
+        // a future change made workers hold a STRONG ref instead, the binding's
+        // stop-swap-respawn would silently stop working — this catches that.
+        let mut db = open_test_db();
+        assert_eq!(Arc::strong_count(&db), 1);
+
+        let workers = spawn_all_workers(&db, 2);
+        assert!(
+            Arc::get_mut(&mut db).is_none(),
+            "while the worker pool runs, its Weak refs must block exclusive access"
+        );
+
+        drop(workers); // joins all worker threads → their Weak refs are released
+        assert!(
+            Arc::get_mut(&mut db).is_some(),
+            "after the worker pool is stopped, exclusive access must be regained"
+        );
+    }
+
+    #[test]
     fn spawn_materializers_without_compactor_wedges_at_delta_max() {
         // **Regression test confirming the bug exists when callers
         // forget the compactor.** This is the failure mode CT 132

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -46,6 +46,18 @@ impl PyYantrikDB {
             _workers: Some(workers),
         }
     }
+
+    /// (Re)spawn the background worker pool against the live engine `Arc`.
+    /// Paired with `self._workers = None` (which drops the guards and JOINs
+    /// the worker threads) around any operation that needs exclusive
+    /// `Arc::get_mut` access — the workers hold `Weak<YantrikDB>` refs, and
+    /// `get_mut` requires weak count 0. No-op if the engine is closed.
+    #[cfg(feature = "embedder-download")]
+    fn respawn_workers(&mut self) {
+        if let Some(arc) = self.inner.as_ref() {
+            self._workers = Some(spawn_all_workers(arc, recommended_worker_count()));
+        }
+    }
 }
 
 /// A thin proxy exposing execute() and commit() on the underlying connection.
@@ -394,17 +406,36 @@ impl PyYantrikDB {
     /// any `_conn` proxy is still live — drop it first).
     #[cfg(feature = "embedder-download")]
     fn set_embedder_named(&mut self, name: &str) -> PyResult<()> {
-        let arc = self
-            .inner
-            .as_mut()
-            .ok_or_else(|| PyRuntimeError::new_err("YantrikDB is closed"))?;
-        let engine = Arc::get_mut(arc).ok_or_else(|| {
-            PyRuntimeError::new_err(
-                "set_embedder_named requires exclusive access to the engine; \
-                 drop any ConnectionProxy / cloned YantrikDB references before calling",
-            )
-        })?;
-        engine.set_embedder_named(name).map_err(map_err)
+        if self.inner.is_none() {
+            return Err(PyRuntimeError::new_err("YantrikDB is closed"));
+        }
+        // The engine swap needs exclusive (`&mut`) access via `Arc::get_mut`,
+        // which requires strong count 1 AND weak count 0. Since v0.9.0 the
+        // constructors spawn a background worker pool (materializer + compactor)
+        // whose threads hold `Weak<YantrikDB>` refs (issue #58) — those alone
+        // make `get_mut` return `None`. So stop the workers first: dropping the
+        // guards JOINs the threads, releasing their weak refs. Respawn after the
+        // swap (success or failure) so the engine keeps its compactor — without
+        // it, writes wedge at delta_max. This is an infrequent, operator-
+        // initiated call, so the brief worker pause is acceptable.
+        self._workers = None;
+
+        let swap = {
+            let arc = self.inner.as_mut().expect("checked is_some above");
+            match Arc::get_mut(arc) {
+                Some(engine) => engine.set_embedder_named(name).map_err(map_err),
+                // A real external clone is still live (e.g. a ConnectionProxy or
+                // a cloned YantrikDB) — the original, legitimate guard. Preserve
+                // its actionable message.
+                None => Err(PyRuntimeError::new_err(
+                    "set_embedder_named requires exclusive access to the engine; \
+                     drop any ConnectionProxy / cloned YantrikDB references before calling",
+                )),
+            }
+        };
+
+        self.respawn_workers();
+        swap
     }
 
     /// Slim-build stub. When the Python crate is built with

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -653,6 +653,63 @@ class TestQueryBuilder:
         assert all(k in c for k in ["similarity", "decay", "recency", "importance", "graph_proximity"])
 
 
+class TestSetEmbedderNamedWorkers:
+    """Regression for issue #58.
+
+    v0.9.0 made the pyo3 constructors spawn a background worker pool
+    (materializer + compactor). Those threads hold ``Weak<YantrikDB>`` refs,
+    and ``set_embedder_named`` reaches the engine via ``Arc::get_mut``, which
+    requires weak count 0 — so the call ALWAYS failed with
+    "set_embedder_named requires exclusive access to the engine", regardless
+    of the model name. The binding now stops the workers (joining the threads,
+    releasing the weak refs), swaps, then respawns the pool.
+
+    These probes use an UNKNOWN model name so they stay hermetic (no network /
+    no model download): before the fix the call could never get past the
+    exclusive-access guard; after it, the engine itself rejects the unknown
+    name with a *different* error. So the invariant is simply: the failure is
+    never the exclusive-access one.
+    """
+
+    def _skip_if_no_download(self, db):
+        """Skip on slim wheels (built --no-default-features) where the named-
+        download path compiles out to a feature-absent stub."""
+        try:
+            db.set_embedder_named("issue-58-no-such-model")
+        except Exception as exc:  # noqa: BLE001 - inspecting the message
+            msg = str(exc).lower()
+            if "embedder-download" in msg and "feature" in msg:
+                pytest.skip("wheel built --no-default-features; named-download path absent")
+            return msg
+        return ""
+
+    def test_set_embedder_named_not_blocked_by_workers(self):
+        """A freshly constructed engine (workers running) can reach the swap."""
+        db = YantrikDB.with_default(":memory:")
+        try:
+            msg = self._skip_if_no_download(db)
+            assert "exclusive access" not in msg, (
+                "set_embedder_named must get past the Arc::get_mut guard once the "
+                f"worker pool is stopped; got: {msg!r}"
+            )
+        finally:
+            db.close()
+
+    def test_stop_swap_respawn_is_repeatable(self):
+        """A second call behaves identically — proves the pool was respawned
+        and the stop/swap/respawn cycle is repeatable, not a one-shot."""
+        db = YantrikDB.with_default(":memory:")
+        try:
+            self._skip_if_no_download(db)  # first cycle (also handles skip)
+            with pytest.raises(Exception) as exc:  # noqa: PT011 - message asserted below
+                db.set_embedder_named("issue-58-still-no-such-model")
+            assert "exclusive access" not in str(exc.value).lower()
+            # Engine is still live after the swap+respawn cycle.
+            assert db.stats()["active_memories"] == 0
+        finally:
+            db.close()
+
+
 # ── Encryption tests ──
 
 


### PR DESCRIPTION
Fixes #58.

## Root cause (with a correction to the issue)

v0.9.0 made the pyo3 constructors spawn a background worker pool (materializer + compactor) in `f6132e0`. The Python `set_embedder_named` reaches the engine via **`Arc::get_mut`**, which hands out a `&mut` only when **strong count == 1 AND weak count == 0**.

The issue suspected the workers hold *cloned (strong)* `YantrikDB` references. They actually hold **`Weak<YantrikDB>`** refs (`compactor_loop(weak: Weak<YantrikDB>, …)`). The weak refs alone are enough to make `get_mut` return `None`, so `set_embedder_named` failed with *"requires exclusive access to the engine"* **regardless of the model name** — breaking the multilingual / named-download swap path and blocking [yantrikdb-mcp#14](https://github.com/yantrikos/yantrikdb-mcp/pull/14).

## Fix

Contained entirely in the binding — no engine API change, no new constructor kwarg:

1. **Stop the worker pool** — `self._workers = None`. Dropping the guards JOINs the threads (`MaterializerGuard`/`CompactorGuard` `Drop`), releasing their weak refs.
2. **Swap** — with the now-exclusive engine, call `engine.set_embedder_named(name)`.
3. **Respawn** — bring the pool back (success or failure) so writes don't wedge at `delta_max`.

The original exclusive-access error is preserved for the legitimate case (a real external `ConnectionProxy` / cloned `YantrikDB` still live). This fixes **both** the construct-then-swap repro and runtime swaps, and keeps the multilingual path a one-liner — so the chosen approach is cleaner than the three options sketched in the issue (no post-construction breakage, no API surface change).

## Tests

- **core** (`materializer.rs`): invariant test — a running pool blocks `Arc::get_mut`; stopping it (join) restores exclusive access. Locks the property the binding depends on, so a future regression to *strong* refs is caught.
- **python** (`TestSetEmbedderNamedWorkers`): hermetic (unknown model name → no network) — the call must reach the engine and never the exclusive-access guard; the stop/swap/respawn cycle is repeatable and leaves the engine live.

Verified against a locally `maturin`-built `0.9.0` wheel: `64/64` `test_engine.py` pass, including the two new cases.

## Downstream

Once this lands and a patch release ships, the `multilingual` e2e in yantrikdb-mcp#14 (currently `xfail` with a link here) passes with no further code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)