### PR TITLE
fix(recall): decompress cold-tier embeddings on read + NaN-guard cosine_similarity (#62)

### DIFF
--- a/crates/yantrikdb-core/src/cognition/consolidate.rs
+++ b/crates/yantrikdb-core/src/cognition/consolidate.rs
@@ -22,7 +22,13 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
         .map(|&x| (x as f64) * (x as f64))
         .sum::<f64>()
         .sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 {
+    // Issue #62 (defense-in-depth port of the #60 hnsw fix): `== 0.0`
+    // misses NaN (`NaN == 0.0` is false), so a NaN norm sailed through and
+    // this function returned NaN — poisoning recall scores AND the
+    // response-level confidence. `!(n > 0.0)` catches NaN, zero, and
+    // negatives; a degenerate vector now degrades to 0.0 similarity
+    // instead of propagating NaN.
+    if !(norm_a > 0.0) || !(norm_b > 0.0) {
         return 0.0;
     }
     dot / (norm_a * norm_b)
@@ -481,6 +487,23 @@ pub fn consolidate(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cosine_similarity_guards_nan_and_zero_norms() {
+        // Issue #62 defect B: the pre-#60 `== 0.0` guard let NaN norms
+        // through and returned NaN. Degenerate vectors must degrade to a
+        // finite 0.0 similarity instead.
+        let nan_vec = vec![f32::NAN, 1.0, 0.0];
+        let finite = vec![1.0f32, 0.0, 0.0];
+        let zero = vec![0.0f32, 0.0, 0.0];
+
+        let s = cosine_similarity(&nan_vec, &finite);
+        assert!(s.is_finite(), "NaN vector must not yield NaN similarity");
+        assert_eq!(s, 0.0);
+        assert_eq!(cosine_similarity(&finite, &nan_vec), 0.0);
+        assert_eq!(cosine_similarity(&zero, &finite), 0.0);
+        assert!((cosine_similarity(&finite, &finite) - 1.0).abs() < 1e-9);
+    }
 
     fn make_mem(
         rid: &str,

--- a/crates/yantrikdb-core/src/engine/durable_embeddings.rs
+++ b/crates/yantrikdb-core/src/engine/durable_embeddings.rs
@@ -46,6 +46,21 @@ use std::collections::HashMap;
 
 use super::YantrikDB;
 
+/// **Issue #62.** `archive()` stores cold-tier embeddings zstd-compressed
+/// in the SAME column hot rows use for raw f32 bytes. Every durable read
+/// must therefore check the zstd magic and decompress (mirroring
+/// `hydrate()`) — otherwise scoring paths reinterpret compressed bytes as
+/// f32 garbage: wrong similarities always, and a chance NaN that poisons
+/// the whole response's confidence. Cheap: a 4-byte magic comparison on
+/// the hot path; decompression only ever runs for genuinely cold rows.
+fn decompress_if_cold(bytes: Vec<u8>) -> Vec<u8> {
+    if crate::compression::is_compressed(&bytes) {
+        crate::serde_helpers::serialize_f32(&crate::compression::decompress_embedding(&bytes))
+    } else {
+        bytes
+    }
+}
+
 /// One row's embedding bytes plus the generation stamp.
 ///
 /// `generation` is the v28 `memories.embedding_generation` column.
@@ -89,9 +104,17 @@ impl<'a> DurableEmbeddingStore<'a> {
     /// Batch-read embeddings for an explicit set of rids.
     ///
     /// Returns `(rid, EmbeddingWithGeneration)` for each rid that
-    /// has a non-NULL embedding column. Rids without an embedding
-    /// (storage_tier='cold' before hydration, tombstoned rows, or
-    /// rids that don't exist) are omitted from the result map.
+    /// has a non-NULL embedding column; rids without one (tombstoned
+    /// rows, or rids that don't exist) are omitted from the result map.
+    ///
+    /// **Issue #62:** cold-tier rows DO have an embedding — `archive()`
+    /// rewrites the column with a zstd-COMPRESSED blob (an earlier version
+    /// of this doc claimed cold rows were omitted; they never were). This
+    /// reader therefore decompresses after decrypting, exactly mirroring
+    /// `hydrate()` — before this fix, every recall scoring path that
+    /// touched a cold record reinterpreted compressed bytes as raw f32,
+    /// producing garbage similarity scores (and, ~50-70% of the time per
+    /// record, a NaN that poisoned the response's confidence field).
     ///
     /// Caller policy on generation:
     /// - `entry.generation == active_search_state.generation`:
@@ -153,6 +176,7 @@ impl<'a> DurableEmbeddingStore<'a> {
             // decrypt_embedding for durable rows on read paths
             // (record/storage are write paths and stay separate).
             let bytes = self.db.decrypt_embedding(&stored_emb)?;
+            let bytes = decompress_if_cold(bytes);
             map.insert(
                 rid,
                 EmbeddingWithGeneration {
@@ -213,6 +237,9 @@ impl<'a> DurableEmbeddingStore<'a> {
         let mut out = Vec::with_capacity(rows.len());
         for (rid, stored_emb, generation) in rows {
             let bytes = self.db.decrypt_embedding(&stored_emb)?;
+            // Issue #62: see read_embeddings_for_rids — cold rows are
+            // compressed at rest and must be decompressed on read.
+            let bytes = decompress_if_cold(bytes);
             out.push((
                 rid,
                 EmbeddingWithGeneration {

--- a/crates/yantrikdb-core/src/engine/indices.rs
+++ b/crates/yantrikdb-core/src/engine/indices.rs
@@ -31,7 +31,16 @@ impl YantrikDB {
             } else {
                 emb_blob
             };
-            let embedding = deserialize_f32(&raw_blob);
+            // Issue #62 defense: this scan is hot-tier-only, but if a
+            // compressed (cold-format) blob ever appears here — tier-column
+            // drift, partial hydrate, manual SQL — decompress instead of
+            // building the index from reinterpreted zstd bytes. One 4-byte
+            // magic check per row.
+            let embedding = if crate::compression::is_compressed(&raw_blob) {
+                crate::compression::decompress_embedding(&raw_blob)
+            } else {
+                deserialize_f32(&raw_blob)
+            };
             if embedding.len() == embedding_dim {
                 index.insert(&rid, &embedding)?;
             }

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -384,6 +384,141 @@ fn recall_survives_nan_embedding_in_candidate_pool() {
 }
 
 #[test]
+fn cold_tier_embeddings_decompress_on_read() {
+    // Issue #62 defect A. archive() rewrites the embedding column with a
+    // zstd-COMPRESSED blob; before the fix, every recall scoring path that
+    // fetched a cold record's embedding reinterpreted those compressed
+    // bytes as raw f32 — garbage similarities always, and (empirically
+    // ~50-70% per record) a NaN that poisoned the response confidence.
+    // The durable read path must hand back the ORIGINAL vector,
+    // bit-identical (zstd is lossless), exactly as hydrate() would.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let original = vec_seed(3.0, 8);
+    let rid = db
+        .record(
+            "a fact destined for cold storage",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &original,
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    assert!(db.archive(&rid).unwrap(), "archived to cold");
+
+    // Sanity: the stored blob really is compressed at rest.
+    {
+        let conn = db.conn();
+        let stored: Vec<u8> = conn
+            .query_row(
+                "SELECT embedding FROM memories WHERE rid = ?1",
+                rusqlite::params![rid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            crate::compression::is_compressed(&stored),
+            "archive() stores zstd bytes in the embedding column"
+        );
+    }
+
+    // The sanctioned durable reader must decompress.
+    let store = super::durable_embeddings::DurableEmbeddingStore::new(&db);
+    let map = store.read_embeddings_for_rids(&[rid.as_str()]).unwrap();
+    let entry = map.get(&rid).expect("cold rid present in read map");
+    let decoded = crate::serde_helpers::deserialize_f32(&entry.bytes);
+    assert_eq!(
+        decoded, original,
+        "cold read must return the original vector, not reinterpreted zstd bytes"
+    );
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
+fn recall_scores_stay_finite_and_sane_with_cold_candidates() {
+    // Issue #62 end-to-end (the reporter's minimal repro): a cold record
+    // surfaced through the keyword lane must score from its REAL vector —
+    // finite score, finite response-level confidence.
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let cold = db
+        .record_text(
+            "the zanzibar deployment uses the falcon cache",
+            "semantic",
+            0.6,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    db.record_text(
+        "an unrelated hot memory about lunch",
+        "semantic",
+        0.5,
+        0.0,
+        604800.0,
+        &empty_meta(),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap();
+
+    assert!(db.archive(&cold).unwrap());
+
+    // Keyword-lane query pulls the cold record into the candidate pool
+    // (it is tombstoned in the ANN index, so FTS is its route in).
+    let resp = db
+        .recall_with_response(
+            &db.embed("zanzibar falcon cache deployment").unwrap(),
+            5,
+            None,
+            None,
+            false,
+            true,
+            Some("zanzibar falcon cache deployment"),
+            true,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    assert!(
+        resp.confidence.is_finite(),
+        "response confidence must be finite, got {}",
+        resp.confidence
+    );
+    for r in &resp.results {
+        assert!(
+            r.score.is_finite(),
+            "every score finite; {} scored {}",
+            r.rid,
+            r.score
+        );
+    }
+    let cold_hit = resp.results.iter().find(|r| r.rid == cold);
+    let hit = cold_hit.expect("cold record surfaces via the keyword lane");
+    assert!(
+        hit.score.is_finite() && hit.score > 0.0,
+        "cold record scores from its real (decompressed) vector, got {}",
+        hit.score
+    );
+}
+
+#[test]
 fn contract_gate_rejects_invalid_writes() {
     // v0.9.3 central numeric/vector contract gate (issue #60 follow-up, sol
     // converged plan item 1). Table-driven entry-path matrix: every invalid


### PR DESCRIPTION
Fixes #62.

Both defects verified against source exactly as @blue-mtn-dog reported — this is the second time their analysis was line-level correct before we touched anything.

## Defect A — the real bug: recall never decompressed cold-tier embeddings

`archive()` rewrites `memories.embedding` with a **zstd blob**; `decompress_embedding` had exactly **one** call site in the whole crate (`hydrate()`). Every recall scoring path that fetched a cold record via `DurableEmbeddingStore` reinterpreted compressed bytes as raw f32 — **garbage similarities always**, plus (~50–70% per record) a chance NaN that poisoned the response-level `confidence`. The cold tier has been silently unscoreable in recall since compression was introduced; #60''s fix made NaN non-fatal, which is exactly what made this *visible* instead of crashing.

**Fix:** `decompress_if_cold()` (4-byte zstd magic check) after decrypt in `read_embeddings_for_rids` **and** `read_embeddings_under_generation`, mirroring `hydrate()`. Also corrects the reader''s stale doc claim that cold rows had no embedding — the code believed its own comment.

## Defect B — the #60 fix never reached the function recall actually uses

`consolidate::cosine_similarity` kept the pre-#60 NaN-blind guard (`== 0.0`). Recall scores through **this** function, not `hnsw::cosine_distance`. Ported the guard (`!(norm > 0.0)`): degenerate vectors degrade to finite 0.0 similarity instead of propagating NaN.

## Defense in depth

`build_vec_index_with_enc` (hot-only scan) also decompresses if a cold-format blob ever reaches it via tier drift or manual SQL.

## Tests

- **Roundtrip**: record → archive → assert the stored blob IS zstd → durable read returns the original vector **bit-identically**.
- **E2E** (the reporter''s repro): archived record surfaces via the keyword lane → finite score > 0, finite response confidence, all scores finite.
- `cosine_similarity` NaN/zero guard unit test.

1616 lib tests pass. Ships as v0.9.4 on merge — the workaround (per-record `hydrate()`) stops being needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)