### PR TITLE
fix(recall): NaN-safe sort comparators + hnsw NaN norm guard (#60)

### DIFF
--- a/crates/yantrikdb-core/src/cognition/action.rs
+++ b/crates/yantrikdb-core/src/cognition/action.rs
@@ -735,11 +735,7 @@ pub fn generate_candidates_for_intent(
     }
 
     // Sort by relevance descending, truncate
-    candidates.sort_by(|a, b| {
-        b.relevance_score
-            .partial_cmp(&a.relevance_score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    candidates.sort_by(|a, b| b.relevance_score.total_cmp(&a.relevance_score));
     candidates.truncate(config.max_candidates_per_intent);
 
     candidates
@@ -767,11 +763,7 @@ pub fn generate_candidates(
     let total_before_filter = all_candidates.len();
 
     // Deduplicate: same schema_name appearing for different intents — keep highest relevance
-    all_candidates.sort_by(|a, b| {
-        b.relevance_score
-            .partial_cmp(&a.relevance_score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    all_candidates.sort_by(|a, b| b.relevance_score.total_cmp(&a.relevance_score));
 
     let mut seen = std::collections::HashSet::new();
     all_candidates.retain(|c| seen.insert(c.schema_name.clone()));

--- a/crates/yantrikdb-core/src/cognition/agenda.rs
+++ b/crates/yantrikdb-core/src/cognition/agenda.rs
@@ -590,7 +590,7 @@ impl Agenda {
         active.sort_by(|a, b| {
             let ua = a.current_urgency(now);
             let ub = b.current_urgency(now);
-            ub.partial_cmp(&ua).unwrap_or(std::cmp::Ordering::Equal)
+            ub.total_cmp(&ua)
         });
 
         active.into_iter().take(limit).collect()

--- a/crates/yantrikdb-core/src/cognition/analogy.rs
+++ b/crates/yantrikdb-core/src/cognition/analogy.rs
@@ -243,9 +243,7 @@ impl AnalogyStore {
             .min_by(|(_, a), (_, b)| {
                 let score_a = a.structural_similarity * (1.0 + a.use_count as f64).ln();
                 let score_b = b.structural_similarity * (1.0 + b.use_count as f64).ln();
-                score_a
-                    .partial_cmp(&score_b)
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                score_a.total_cmp(&score_b)
             })
             .map(|(i, _)| i)
             .unwrap();
@@ -416,7 +414,7 @@ pub fn compute_structural_similarity(
     }
 
     // Sort by quality descending for greedy assignment.
-    pair_scores.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+    pair_scores.sort_by(|a, b| b.2.total_cmp(&a.2));
 
     // ── Step 2: Greedy 1:1 assignment ──
     let mut used_source = vec![false; source_nodes.len()];
@@ -669,11 +667,7 @@ pub fn generate_candidate_inferences(
     }
 
     // Sort by confidence descending.
-    inferences.sort_by(|a, b| {
-        b.confidence
-            .partial_cmp(&a.confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    inferences.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
 
     inferences
 }
@@ -786,11 +780,7 @@ pub fn find_analogies(
     }
 
     // Sort by structural similarity descending.
-    results.sort_by(|a, b| {
-        b.structural_similarity
-            .partial_cmp(&a.structural_similarity)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    results.sort_by(|a, b| b.structural_similarity.total_cmp(&a.structural_similarity));
 
     results.truncate(query.max_results);
     results
@@ -892,11 +882,7 @@ pub fn transfer_strategy(
     }
 
     // Sort by confidence descending.
-    transferred.sort_by(|a, b| {
-        b.transfer_confidence
-            .partial_cmp(&a.transfer_confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    transferred.sort_by(|a, b| b.transfer_confidence.total_cmp(&a.transfer_confidence));
 
     transferred
 }
@@ -949,8 +935,7 @@ pub fn detect_analogical_opportunities(
     opportunities.sort_by(|a, b| {
         b.mapping
             .structural_similarity
-            .partial_cmp(&a.mapping.structural_similarity)
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .total_cmp(&a.mapping.structural_similarity)
     });
 
     opportunities

--- a/crates/yantrikdb-core/src/cognition/attention.rs
+++ b/crates/yantrikdb-core/src/cognition/attention.rs
@@ -254,12 +254,7 @@ impl WorkingSet {
     /// Get all nodes sorted by activation (descending).
     pub fn by_activation(&self) -> Vec<&CognitiveNode> {
         let mut nodes: Vec<_> = self.nodes.values().collect();
-        nodes.sort_by(|a, b| {
-            b.attrs
-                .activation
-                .partial_cmp(&a.attrs.activation)
-                .unwrap_or(Ordering::Equal)
-        });
+        nodes.sort_by(|a, b| b.attrs.activation.total_cmp(&a.attrs.activation));
         nodes
     }
 
@@ -269,8 +264,7 @@ impl WorkingSet {
         nodes.sort_by(|a, b| {
             b.attrs
                 .relevance_score()
-                .partial_cmp(&a.attrs.relevance_score())
-                .unwrap_or(Ordering::Equal)
+                .total_cmp(&a.attrs.relevance_score())
         });
         nodes
     }
@@ -302,12 +296,7 @@ impl WorkingSet {
         let ids: Vec<u32> = heap.into_iter().map(|e| e.raw_id).collect();
         let mut result: Vec<&CognitiveNode> =
             ids.iter().filter_map(|id| self.nodes.get(id)).collect();
-        result.sort_by(|a, b| {
-            b.attrs
-                .activation
-                .partial_cmp(&a.attrs.activation)
-                .unwrap_or(Ordering::Equal)
-        });
+        result.sort_by(|a, b| b.attrs.activation.total_cmp(&a.attrs.activation));
         result
     }
 
@@ -552,7 +541,7 @@ impl WorkingSet {
 
             // Top-K truncation: only keep the most activated nodes in the frontier
             if next_frontier.len() > self.config.top_k_per_hop {
-                next_frontier.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+                next_frontier.sort_by(|a, b| b.1.total_cmp(&a.1));
                 next_frontier.truncate(self.config.top_k_per_hop);
             }
 
@@ -629,7 +618,7 @@ impl WorkingSet {
             }
 
             if next_frontier.len() > self.config.top_k_per_hop {
-                next_frontier.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+                next_frontier.sort_by(|a, b| b.1.total_cmp(&a.1));
                 next_frontier.truncate(self.config.top_k_per_hop);
             }
 
@@ -680,12 +669,7 @@ impl WorkingSet {
         self.nodes
             .values()
             .filter(|n| n.kind() == kind)
-            .max_by(|a, b| {
-                a.attrs
-                    .activation
-                    .partial_cmp(&b.attrs.activation)
-                    .unwrap_or(Ordering::Equal)
-            })
+            .max_by(|a, b| a.attrs.activation.total_cmp(&b.attrs.activation))
     }
 
     /// Find all active beliefs (activation > threshold).
@@ -703,12 +687,7 @@ impl WorkingSet {
             .values()
             .filter(|n| n.attrs.urgency > threshold)
             .collect();
-        nodes.sort_by(|a, b| {
-            b.attrs
-                .urgency
-                .partial_cmp(&a.attrs.urgency)
-                .unwrap_or(Ordering::Equal)
-        });
+        nodes.sort_by(|a, b| b.attrs.urgency.total_cmp(&a.attrs.urgency));
         nodes
     }
 
@@ -809,11 +788,7 @@ impl WorkingSet {
             })
             .collect();
 
-        node_summaries.sort_by(|a, b| {
-            b.activation
-                .partial_cmp(&a.activation)
-                .unwrap_or(Ordering::Equal)
-        });
+        node_summaries.sort_by(|a, b| b.activation.total_cmp(&a.activation));
 
         let edge_count: usize = self.adjacency.values().map(|v| v.len()).sum();
 
@@ -839,8 +814,7 @@ impl WorkingSet {
             .min_by(|a, b| {
                 a.attrs
                     .relevance_score()
-                    .partial_cmp(&b.attrs.relevance_score())
-                    .unwrap_or(Ordering::Equal)
+                    .total_cmp(&b.attrs.relevance_score())
             })
             .map(|n| n.id)
     }
@@ -877,10 +851,7 @@ impl PartialOrd for ActivationEntry {
 impl Ord for ActivationEntry {
     fn cmp(&self, other: &Self) -> Ordering {
         // REVERSED: min-heap behavior — lowest activation at top
-        other
-            .activation
-            .partial_cmp(&self.activation)
-            .unwrap_or(Ordering::Equal)
+        other.activation.total_cmp(&self.activation)
     }
 }
 

--- a/crates/yantrikdb-core/src/cognition/belief_network.rs
+++ b/crates/yantrikdb-core/src/cognition/belief_network.rs
@@ -879,11 +879,7 @@ fn compute_evidence_contributions(
     }
 
     // Sort by impact descending.
-    contributions.sort_by(|a, b| {
-        b.impact
-            .partial_cmp(&a.impact)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    contributions.sort_by(|a, b| b.impact.total_cmp(&a.impact));
 
     contributions
 }
@@ -962,7 +958,7 @@ pub fn sensitivity_to_evidence(
         }
     }
 
-    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| b.1.total_cmp(&a.1));
 
     results
 }

--- a/crates/yantrikdb-core/src/cognition/belief_query.rs
+++ b/crates/yantrikdb-core/src/cognition/belief_query.rs
@@ -186,12 +186,7 @@ pub fn query_beliefs<'a>(
     // Sort
     match pattern.order {
         BeliefOrder::ByConfidence => {
-            results.sort_by(|a, b| {
-                b.attrs
-                    .confidence
-                    .partial_cmp(&a.attrs.confidence)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
+            results.sort_by(|a, b| b.attrs.confidence.total_cmp(&a.attrs.confidence));
         }
         BeliefOrder::ByRecency => {
             results.sort_by(|a, b| b.attrs.last_updated_ms.cmp(&a.attrs.last_updated_ms));
@@ -200,20 +195,10 @@ pub fn query_beliefs<'a>(
             results.sort_by(|a, b| b.attrs.evidence_count.cmp(&a.attrs.evidence_count));
         }
         BeliefOrder::BySalience => {
-            results.sort_by(|a, b| {
-                b.attrs
-                    .salience
-                    .partial_cmp(&a.attrs.salience)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
+            results.sort_by(|a, b| b.attrs.salience.total_cmp(&a.attrs.salience));
         }
         BeliefOrder::ByVolatility => {
-            results.sort_by(|a, b| {
-                b.attrs
-                    .volatility
-                    .partial_cmp(&a.attrs.volatility)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
+            results.sort_by(|a, b| b.attrs.volatility.total_cmp(&a.attrs.volatility));
         }
     }
 
@@ -354,16 +339,14 @@ pub fn belief_inventory(nodes: &[&CognitiveNode]) -> BeliefInventory {
     }
 
     // Top-5 most volatile
-    volatile_heap.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+    volatile_heap.sort_by(|a, b| b.2.total_cmp(&a.2));
     inv.most_volatile = volatile_heap.into_iter().take(5).collect();
 
     // Top-5 strongest (by distance from 0.5)
     strongest_heap.sort_by(|a, b| {
         let dist_a = (a.2 - 0.5).abs();
         let dist_b = (b.2 - 0.5).abs();
-        dist_b
-            .partial_cmp(&dist_a)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        dist_b.total_cmp(&dist_a)
     });
     inv.strongest = strongest_heap.into_iter().take(5).collect();
 
@@ -371,9 +354,7 @@ pub fn belief_inventory(nodes: &[&CognitiveNode]) -> BeliefInventory {
     contested_heap.sort_by(|a, b| {
         let uncertainty_a = (a.2 - 0.5).abs();
         let uncertainty_b = (b.2 - 0.5).abs();
-        uncertainty_a
-            .partial_cmp(&uncertainty_b)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        uncertainty_a.total_cmp(&uncertainty_b)
     });
     inv.most_contested = contested_heap.into_iter().take(5).collect();
 
@@ -391,11 +372,7 @@ fn compute_confidence_trend(evidence: &[EvidenceEntry]) -> f64 {
 
     // Split evidence into halves by time
     let mut sorted: Vec<&EvidenceEntry> = evidence.iter().collect();
-    sorted.sort_by(|a, b| {
-        a.timestamp
-            .partial_cmp(&b.timestamp)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    sorted.sort_by(|a, b| a.timestamp.total_cmp(&b.timestamp));
 
     let mid = sorted.len() / 2;
     let early_avg: f64 = sorted[..mid].iter().map(|e| e.weight).sum::<f64>() / mid as f64;

--- a/crates/yantrikdb-core/src/cognition/benchmark.rs
+++ b/crates/yantrikdb-core/src/cognition/benchmark.rs
@@ -3440,7 +3440,7 @@ fn run_temporal_tests(run: &mut BenchRun, scenario: &PersonaScenario) {
             temporal::recency_relevance(last, now, &config)
         })
         .collect();
-    recency_scores.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    recency_scores.sort_by(|a, b| b.total_cmp(a));
     let all_bounded = recency_scores.iter().all(|&s| s >= 0.0 && s <= 1.0);
     run.add(BenchResult {
         category: "temporal".into(),

--- a/crates/yantrikdb-core/src/cognition/causal.rs
+++ b/crates/yantrikdb-core/src/cognition/causal.rs
@@ -379,7 +379,7 @@ impl CausalStore {
             .enumerate()
             .map(|(i, e)| (i, e.confidence))
             .collect();
-        indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        indexed.sort_by(|a, b| a.1.total_cmp(&b.1));
 
         let to_remove = self.edges.len() - self.config.max_edges;
         let remove_set: std::collections::HashSet<usize> =
@@ -430,7 +430,7 @@ pub fn discover_temporal_patterns(
 
     // Sort timestamps within each kind.
     for timestamps in by_kind.values_mut() {
-        timestamps.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        timestamps.sort_by(|a, b| a.total_cmp(b));
     }
 
     let mut patterns = Vec::new();
@@ -973,9 +973,7 @@ pub fn predict_effects(
     results.sort_by(|a, b| {
         let score_a = a.expected_strength.abs() * a.confidence;
         let score_b = b.expected_strength.abs() * b.confidence;
-        score_b
-            .partial_cmp(&score_a)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        score_b.total_cmp(&score_a)
     });
     results
 }
@@ -1473,7 +1471,7 @@ fn median_f64(values: &[f64]) -> f64 {
         return 0.0;
     }
     let mut sorted = values.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sorted.sort_by(|a, b| a.total_cmp(b));
     let n = sorted.len();
     if n % 2 == 0 {
         (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
@@ -1491,7 +1489,7 @@ fn quartiles_f64(values: &[f64]) -> (f64, f64) {
         );
     }
     let mut sorted = values.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sorted.sort_by(|a, b| a.total_cmp(b));
     let n = sorted.len();
     let q1 = sorted[n / 4];
     let q3 = sorted[3 * n / 4];

--- a/crates/yantrikdb-core/src/cognition/coherence.rs
+++ b/crates/yantrikdb-core/src/cognition/coherence.rs
@@ -326,12 +326,7 @@ pub fn plan_enforcement(
                 }
             })
             .collect();
-        candidates.sort_by(|a, b| {
-            a.attrs
-                .salience
-                .partial_cmp(&b.attrs.salience)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        candidates.sort_by(|a, b| a.attrs.salience.total_cmp(&b.attrs.salience));
 
         for node in candidates.into_iter().take(to_prune) {
             actions.push(EnforcementAction {
@@ -368,11 +363,7 @@ pub fn plan_enforcement(
     // 4. Resolve belief contradictions (highest-severity first).
     let mut conflicts_resolved = 0usize;
     let mut sorted_contradictions = report.belief_contradictions.clone();
-    sorted_contradictions.sort_by(|a, b| {
-        b.severity
-            .partial_cmp(&a.severity)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    sorted_contradictions.sort_by(|a, b| b.severity.total_cmp(&a.severity));
 
     let max_resolutions = if emergency { 5 } else { 2 };
     for contradiction in sorted_contradictions.iter().take(max_resolutions) {

--- a/crates/yantrikdb-core/src/cognition/consolidate.rs
+++ b/crates/yantrikdb-core/src/cognition/consolidate.rs
@@ -53,12 +53,7 @@ pub fn find_clusters(
 
     // Sort by creation time (return indices)
     let mut indices: Vec<usize> = (0..memories.len()).collect();
-    indices.sort_by(|&a, &b| {
-        memories[a]
-            .created_at
-            .partial_cmp(&memories[b].created_at)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    indices.sort_by(|&a, &b| memories[a].created_at.total_cmp(&memories[b].created_at));
 
     let mut used = HashSet::new();
     let mut clusters: Vec<Vec<usize>> = Vec::new();
@@ -119,11 +114,7 @@ pub fn find_clusters(
 /// and combining key facts from the cluster.
 pub fn extractive_summary(memories: &[MemoryWithEmbedding]) -> String {
     let mut ranked: Vec<&MemoryWithEmbedding> = memories.iter().collect();
-    ranked.sort_by(|a, b| {
-        b.importance
-            .partial_cmp(&a.importance)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    ranked.sort_by(|a, b| b.importance.total_cmp(&a.importance));
 
     let lead = &ranked[0].text;
     let additional: Vec<&str> = ranked[1..]

--- a/crates/yantrikdb-core/src/cognition/contradiction.rs
+++ b/crates/yantrikdb-core/src/cognition/contradiction.rs
@@ -351,11 +351,9 @@ pub fn scan_contradictions(
     result.conflicts.extend(prefs);
 
     // Sort by severity descending, truncate
-    result.conflicts.sort_by(|a, b| {
-        b.severity
-            .partial_cmp(&a.severity)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    result
+        .conflicts
+        .sort_by(|a, b| b.severity.total_cmp(&a.severity));
     result.conflicts.truncate(config.max_conflicts);
 
     result

--- a/crates/yantrikdb-core/src/cognition/counterfactual.rs
+++ b/crates/yantrikdb-core/src/cognition/counterfactual.rs
@@ -491,9 +491,7 @@ pub fn compare_outcomes(
     changed_nodes.sort_by(|a, b| {
         let mag_a = (a.counterfactual - a.actual).abs();
         let mag_b = (b.counterfactual - b.actual).abs();
-        mag_b
-            .partial_cmp(&mag_a)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        mag_b.total_cmp(&mag_a)
     });
 
     // Estimate counterfactual utility from activations.
@@ -629,8 +627,7 @@ fn explain_simulation(
         sorted.sort_by(|a, b| {
             b.propagated_strength
                 .abs()
-                .partial_cmp(&a.propagated_strength.abs())
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .total_cmp(&a.propagated_strength.abs())
         });
 
         for step in sorted.iter().take(3) {
@@ -708,9 +705,7 @@ pub fn why_not(
     results.sort_by(|a, b| {
         let score_a = a.confidence * a.trajectory.len() as f64;
         let score_b = b.confidence * b.trajectory.len() as f64;
-        score_b
-            .partial_cmp(&score_a)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        score_b.total_cmp(&score_a)
     });
 
     results
@@ -759,12 +754,7 @@ pub fn detect_regret_opportunities(
     }
 
     // Sort by |regret_score| descending (worst regrets first).
-    all_results.sort_by(|a, b| {
-        b.regret_score
-            .abs()
-            .partial_cmp(&a.regret_score.abs())
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    all_results.sort_by(|a, b| b.regret_score.abs().total_cmp(&a.regret_score.abs()));
 
     // Detect patterns: most common tags in regretted decisions.
     let pattern = detect_regret_pattern(&regret_tags, decisions.len());
@@ -901,11 +891,7 @@ pub fn sensitivity_analysis(
     }
 
     // Sort by sensitivity descending.
-    entries.sort_by(|a, b| {
-        b.sensitivity
-            .partial_cmp(&a.sensitivity)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    entries.sort_by(|a, b| b.sensitivity.total_cmp(&a.sensitivity));
 
     entries
 }

--- a/crates/yantrikdb-core/src/cognition/evaluator.rs
+++ b/crates/yantrikdb-core/src/cognition/evaluator.rs
@@ -405,11 +405,7 @@ pub fn evaluate_candidates(
         .collect();
 
     // Sort by utility descending
-    evaluated.sort_by(|a, b| {
-        b.utility
-            .partial_cmp(&a.utility)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    evaluated.sort_by(|a, b| b.utility.total_cmp(&a.utility));
 
     // Filter by min_utility
     let filtered: Vec<EvaluatedAction> = evaluated

--- a/crates/yantrikdb-core/src/cognition/experimenter.rs
+++ b/crates/yantrikdb-core/src/cognition/experimenter.rs
@@ -469,9 +469,7 @@ pub fn assign_variant(
             // Use index-based jitter for determinism
             let ja = jitter_seed * (1.0 + *i as f64 * 0.1) % 0.05;
             let jb = jitter_seed * (1.0 + *j as f64 * 0.1) % 0.05;
-            a.thompson_score(ja)
-                .partial_cmp(&b.thompson_score(jb))
-                .unwrap()
+            a.thompson_score(ja).total_cmp(&b.thompson_score(jb))
         })
         .map(|(i, _)| i)
         .unwrap_or(0);
@@ -575,7 +573,7 @@ pub fn conclude_experiment(experiment: &mut Experiment, now: f64) -> Option<(usi
         .variant_results
         .iter()
         .enumerate()
-        .max_by(|(_, a), (_, b)| a.mean().partial_cmp(&b.mean()).unwrap())
+        .max_by(|(_, a), (_, b)| a.mean().total_cmp(&b.mean()))
         .map(|(i, _)| i)?;
 
     experiment.winner = Some(winner_idx);

--- a/crates/yantrikdb-core/src/cognition/extractor.rs
+++ b/crates/yantrikdb-core/src/cognition/extractor.rs
@@ -569,11 +569,7 @@ fn tier1_extract(text: &str, _config: &ExtractorConfig) -> Vec<CognitiveUpdate> 
     }
 
     // Sort by confidence descending
-    updates.sort_by(|a, b| {
-        b.confidence
-            .partial_cmp(&a.confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    updates.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
     updates
 }
 
@@ -1348,11 +1344,7 @@ pub fn extract(
     all_updates.retain(|u| u.confidence >= config.min_confidence);
 
     // ── Sort by confidence descending ──
-    all_updates.sort_by(|a, b| {
-        b.confidence
-            .partial_cmp(&a.confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    all_updates.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
 
     // ── Truncate to max updates ──
     all_updates.truncate(config.max_updates);

--- a/crates/yantrikdb-core/src/cognition/flywheel.rs
+++ b/crates/yantrikdb-core/src/cognition/flywheel.rs
@@ -892,7 +892,7 @@ fn enforce_max_beliefs(store: &mut BeliefStore, config: &FlywheelConfig) {
         .iter()
         .map(|(k, b)| (k.clone(), b.confidence))
         .collect();
-    entries.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    entries.sort_by(|a, b| a.1.total_cmp(&b.1));
 
     let to_remove = store.len() - config.max_beliefs;
     for (key, _) in entries.into_iter().take(to_remove) {

--- a/crates/yantrikdb-core/src/cognition/hawkes.rs
+++ b/crates/yantrikdb-core/src/cognition/hawkes.rs
@@ -304,7 +304,7 @@ impl EventTypeModel {
         }
 
         let mut sorted = timestamps.to_vec();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.sort_by(|a, b| a.total_cmp(b));
 
         // Compute inter-event statistics
         let mut intervals = Vec::new();
@@ -342,7 +342,7 @@ impl EventTypeModel {
 
             // β from median inter-event time
             let mut sorted_intervals = intervals.clone();
-            sorted_intervals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            sorted_intervals.sort_by(|a, b| a.total_cmp(b));
             let median = sorted_intervals[sorted_intervals.len() / 2];
             let beta = if median > 0.0 {
                 1.0 / median
@@ -579,7 +579,7 @@ impl EventTypeModel {
             .hourly_multipliers
             .iter()
             .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
             .map(|(h, &m)| (h, m))
             .unwrap_or((0, 1.0));
 
@@ -739,12 +739,7 @@ impl HawkesRegistry {
         }
 
         // Sort by confidence descending
-        anticipated.sort_by(|a, b| {
-            b.prediction
-                .confidence
-                .partial_cmp(&a.prediction.confidence)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        anticipated.sort_by(|a, b| b.prediction.confidence.total_cmp(&a.prediction.confidence));
 
         anticipated
     }
@@ -782,9 +777,7 @@ impl HawkesRegistry {
             .min_by(|(_, a), (_, b)| {
                 let last_a = a.recent_events.last().copied().unwrap_or(0.0);
                 let last_b = b.recent_events.last().copied().unwrap_or(0.0);
-                last_a
-                    .partial_cmp(&last_b)
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                last_a.total_cmp(&last_b)
             })
             .map(|(k, _)| k.clone());
 

--- a/crates/yantrikdb-core/src/cognition/intent.rs
+++ b/crates/yantrikdb-core/src/cognition/intent.rs
@@ -658,9 +658,7 @@ pub fn generate_episode_hypotheses(
             NodePayload::Episode(ep) => ep.occurred_at,
             _ => 0.0,
         };
-        a_time
-            .partial_cmp(&b_time)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        a_time.total_cmp(&b_time)
     });
 
     match seed {
@@ -807,11 +805,7 @@ pub fn infer_intents(
     }
 
     // Sort by posterior descending
-    all_hypotheses.sort_by(|a, b| {
-        b.posterior
-            .partial_cmp(&a.posterior)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    all_hypotheses.sort_by(|a, b| b.posterior.total_cmp(&a.posterior));
 
     // Filter by min_posterior and truncate
     let filtered: Vec<ScoredIntent> = all_hypotheses

--- a/crates/yantrikdb-core/src/cognition/introspection.rs
+++ b/crates/yantrikdb-core/src/cognition/introspection.rs
@@ -349,8 +349,7 @@ fn extract_discoveries(store: &BeliefStore) -> Vec<Discovery> {
     // Sort by confidence descending, then evidence count descending
     candidates.sort_by(|a, b| {
         b.confidence
-            .partial_cmp(&a.confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .total_cmp(&a.confidence)
             .then_with(|| b.evidence_count.cmp(&a.evidence_count))
     });
 
@@ -410,11 +409,11 @@ fn build_milestones(inputs: &IntrospectionInputs) -> Vec<LearningMilestone> {
     }
 
     // ── First belief milestone ──
-    if let Some(earliest) = inputs.belief_store.iter().min_by(|a, b| {
-        a.formed_at
-            .partial_cmp(&b.formed_at)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    }) {
+    if let Some(earliest) = inputs
+        .belief_store
+        .iter()
+        .min_by(|a, b| a.formed_at.total_cmp(&b.formed_at))
+    {
         milestones.push(LearningMilestone {
             timestamp: earliest.formed_at,
             kind: MilestoneKind::FirstBelief,
@@ -462,11 +461,7 @@ fn build_milestones(inputs: &IntrospectionInputs) -> Vec<LearningMilestone> {
     }
 
     // Sort chronologically and truncate
-    milestones.sort_by(|a, b| {
-        a.timestamp
-            .partial_cmp(&b.timestamp)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    milestones.sort_by(|a, b| a.timestamp.total_cmp(&b.timestamp));
     milestones.truncate(MAX_MILESTONES);
     milestones
 }

--- a/crates/yantrikdb-core/src/cognition/patterns.rs
+++ b/crates/yantrikdb-core/src/cognition/patterns.rs
@@ -635,11 +635,7 @@ fn mine_cross_domain_patterns(db: &YantrikDB, config: &PatternConfig) -> Result<
     }
 
     // Sort by score descending, keep top results
-    patterns.sort_by(|a, b| {
-        b.confidence
-            .partial_cmp(&a.confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    patterns.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
     patterns.truncate(config.max_patterns);
 
     Ok(patterns)
@@ -747,11 +743,7 @@ fn mine_entity_bridges(db: &YantrikDB, config: &PatternConfig) -> Result<Vec<Raw
     }
 
     // Sort by score descending, keep top 10
-    patterns.sort_by(|a, b| {
-        b.confidence
-            .partial_cmp(&a.confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    patterns.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
     patterns.truncate(10);
 
     Ok(patterns)

--- a/crates/yantrikdb-core/src/cognition/personality_bias.rs
+++ b/crates/yantrikdb-core/src/cognition/personality_bias.rs
@@ -575,8 +575,7 @@ pub fn personality_impact(
         .max_by(|a, b| {
             a.bias_result
                 .total_bias
-                .partial_cmp(&b.bias_result.total_bias)
-                .unwrap()
+                .total_cmp(&b.bias_result.total_bias)
         })
         .filter(|a| a.bias_result.total_bias > 0.0)
         .map(|a| a.action_description.clone());
@@ -586,8 +585,7 @@ pub fn personality_impact(
         .min_by(|a, b| {
             a.bias_result
                 .total_bias
-                .partial_cmp(&b.bias_result.total_bias)
-                .unwrap()
+                .total_cmp(&b.bias_result.total_bias)
         })
         .filter(|a| a.bias_result.total_bias < 0.0)
         .map(|a| a.action_description.clone());

--- a/crates/yantrikdb-core/src/cognition/perspective.rs
+++ b/crates/yantrikdb-core/src/cognition/perspective.rs
@@ -501,11 +501,7 @@ pub fn detect_perspective_shift(
     }
 
     // Sort by confidence descending.
-    transitions.sort_by(|a, b| {
-        b.confidence
-            .partial_cmp(&a.confidence)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    transitions.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
 
     transitions
 }
@@ -652,11 +648,7 @@ pub fn perspective_conflict_check(
     }
 
     // Sort by severity.
-    conflicts.sort_by(|a, b| {
-        b.severity
-            .partial_cmp(&a.severity)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    conflicts.sort_by(|a, b| b.severity.total_cmp(&a.severity));
 
     conflicts
 }

--- a/crates/yantrikdb-core/src/cognition/planner.rs
+++ b/crates/yantrikdb-core/src/cognition/planner.rs
@@ -409,12 +409,7 @@ pub fn instantiate_plan(goal_id: NodeId, ctx: &PlanningContext) -> PlanProposal 
     let candidates_evaluated = candidate_plans.len();
 
     // Score, sort, and take top-k.
-    candidate_plans.sort_by(|a, b| {
-        b.score
-            .composite
-            .partial_cmp(&a.score.composite)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    candidate_plans.sort_by(|a, b| b.score.composite.total_cmp(&a.score.composite));
     candidate_plans.truncate(config.top_k);
 
     // Check constraints against all remaining plans.

--- a/crates/yantrikdb-core/src/cognition/policy.rs
+++ b/crates/yantrikdb-core/src/cognition/policy.rs
@@ -752,7 +752,7 @@ pub fn select_action(
     }
 
     // Sort by adjusted utility descending
-    adjusted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    adjusted.sort_by(|a, b| b.0.total_cmp(&a.0));
 
     // ── Phase 3: Threshold filter ──
 

--- a/crates/yantrikdb-core/src/cognition/receptivity.rs
+++ b/crates/yantrikdb-core/src/cognition/receptivity.rs
@@ -559,20 +559,16 @@ impl ReceptivityEstimate {
 
     /// The single most negative factor (biggest reason not to interrupt).
     pub fn top_blocker(&self) -> Option<&ReceptivityFactor> {
-        self.factors.iter().min_by(|a, b| {
-            a.contribution
-                .partial_cmp(&b.contribution)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
+        self.factors
+            .iter()
+            .min_by(|a, b| a.contribution.total_cmp(&b.contribution))
     }
 
     /// The single most positive factor (biggest reason to interrupt).
     pub fn top_enabler(&self) -> Option<&ReceptivityFactor> {
-        self.factors.iter().max_by(|a, b| {
-            a.contribution
-                .partial_cmp(&b.contribution)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
+        self.factors
+            .iter()
+            .max_by(|a, b| a.contribution.total_cmp(&b.contribution))
     }
 }
 

--- a/crates/yantrikdb-core/src/cognition/replay.rs
+++ b/crates/yantrikdb-core/src/cognition/replay.rs
@@ -316,11 +316,7 @@ pub fn add_to_buffer(
             .entries
             .iter()
             .enumerate()
-            .min_by(|(_, a), (_, b)| {
-                a.priority
-                    .partial_cmp(&b.priority)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
+            .min_by(|(_, a), (_, b)| a.priority.total_cmp(&b.priority))
             .map(|(i, _)| i)
         {
             if engine.buffer.entries[min_idx].priority < priority {
@@ -378,11 +374,10 @@ pub fn reprioritize_buffer(engine: &mut ReplayEngine, now_ms: u64) {
     }
 
     // Sort by priority descending.
-    engine.buffer.entries.sort_by(|a, b| {
-        b.priority
-            .partial_cmp(&a.priority)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    engine
+        .buffer
+        .entries
+        .sort_by(|a, b| b.priority.total_cmp(&a.priority));
 }
 
 /// Sample episodes from the buffer for replay.
@@ -564,7 +559,7 @@ pub fn discover_cross_associations(
     }
 
     // Deduplicate.
-    associations.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+    associations.sort_by(|a, b| b.2.total_cmp(&a.2));
     associations.dedup_by(|a, b| a.0 == b.0 && a.1 == b.1);
 
     associations

--- a/crates/yantrikdb-core/src/cognition/schema_induction.rs
+++ b/crates/yantrikdb-core/src/cognition/schema_induction.rs
@@ -753,7 +753,7 @@ pub fn match_schemas(context: &ContextSnapshot, store: &SchemaStore) -> Vec<(Sch
         }
     }
 
-    matches.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    matches.sort_by(|a, b| b.1.total_cmp(&a.1));
     matches
 }
 

--- a/crates/yantrikdb-core/src/cognition/skills.rs
+++ b/crates/yantrikdb-core/src/cognition/skills.rs
@@ -1268,10 +1268,7 @@ fn enforce_max_skills(registry: &mut SkillRegistry, config: &SkillConfig) {
         .collect();
 
     // Sort by priority ascending, then confidence ascending (remove lowest first)
-    ranked.sort_by(|a, b| {
-        a.2.cmp(&b.2)
-            .then(a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
-    });
+    ranked.sort_by(|a, b| a.2.cmp(&b.2).then(a.1.total_cmp(&b.1)));
 
     let to_remove = registry.skills.len() - config.max_skills;
     for (key, _, _) in ranked.into_iter().take(to_remove) {
@@ -1346,11 +1343,7 @@ pub fn find_matching_skills(
         .collect();
 
     // Sort by relevance descending
-    matches.sort_by(|a, b| {
-        b.relevance
-            .partial_cmp(&a.relevance)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    matches.sort_by(|a, b| b.relevance.total_cmp(&a.relevance));
     matches.truncate(max_results);
     matches
 }

--- a/crates/yantrikdb-core/src/cognition/surfacing.rs
+++ b/crates/yantrikdb-core/src/cognition/surfacing.rs
@@ -597,11 +597,7 @@ pub fn run_surfacing_pipeline(
     }
 
     // Sort by net utility (highest first)
-    suggestions.sort_by(|a, b| {
-        b.net_utility
-            .partial_cmp(&a.net_utility)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    suggestions.sort_by(|a, b| b.net_utility.total_cmp(&a.net_utility));
 
     // Limit to max_suggestions
     suggestions.truncate(config.max_suggestions);
@@ -790,11 +786,9 @@ pub fn run_surfacing_with_preferences(
     }
 
     // Re-sort after adjustment
-    result.suggestions.sort_by(|a, b| {
-        b.net_utility
-            .partial_cmp(&a.net_utility)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    result
+        .suggestions
+        .sort_by(|a, b| b.net_utility.total_cmp(&a.net_utility));
 
     result
 }

--- a/crates/yantrikdb-core/src/cognition/temporal.rs
+++ b/crates/yantrikdb-core/src/cognition/temporal.rs
@@ -313,7 +313,7 @@ pub fn rank_by_recency(events: &[(u64, f64)], now: f64, config: &RecencyConfig) 
         .iter()
         .map(|&(id, time)| (id, recency_relevance(time, now, config)))
         .collect();
-    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1));
     scored
 }
 
@@ -407,7 +407,7 @@ pub fn detect_periodicity(timestamps: &[f64], config: &PeriodicityConfig) -> Per
     }
 
     let mut sorted = timestamps.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sorted.sort_by(|a, b| a.total_cmp(b));
 
     let span = sorted.last().unwrap() - sorted.first().unwrap();
     if span <= 0.0 {
@@ -472,11 +472,7 @@ pub fn detect_periodicity(timestamps: &[f64], config: &PeriodicityConfig) -> Per
     }
 
     // Sort by correlation descending
-    detected.sort_by(|a, b| {
-        b.correlation
-            .partial_cmp(&a.correlation)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    detected.sort_by(|a, b| b.correlation.total_cmp(&a.correlation));
 
     PeriodicityResult {
         detected,
@@ -683,7 +679,7 @@ pub fn detect_bursts(timestamps: &[f64], config: &BurstConfig) -> BurstResult {
     }
 
     let mut sorted = timestamps.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    sorted.sort_by(|a, b| a.total_cmp(b));
 
     let first = sorted[0];
     let last = sorted[sorted.len() - 1];
@@ -814,11 +810,7 @@ pub fn mine_temporal_motifs(events: &[LabeledEvent], config: &MotifConfig) -> Ve
 
     // Sort by timestamp
     let mut sorted: Vec<&LabeledEvent> = events.iter().collect();
-    sorted.sort_by(|a, b| {
-        a.timestamp
-            .partial_cmp(&b.timestamp)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    sorted.sort_by(|a, b| a.timestamp.total_cmp(&b.timestamp));
 
     // Extract all subsequences of valid length within max_gap constraint
     // Key: sequence of labels → list of (span_secs, gap_secs_list)
@@ -928,9 +920,7 @@ pub fn mine_temporal_motifs(events: &[LabeledEvent], config: &MotifConfig) -> Ve
     motifs.sort_by(|a, b| {
         let score_a = a.occurrences as f64 * a.confidence;
         let score_b = b.occurrences as f64 * b.confidence;
-        score_b
-            .partial_cmp(&score_a)
-            .unwrap_or(std::cmp::Ordering::Equal)
+        score_b.total_cmp(&score_a)
     });
 
     motifs
@@ -1115,7 +1105,7 @@ pub fn topological_order(events: &[TemporalEvent]) -> TemporalOrder {
     queue.sort_by(|a, b| {
         let ta = ts_map.get(a).copied().unwrap_or(0.0);
         let tb = ts_map.get(b).copied().unwrap_or(0.0);
-        ta.partial_cmp(&tb).unwrap_or(std::cmp::Ordering::Equal)
+        ta.total_cmp(&tb)
     });
 
     let mut ordered = Vec::new();
@@ -1150,7 +1140,7 @@ pub fn topological_order(events: &[TemporalEvent]) -> TemporalOrder {
         queue.sort_by(|a, b| {
             let ta = ts_map.get(a).copied().unwrap_or(0.0);
             let tb = ts_map.get(b).copied().unwrap_or(0.0);
-            ta.partial_cmp(&tb).unwrap_or(std::cmp::Ordering::Equal)
+            ta.total_cmp(&tb)
         });
     }
 

--- a/crates/yantrikdb-core/src/cognition/triggers.rs
+++ b/crates/yantrikdb-core/src/cognition/triggers.rs
@@ -112,11 +112,7 @@ pub fn check_decay_triggers(
         }
     }
 
-    triggers.sort_by(|a, b| {
-        b.urgency
-            .partial_cmp(&a.urgency)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    triggers.sort_by(|a, b| b.urgency.total_cmp(&a.urgency));
     triggers.truncate(max_triggers);
     Ok(triggers)
 }
@@ -696,11 +692,7 @@ pub fn check_all_triggers(
     triggers.extend(check_valence_trend(db)?);
     triggers.extend(check_entity_anomaly(db)?);
 
-    triggers.sort_by(|a, b| {
-        b.urgency
-            .partial_cmp(&a.urgency)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    triggers.sort_by(|a, b| b.urgency.total_cmp(&a.urgency));
     triggers.truncate(max_triggers);
     Ok(triggers)
 }

--- a/crates/yantrikdb-core/src/cognition/world_model.rs
+++ b/crates/yantrikdb-core/src/cognition/world_model.rs
@@ -348,7 +348,7 @@ impl OutcomeDistribution {
         let idx = posteriors
             .iter()
             .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
             .map(|(i, _)| i)
             .unwrap_or(0);
         match idx {
@@ -492,7 +492,7 @@ impl TransitionModel {
             .max_by(|&&a, &&b| {
                 let ra = self.expected_success(features, a);
                 let rb = self.expected_success(features, b);
-                ra.partial_cmp(&rb).unwrap()
+                ra.total_cmp(&rb)
             })
             .copied()
     }

--- a/crates/yantrikdb-core/src/engine/cognition.rs
+++ b/crates/yantrikdb-core/src/engine/cognition.rs
@@ -346,11 +346,7 @@ impl YantrikDB {
 
         // Phase 7: Sort by urgency, truncate
         let mut final_triggers = filtered;
-        final_triggers.sort_by(|a, b| {
-            b.urgency
-                .partial_cmp(&a.urgency)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        final_triggers.sort_by(|a, b| b.urgency.total_cmp(&a.urgency));
         final_triggers.truncate(config.max_triggers);
 
         // Phase 7: Derive personality traits

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -469,11 +469,7 @@ impl YantrikDB {
         }
 
         base.extend(added);
-        base.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        base.sort_by(|a, b| b.score.total_cmp(&a.score));
         base.truncate(top_k);
         Ok(base)
     }

--- a/crates/yantrikdb-core/src/engine/query_dsl.rs
+++ b/crates/yantrikdb-core/src/engine/query_dsl.rs
@@ -232,7 +232,7 @@ impl<'a> YantrikExecutor<'a> {
         }
 
         // Sort by score descending and assign ranks.
-        ranked.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        ranked.sort_by(|a, b| b.score.total_cmp(&a.score));
         for (i, r) in ranked.iter_mut().enumerate() {
             r.rank = i + 1;
         }

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -1077,8 +1077,7 @@ impl YantrikDB {
                         (rid.clone(), rank)
                     })
                     .collect();
-                candidates
-                    .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                candidates.sort_by(|a, b| b.1.total_cmp(&a.1));
                 candidates
                     .into_iter()
                     .take(VALENCE_SCAN_MAX)
@@ -1407,11 +1406,7 @@ impl YantrikDB {
             } else if query_text.is_none() {
                 // Embedding-only search (no query text): seed from top results
                 let mut seed_sorted = scored.clone();
-                seed_sorted.sort_by(|a, b| {
-                    b.score
-                        .partial_cmp(&a.score)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
+                seed_sorted.sort_by(|a, b| b.score.total_cmp(&a.score));
                 let seed_count = 3.min(seed_sorted.len());
                 let seed_rids: Vec<&str> = seed_sorted[..seed_count]
                     .iter()
@@ -1592,8 +1587,7 @@ impl YantrikDB {
                             Some((rid, rank))
                         })
                         .collect();
-                    candidates
-                        .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                    candidates.sort_by(|a, b| b.1.total_cmp(&a.1));
                     candidates
                         .into_iter()
                         .take(preselect_pool)
@@ -1700,11 +1694,7 @@ impl YantrikDB {
         // step 4 where keyword_reserved items are exempt from MMR diversity
         // penalty, guaranteeing they survive into the final results.
         {
-            scored.sort_by(|a, b| {
-                b.score
-                    .partial_cmp(&a.score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
+            scored.sort_by(|a, b| b.score.total_cmp(&a.score));
 
             let cutoff_idx = top_k.min(scored.len()).saturating_sub(1);
             let cutoff_score = scored.get(cutoff_idx).map(|r| r.score).unwrap_or(0.0);
@@ -1722,7 +1712,7 @@ impl YantrikDB {
                 })
                 .map(|(i, r)| (i, r.scores.similarity))
                 .collect();
-            kw_below.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            kw_below.sort_by(|a, b| b.1.total_cmp(&a.1));
 
             // Boost best keyword candidates just above the cutoff
             for (idx, _) in kw_below.into_iter().take(KEYWORD_RESERVE_SLOTS) {
@@ -1739,11 +1729,7 @@ impl YantrikDB {
         // "Arjun cooked X today" x50) dominate all K result slots. MMR ensures
         // each result adds new information by penalizing candidates too similar
         // to already-selected results.
-        scored.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        scored.sort_by(|a, b| b.score.total_cmp(&a.score));
 
         let min_pool_for_mmr = (top_k * 3).max(20);
         if scored.len() > top_k && scored.len() >= min_pool_for_mmr {
@@ -1843,18 +1829,10 @@ impl YantrikDB {
         match recall_order {
             RecallOrder::Relevance => {}
             RecallOrder::Certainty => {
-                scored.sort_by(|a, b| {
-                    b.certainty
-                        .partial_cmp(&a.certainty)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
+                scored.sort_by(|a, b| b.certainty.total_cmp(&a.certainty));
             }
             RecallOrder::Recency => {
-                scored.sort_by(|a, b| {
-                    b.created_at
-                        .partial_cmp(&a.created_at)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
+                scored.sort_by(|a, b| b.created_at.total_cmp(&a.created_at));
             }
         }
 
@@ -3264,8 +3242,7 @@ impl YantrikDB {
                         (rid.clone(), rank)
                     })
                     .collect();
-                candidates
-                    .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                candidates.sort_by(|a, b| b.1.total_cmp(&a.1));
                 candidates
                     .into_iter()
                     .take(VALENCE_SCAN_MAX)
@@ -3582,11 +3559,7 @@ impl YantrikDB {
             } else if query_text.is_none() {
                 // Embedding-only search (no query text): seed from top results
                 let mut seed_sorted = scored.clone();
-                seed_sorted.sort_by(|a, b| {
-                    b.score
-                        .partial_cmp(&a.score)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
+                seed_sorted.sort_by(|a, b| b.score.total_cmp(&a.score));
                 let seed_count = 3.min(seed_sorted.len());
                 let seed_rids: Vec<&str> = seed_sorted[..seed_count]
                     .iter()
@@ -3754,8 +3727,7 @@ impl YantrikDB {
                             Some((r, rank))
                         })
                         .collect();
-                    candidates
-                        .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                    candidates.sort_by(|a, b| b.1.total_cmp(&a.1));
                     candidates
                         .into_iter()
                         .take(preselect_pool)
@@ -3854,11 +3826,7 @@ impl YantrikDB {
 
         // ── Phase 3.5: Keyword slot reservation (mirrors recall()) ──
         {
-            scored.sort_by(|a, b| {
-                b.score
-                    .partial_cmp(&a.score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
+            scored.sort_by(|a, b| b.score.total_cmp(&a.score));
             let cutoff_idx = top_k.min(scored.len()).saturating_sub(1);
             let cutoff_score = scored.get(cutoff_idx).map(|r| r.score).unwrap_or(0.0);
 
@@ -3875,7 +3843,7 @@ impl YantrikDB {
                 })
                 .map(|(i, r)| (i, r.scores.similarity))
                 .collect();
-            kw_below.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            kw_below.sort_by(|a, b| b.1.total_cmp(&a.1));
 
             for (idx, _) in kw_below.into_iter().take(KEYWORD_RESERVE_SLOTS) {
                 scored[idx].score = cutoff_score + 0.001;
@@ -3887,11 +3855,7 @@ impl YantrikDB {
 
         // ── Phase 4: MMR diversity selection ──
         let t_sort = Instant::now();
-        scored.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        scored.sort_by(|a, b| b.score.total_cmp(&a.score));
 
         let min_pool_for_mmr = (top_k * 3).max(20);
         if scored.len() > top_k && scored.len() >= min_pool_for_mmr {

--- a/crates/yantrikdb-core/src/engine/storage.rs
+++ b/crates/yantrikdb-core/src/engine/storage.rs
@@ -215,7 +215,7 @@ impl YantrikDB {
         }; // drop conn before archive() which re-acquires it
 
         // Sort ascending — lowest score = most evictable
-        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.sort_by(|a, b| a.1.total_cmp(&b.1));
 
         let mut archived_rids = Vec::new();
         for (rid, _) in scored.into_iter().take(to_evict) {

--- a/crates/yantrikdb-core/src/engine/temporal.rs
+++ b/crates/yantrikdb-core/src/engine/temporal.rs
@@ -86,9 +86,7 @@ impl YantrikDB {
         results.sort_by(|a, b| {
             let best_a = a.1.detected.first().map(|d| d.correlation).unwrap_or(0.0);
             let best_b = b.1.detected.first().map(|d| d.correlation).unwrap_or(0.0);
-            best_b
-                .partial_cmp(&best_a)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            best_b.total_cmp(&best_a)
         });
 
         Ok(results)
@@ -260,7 +258,7 @@ impl YantrikDB {
             })
             .collect();
 
-        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         Ok(scored)
     }
@@ -314,7 +312,7 @@ impl YantrikDB {
         }
 
         // Sort by urgency descending
-        entries.sort_by(|a, b| b.3.partial_cmp(&a.3).unwrap_or(std::cmp::Ordering::Equal));
+        entries.sort_by(|a, b| b.3.total_cmp(&a.3));
 
         Ok(entries)
     }

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -300,6 +300,71 @@ fn test_recall_basic() {
 }
 
 #[test]
+fn recall_survives_nan_embedding_in_candidate_pool() {
+    // Issue #60 end-to-end repro. A stored embedding with a NaN component used
+    // to yield a NaN similarity score — the old hnsw zero-norm guard missed NaN
+    // (`NaN == 0.0` is false) — which, mixed with the finite scores of normal
+    // candidates in the SAME recall sort, tripped Rust >= 1.81 driftsort's
+    // total-order panic ("comparison function does not implement a total
+    // order"). Now cosine_distance guards the NaN to a finite value AND every
+    // recall sort uses f64::total_cmp, so recall returns cleanly. This guards
+    // both fixes: a regressed hnsw guard trips the is_finite assertion below
+    // even if driftsort happens not to panic on this input size.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let add = |text: &str, emb: Vec<f32>| {
+        db.record(
+            text,
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &emb,
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    };
+    add("finite one", vec_seed(1.0, 8));
+    add("finite two", vec_seed(5.0, 8));
+    add("finite three", vec_seed(1.1, 8));
+    // The poison pill: a NaN component in an otherwise-normal stored embedding.
+    let mut nan_emb = vec_seed(2.0, 8);
+    nan_emb[0] = f32::NAN;
+    add("nan memory", nan_emb);
+
+    let results = db
+        .recall(
+            &vec_seed(1.0, 8),
+            10,
+            None,
+            None,
+            false,
+            false,
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("recall must not panic with a NaN embedding in the candidate pool");
+    assert!(
+        !results.is_empty(),
+        "recall returns the finite-scored candidates"
+    );
+    assert!(
+        results.iter().all(|r| r.score.is_finite()),
+        "every returned score is finite — the NaN embedding was guarded, not \
+         propagated into the sort comparator"
+    );
+}
+
+#[test]
 fn test_recall_empty() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let results = db

--- a/crates/yantrikdb-core/src/vector/delta_index.rs
+++ b/crates/yantrikdb-core/src/vector/delta_index.rs
@@ -399,7 +399,7 @@ impl DeltaIndex {
         }
 
         // Sort by distance ascending, take top-k.
-        merged.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        merged.sort_by(|a, b| a.1.total_cmp(&b.1));
         merged.truncate(k);
         Ok(merged)
     }

--- a/crates/yantrikdb-core/src/vector/hnsw.rs
+++ b/crates/yantrikdb-core/src/vector/hnsw.rs
@@ -35,10 +35,16 @@ fn cosine_distance(a: &[f32], b: &[f32]) -> f64 {
         .map(|&x| (x as f64) * (x as f64))
         .sum::<f64>()
         .sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 {
+    // Guard zero AND NaN norms. `norm_a == 0.0` misses NaN (`NaN == 0.0` is
+    // false), and `f64::clamp` preserves a NaN `self`, so a NaN norm would let
+    // a NaN distance escape — which then poisons callers' sort comparators
+    // (issue #60). `!(norm > 0.0)` is true for NaN, 0.0, and negatives (every
+    // comparison with NaN is false), so it catches all three.
+    if !(norm_a > 0.0) || !(norm_b > 0.0) {
         return 1.0;
     }
-    // Clamp to [0.0, 2.0] to handle floating-point rounding
+    // Clamp to [0.0, 2.0] to handle floating-point rounding. With both norms
+    // > 0.0 and finite, the ratio cannot be NaN here, so clamp is NaN-safe.
     (1.0 - (dot / (norm_a * norm_b))).clamp(0.0, 2.0)
 }
 
@@ -62,10 +68,7 @@ impl Eq for Candidate {}
 impl Ord for Candidate {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reverse: BinaryHeap is a max-heap, so reverse for min-heap behavior
-        other
-            .distance
-            .partial_cmp(&self.distance)
-            .unwrap_or(Ordering::Equal)
+        other.distance.total_cmp(&self.distance)
     }
 }
 impl PartialOrd for Candidate {
@@ -90,9 +93,7 @@ impl Eq for FarCandidate {}
 
 impl Ord for FarCandidate {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.distance
-            .partial_cmp(&other.distance)
-            .unwrap_or(Ordering::Equal)
+        self.distance.total_cmp(&other.distance)
     }
 }
 impl PartialOrd for FarCandidate {
@@ -303,7 +304,7 @@ impl HnswIndex {
             .filter(|&&n| !self.nodes[n].tombstoned)
             .map(|&n| (n, cosine_distance(&node_emb, &self.nodes[n].embedding)))
             .collect();
-        neighbors_with_dist.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
+        neighbors_with_dist.sort_by(|a, b| a.1.total_cmp(&b.1));
         neighbors_with_dist.truncate(max_m);
         self.nodes[node_idx].neighbors[layer] =
             neighbors_with_dist.iter().map(|&(n, _)| n).collect();
@@ -490,11 +491,7 @@ impl HnswIndex {
                 distance: fc.distance,
             })
             .collect();
-        sorted.sort_by(|a, b| {
-            a.distance
-                .partial_cmp(&b.distance)
-                .unwrap_or(Ordering::Equal)
-        });
+        sorted.sort_by(|a, b| a.distance.total_cmp(&b.distance));
         sorted
     }
 }
@@ -547,7 +544,7 @@ impl BruteForceIndex {
             .filter(|(_, _, tombstoned)| !tombstoned)
             .map(|(rid, emb, _)| (rid.clone(), cosine_distance(query, emb)))
             .collect();
-        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
+        scored.sort_by(|a, b| a.1.total_cmp(&b.1));
         scored.truncate(k);
         scored
     }
@@ -565,6 +562,33 @@ impl BruteForceIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cosine_distance_guards_nan_and_zero_norms() {
+        // Issue #60: the zero-norm guard used `norm == 0.0`, which misses NaN
+        // (`NaN == 0.0` is false) and lets a NaN distance escape (`clamp`
+        // preserves NaN). A NaN norm arises from a NaN-valued embedding
+        // component. The distance must always come back finite so it can never
+        // poison a caller's sort comparator.
+        let nan_vec = vec![f32::NAN, 1.0, 0.0];
+        let finite = vec![1.0f32, 0.0, 0.0];
+        let zero = vec![0.0f32, 0.0, 0.0];
+
+        let d_nan = cosine_distance(&nan_vec, &finite);
+        assert!(
+            d_nan.is_finite(),
+            "NaN embedding must not yield NaN distance"
+        );
+        assert_eq!(d_nan, 1.0);
+
+        // Symmetric: NaN on the other side.
+        assert_eq!(cosine_distance(&finite, &nan_vec), 1.0);
+        // Zero norm still guarded (unchanged behavior).
+        assert_eq!(cosine_distance(&zero, &finite), 1.0);
+        // Sanity: a normal pair is finite and within the clamped range.
+        let d = cosine_distance(&finite, &finite);
+        assert!(d.is_finite() && (0.0..=2.0).contains(&d));
+    }
 
     /// Generate a deterministic unit-norm embedding.
     fn vec_seed(seed: f32, dim: usize) -> Vec<f32> {


### PR DESCRIPTION
Fixes #60.

## Two latent NaN bugs that together crash recall

1. **hnsw `cosine_distance()` NaN norm guard.** The zero-norm guard used `norm == 0.0`, which misses NaN (`NaN == 0.0` is `false`); `f64::clamp` also preserves a NaN `self`. So a NaN-valued embedding produced a NaN distance/score with no interception. Now `!(norm > 0.0)` — true for NaN, `0.0`, and negatives.

2. **Sort comparators.** `partial_cmp(x).unwrap_or(Ordering::Equal)` is **not a valid total order** once NaN mixes with finite values (every NaN comparison maps to `Equal`, breaking transitivity). Rust ≥ 1.81''s driftsort detects this and **panics** — taking down `recall()` / `procedure(action="surface")` (which shares the same pipeline) and leaving the MCP session returning `-32602` afterward.

## Scope: crate-wide sweep (per maintainer decision)

Rather than fix only the reported recall sites, every float sort comparator now uses **`f64::total_cmp`** — IEEE `totalOrder`, never panics, and **order-identical to `partial_cmp` for all finite values** (NaN just lands in a deterministic slot). **117 sites across 40 files**, including:
- the `recall_profiled` (profiling-gated) duplicates the issue flagged,
- the hnsw heap `Ord` impls (`Candidate` / `FarCandidate`),
- the `.unwrap()` comparator variants (which panic on NaN) folded in as well.

`total_cmp` is a stdlib-guaranteed total order, so the swept sorts **categorically cannot panic** — a stronger guarantee than any per-site test.

## Tests

- **hnsw** (`cosine_distance_guards_nan_and_zero_norms`): distance comes back finite (`1.0`) for NaN and zero norms.
- **engine** (`recall_survives_nan_embedding_in_candidate_pool`): end-to-end recall with a NaN-valued embedding mixed into a pool of finite candidates returns cleanly with all-finite scores. Reproduces the reported incident (old code: NaN score → panic / NaN result) and guards **both** fixes — a regressed hnsw guard trips the `is_finite` assertion even if driftsort happens not to panic at this pool size.

Full suite green: **1601 default / 1568 slim**, fmt clean, pyo3 crate type-checks.

## Out of scope (separate repo)

The report also notes unguarded divisions in `yantrikdb-mcp`''s ONNX `embedder.py` (a possible NaN *source*). That lives in [yantrikos/yantrikdb-mcp](https://github.com/yantrikos/yantrikdb-mcp) and is flagged there separately. This PR hardens the **engine** so a NaN from *any* source can no longer crash recall — defense at the point of consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)