### PR TITLE
feat(v0.10): Item 1 — status-led read path (T01 groundwork, T05/T08/T10 implemented)

### DIFF
--- a/crates/yantrikdb-core/benches/engine_bench.rs
+++ b/crates/yantrikdb-core/benches/engine_bench.rs
@@ -165,6 +165,7 @@ fn bench_recall(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    false,
                 )
                 .unwrap()
             })
@@ -396,6 +397,7 @@ fn bench_recall_scaled(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    false,
                 )
                 .unwrap()
             })
@@ -436,6 +438,7 @@ fn bench_recall_dim_comparison(c: &mut Criterion) {
                             None,
                             None,
                             None,
+                            false,
                         )
                         .unwrap()
                     })
@@ -477,6 +480,7 @@ fn bench_recall_100k(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    false,
                 )
                 .unwrap()
             })
@@ -512,6 +516,7 @@ fn bench_recall_with_graph(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    false,
                 )
                 .unwrap()
             })
@@ -533,6 +538,7 @@ fn bench_recall_with_graph(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    false,
                 )
                 .unwrap()
             })
@@ -571,6 +577,7 @@ fn bench_reinforce_overhead(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    false,
                 )
                 .unwrap()
         })
@@ -593,6 +600,7 @@ fn bench_reinforce_overhead(c: &mut Criterion) {
                     None,
                     None,
                     None,
+                    false,
                 )
                 .unwrap()
         })

--- a/crates/yantrikdb-core/examples/perf_at_scale.rs
+++ b/crates/yantrikdb-core/examples/perf_at_scale.rs
@@ -193,6 +193,7 @@ fn run_one(n: usize) -> Row {
         let results = db
             .recall(
                 &query, TOP_K, None, None, false, false, None, true, None, None, None, None, None,
+                false,
             )
             .expect("recall failed");
         let lat_us = q_start.elapsed().as_secs_f64() * 1_000_000.0;

--- a/crates/yantrikdb-core/examples/wedge_repro.rs
+++ b/crates/yantrikdb-core/examples/wedge_repro.rs
@@ -299,7 +299,8 @@ fn run() {
                 let query = vec_seed((q_seed as f32) * 0.71 + 7.0, dim);
                 let t = Instant::now();
                 let _ = db_c.recall(
-                    &query, 10, None, None, false, false, None, false, None, None, None, None, None,
+                    &query, 10, None, None, false, false, None, false, None, None, None, None,
+                    None, false,
                 );
                 let dur_ns = t.elapsed().as_nanos() as u64;
                 let bucket = started.elapsed().as_secs();

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -181,6 +181,11 @@ pub struct RecallResponse {
     pub certainty_reasons: Vec<String>,
     pub retrieval_summary: RetrievalSummary,
     pub hints: Vec<RefinementHint>,
+    /// v0.10 Item 1b (trace T08): typed coverage of what was searched
+    /// and why the result set looks the way it does. serde(default) so
+    /// pre-v0.10 serialized responses still deserialize.
+    #[serde(default)]
+    pub coverage: SearchCoverage,
 }
 
 /// Summary of how retrieval was performed.
@@ -190,6 +195,61 @@ pub struct RetrievalSummary {
     pub score_spread: f64,
     pub sources_used: Vec<String>,
     pub candidate_count: usize,
+}
+
+/// v0.10 Item 1b — trace T08 "absence-with-coverage". Typed statement
+/// of the search scope and outcome, so a consumer can distinguish "the
+/// substrate has nothing in this scope" from "candidates exist but none
+/// cleared the relevance gate" WITHOUT parsing certainty_reasons prose.
+/// nuron's false-retry loop (T08 fixture) came from exactly that
+/// ambiguity: an empty result read as a transient failure, so the agent
+/// retried a query that could never succeed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchCoverage {
+    /// Namespace scope searched (`None` = all namespaces).
+    pub namespace: Option<String>,
+    /// Memory-type scope searched (`None` = all types).
+    pub memory_type: Option<String>,
+    /// Records in scope after filters — the candidate universe, not the
+    /// HNSW pool.
+    pub candidate_count: usize,
+    /// The relevance gate consulted for the outcome: the per-database
+    /// learned `gate_tau` (similarity level where importance boosting
+    /// engages — the engine's own notion of "relevant enough").
+    pub threshold_tau: f64,
+    /// Top similarity among returned results (0.0 when empty).
+    pub top_similarity: f64,
+    /// The typed T08 distinction.
+    pub outcome: CoverageOutcome,
+}
+
+impl Default for SearchCoverage {
+    fn default() -> Self {
+        Self {
+            namespace: None,
+            memory_type: None,
+            candidate_count: 0,
+            threshold_tau: 0.0,
+            top_similarity: 0.0,
+            outcome: CoverageOutcome::NoMatchingRecord,
+        }
+    }
+}
+
+/// v0.10 Item 1b — why a recall's result set looks the way it does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CoverageOutcome {
+    /// Results returned and the best of them clears the relevance gate.
+    Matched,
+    /// Candidates exist in scope, but nothing returned clears the gate
+    /// (or nothing was returned at all). These are guesses, not
+    /// knowledge — retrying the same query will not improve them.
+    BelowThreshold,
+    /// The searched scope contains no records. There is nothing to
+    /// find; do not retry.
+    NoMatchingRecord,
 }
 
 /// A hint for refining a query when confidence is low.

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -238,6 +238,24 @@ pub struct Stats {
     pub vec_index_entries: usize,
     pub graph_index_entities: usize,
     pub graph_index_edges: usize,
+    // v0.10 Item 1: status-led read path adoption surface. All
+    // serde(default) so pre-v0.10 serialized stats still deserialize.
+    /// `"exclude_superseded"` (status-led read path active) or
+    /// `"legacy"` (include-everything; pre-v0.10 DB that hasn't opted in).
+    #[serde(default)]
+    pub status_read_policy: String,
+    /// Records currently superseded (selected active inbound
+    /// `supersedes` edge). Global — link identity is namespace-checked
+    /// at creation, so no per-namespace filter applies here.
+    #[serde(default)]
+    pub superseded_records: i64,
+    /// Adoption nudge: superseded results actually served since engine
+    /// boot (only possible on legacy policy or `include_superseded`
+    /// calls). Non-zero on a legacy DB means the status read policy
+    /// would have excluded stale facts — consider
+    /// `set_status_read_policy(true)`.
+    #[serde(default)]
+    pub superseded_served_since_boot: u64,
 }
 
 /// A proactive trigger.
@@ -893,6 +911,9 @@ pub struct RecallQuery {
     // Issue #46: confidence first-class on recall.
     pub certainty_min: Option<f64>,
     pub order: Option<String>,
+    // v0.10 Item 1: re-admit superseded records (stamped) for
+    // history/archaeology queries. No-op on legacy-policy databases.
+    pub include_superseded: bool,
 }
 
 impl RecallQuery {
@@ -912,7 +933,17 @@ impl RecallQuery {
             source: None,
             certainty_min: None,
             order: None,
+            include_superseded: false,
         }
+    }
+
+    /// v0.10 Item 1: include superseded records in results (stamped
+    /// with `current_status = Superseded` + `superseded_by`) instead of
+    /// excluding them under the status read policy. For "show me what I
+    /// used to believe" archaeology queries.
+    pub fn include_superseded(mut self) -> Self {
+        self.include_superseded = true;
+        self
     }
 
     /// Issue #46: drop results whose certainty falls below `min`.

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -109,6 +109,33 @@ pub struct ScoreContributions {
     pub graph_proximity: f64,
 }
 
+/// **v0.10 Item 1 — typed temporal status (the status+flags algebra).**
+///
+/// `current_status` is EXCLUSIVE and chain-derived: a record either has a
+/// selected active inbound Supersedes successor (`Superseded`) or it does
+/// not (`Active`). Everything else — disputed, aged — is an ORTHOGONAL
+/// flag, because those states co-occur with either status ("superseded AND
+/// the successor is disputed" is exactly the situation an agent most needs
+/// rendered honestly — consumer review). `#[non_exhaustive]` so
+/// retracted/expired can join in v0.11+ without a breaking change.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordStatus {
+    #[default]
+    Active,
+    Superseded,
+}
+
+impl RecordStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RecordStatus::Active => "active",
+            RecordStatus::Superseded => "superseded",
+        }
+    }
+}
+
 /// A recall result with scoring information.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecallResult {
@@ -128,6 +155,21 @@ pub struct RecallResult {
     pub domain: String,
     pub source: String,
     pub emotional_state: Option<String>,
+    // ── v0.10 Item 1: typed temporal status (status leads, prose follows;
+    //    the why_retrieved prose stamps are retained for one release) ──
+    /// Exclusive chain-derived status.
+    #[serde(default)]
+    pub current_status: RecordStatus,
+    /// The rid of the selected successor when `current_status == Superseded`.
+    #[serde(default)]
+    pub superseded_by: Option<String>,
+    /// Open-conflict counterpart rids (many-to-many; cleared on resolution).
+    #[serde(default)]
+    pub disputed_with: Vec<String>,
+    /// Set when the record is aged-unconfirmed: the last time it was
+    /// verified/updated. None = not aged.
+    #[serde(default)]
+    pub aged_last_verified: Option<f64>,
 }
 
 /// Response from recall with confidence and hints for interactive retrieval.

--- a/crates/yantrikdb-core/src/distributed/sync.rs
+++ b/crates/yantrikdb-core/src/distributed/sync.rs
@@ -543,6 +543,7 @@ mod tests {
         let a_results = a
             .recall(
                 &emb1, 2, None, None, false, false, None, false, None, None, None, None, None,
+                false,
             )
             .unwrap();
         assert!(!a_results.is_empty());

--- a/crates/yantrikdb-core/src/engine/conflict.rs
+++ b/crates/yantrikdb-core/src/engine/conflict.rs
@@ -444,6 +444,11 @@ impl YantrikDB {
                 } else {
                     memory_a
                 };
+                // v0.10 Item 1: typed disputed flag (many-to-many; the prose
+                // stamp below is retained for one release).
+                if !r.disputed_with.contains(&other) {
+                    r.disputed_with.push(other.clone());
+                }
                 r.why_retrieved.push(format!(
                     "⚠ unresolved {priority} conflict ({ctype}) with {other} — verify before relying"
                 ));

--- a/crates/yantrikdb-core/src/engine/digest.rs
+++ b/crates/yantrikdb-core/src/engine/digest.rs
@@ -41,6 +41,13 @@ pub struct SessionDigestConfig {
     pub max_triggers: usize,
     /// Max characters of each memory's text to include as a snippet.
     pub snippet_chars: usize,
+    /// v0.10 Item 1c (trace T10): expansion switch. The digest main view
+    /// follows the status read policy — superseded records are excluded
+    /// from `top_decisions` on policy-active databases. Setting this to
+    /// `true` re-admits them, stamped with `current_status` +
+    /// `superseded_by`, for history/archaeology packets. No-op on
+    /// legacy-policy databases (everything already included).
+    pub include_superseded: bool,
 }
 
 impl Default for SessionDigestConfig {
@@ -52,6 +59,7 @@ impl Default for SessionDigestConfig {
             max_conflicts: 5,
             max_triggers: 5,
             snippet_chars: 240,
+            include_superseded: false,
         }
     }
 }
@@ -64,6 +72,17 @@ pub struct DigestEntry {
     pub importance: f64,
     pub created_at: f64,
     pub namespace: String,
+    /// v0.10 Item 1c: chain-derived status (Active unless the record has
+    /// a selected inbound supersedes edge — only visible when the packet
+    /// was built with `include_superseded`).
+    pub current_status: crate::types::RecordStatus,
+    /// Successor rid when `current_status` is Superseded.
+    pub superseded_by: Option<String>,
+    /// v0.10 Item 1c (T10 "D-with-flag"): the record participates in an
+    /// OPEN conflict. Disputed records stay in the main view — a dispute
+    /// is a flag, not a demotion; the engine never silently picks a
+    /// winner.
+    pub disputed: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -81,6 +100,31 @@ pub struct DigestTrigger {
     pub trigger_type: String,
     pub urgency: f64,
     pub reason: String,
+}
+
+/// v0.10 Item 1c — one status transition visible to a resuming session.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct StatusTransition {
+    /// The record whose status changed.
+    pub rid: String,
+    pub from: crate::types::RecordStatus,
+    pub to: crate::types::RecordStatus,
+    /// The successor that caused the transition (supersession).
+    pub by_rid: Option<String>,
+    /// When the transition was committed (link `created_at`; injectable
+    /// clock under the testing feature).
+    pub at: f64,
+}
+
+/// v0.10 Item 1c — "what changed since T" for resuming sessions
+/// (trace T10 assertion 3).
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct ChangesSince {
+    pub since: f64,
+    /// Active records created after `since`, oldest first.
+    pub new_records: Vec<DigestEntry>,
+    /// Status transitions committed after `since`, oldest first.
+    pub status_transitions: Vec<StatusTransition>,
 }
 
 /// The session-start briefing.
@@ -116,6 +160,11 @@ impl YantrikDB {
                     importance: head.importance,
                     created_at: head.created_at,
                     namespace: head.namespace,
+                    // The narrative chain is append-only by convention;
+                    // chain_head already resolves to its tip.
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed: false,
                 });
             }
         }
@@ -123,24 +172,42 @@ impl YantrikDB {
         // Top live decisions — highest importance, most recent first. Read
         // directly so we can rank by importance (list_records ranks by rid).
         // v0.9.3: scoped to config.namespace when set (isolation contract).
+        //
+        // v0.10 Item 1c (trace T10): the main view is status-led — on
+        // policy-active databases, superseded records don't spend the
+        // packet's token budget re-teaching stale decisions. They come
+        // back (stamped) only behind config.include_superseded.
+        let exclude_superseded = self.status_read_policy() && !config.include_superseded;
         {
+            let not_superseded = if exclude_superseded {
+                " AND NOT EXISTS (SELECT 1 FROM record_links l \
+                   WHERE l.target_rid = memories.rid AND l.link_type = 'supersedes' \
+                   AND l.status = 'active' AND l.selection_state = 'selected')"
+            } else {
+                ""
+            };
             let conn = self.conn();
             let (sql, ns_param) = match config.namespace.as_deref() {
                 Some(ns) => (
-                    "SELECT rid, text, importance, created_at, namespace FROM memories \
-                     WHERE consolidation_status = 'active' AND importance >= 0.7 \
-                     AND namespace = ?2 \
-                     ORDER BY importance DESC, created_at DESC LIMIT ?1",
+                    format!(
+                        "SELECT rid, text, importance, created_at, namespace FROM memories \
+                         WHERE consolidation_status = 'active' AND importance >= 0.7 \
+                         AND namespace = ?2{not_superseded} \
+                         ORDER BY importance DESC, created_at DESC LIMIT ?1"
+                    ),
                     Some(ns.to_string()),
                 ),
                 None => (
-                    "SELECT rid, text, importance, created_at, namespace FROM memories \
-                     WHERE consolidation_status = 'active' AND importance >= 0.7 \
-                     ORDER BY importance DESC, created_at DESC LIMIT ?1",
+                    format!(
+                        "SELECT rid, text, importance, created_at, namespace FROM memories \
+                         WHERE consolidation_status = 'active' AND importance >= 0.7\
+                         {not_superseded} \
+                         ORDER BY importance DESC, created_at DESC LIMIT ?1"
+                    ),
                     None,
                 ),
             };
-            let mut stmt = conn.prepare(sql)?;
+            let mut stmt = conn.prepare(&sql)?;
             let map_row = |r: &rusqlite::Row| {
                 Ok((
                     r.get::<_, String>(0)?,
@@ -159,8 +226,41 @@ impl YantrikDB {
                     .collect::<std::result::Result<Vec<_>, _>>()?,
             };
             drop(stmt);
+
+            // v0.10 Item 1c stamps. Disputed (T10 "D-with-flag"): the
+            // record participates in an open conflict — flagged, never
+            // dropped. Superseded stamping only matters on expansion
+            // packets (the main view already excluded those rows).
+            let mut disputed_stmt = conn.prepare(
+                "SELECT EXISTS(SELECT 1 FROM conflicts \
+                 WHERE status = 'open' AND (memory_a = ?1 OR memory_b = ?1))",
+            )?;
+            let mut successor_stmt = conn.prepare(
+                "SELECT source_rid FROM record_links WHERE target_rid = ?1 \
+                 AND link_type = 'supersedes' \
+                 AND status = 'active' AND selection_state = 'selected' \
+                 LIMIT 1",
+            )?;
+            let mut stamped: Vec<(bool, Option<String>)> = Vec::with_capacity(rows.len());
+            for (rid, _, _, _, _) in &rows {
+                let disputed: bool = disputed_stmt.query_row(params![rid], |r| r.get(0))?;
+                let successor: Option<String> = if exclude_superseded {
+                    None // main view: superseded rows are already gone
+                } else {
+                    use rusqlite::OptionalExtension;
+                    successor_stmt
+                        .query_row(params![rid], |r| r.get(0))
+                        .optional()?
+                };
+                stamped.push((disputed, successor));
+            }
+            drop(disputed_stmt);
+            drop(successor_stmt);
             drop(conn);
-            for (rid, enc_text, importance, created_at, namespace) in rows {
+
+            for ((rid, enc_text, importance, created_at, namespace), (disputed, successor)) in
+                rows.into_iter().zip(stamped)
+            {
                 let text = self.decrypt_text(&enc_text).unwrap_or(enc_text);
                 digest.top_decisions.push(DigestEntry {
                     snippet: snip(&text, config.snippet_chars),
@@ -168,6 +268,13 @@ impl YantrikDB {
                     importance,
                     created_at,
                     namespace,
+                    current_status: if successor.is_some() {
+                        crate::types::RecordStatus::Superseded
+                    } else {
+                        Default::default()
+                    },
+                    superseded_by: successor,
+                    disputed,
                 });
             }
         }
@@ -254,6 +361,122 @@ impl YantrikDB {
         digest.last_maintenance = self.last_maintenance_cycle()?;
 
         Ok(digest)
+    }
+
+    /// v0.10 Item 1c — trace T10 assertion 3: "what changed since T".
+    ///
+    /// Returns exactly the records created and the status transitions
+    /// committed after `since` (epoch seconds), optionally scoped to a
+    /// namespace. Built for the resuming-session case: instead of
+    /// re-reading the whole packet, a host asks "what moved while I was
+    /// away". Timestamps come from `time::now_secs` at write time, so
+    /// the testing feature's injectable clock makes this deterministic.
+    ///
+    /// Status transitions currently cover supersession (Active →
+    /// Superseded, with the successor rid). A retraction re-promotes the
+    /// record on the read path immediately, but `record_links` keeps no
+    /// retraction timestamp, so retractions are not (yet) reported here.
+    pub fn what_changed_since(
+        &self,
+        since: f64,
+        namespace: Option<&str>,
+        snippet_chars: usize,
+    ) -> Result<ChangesSince> {
+        let snip = |s: &str, n: usize| -> String { s.chars().take(n).collect::<String>() };
+        let mut changes = ChangesSince {
+            since,
+            ..Default::default()
+        };
+
+        let conn = self.conn();
+
+        // New records after T (active only; tombstoned/consolidated rows
+        // are lifecycle, not content the resuming session must learn).
+        let (rec_sql, transitions_sql) = match namespace {
+            Some(_) => (
+                "SELECT rid, text, importance, created_at, namespace FROM memories \
+                 WHERE created_at > ?1 AND consolidation_status = 'active' \
+                 AND namespace = ?2 ORDER BY created_at ASC",
+                "SELECT l.target_rid, l.source_rid, l.created_at \
+                 FROM record_links l JOIN memories m ON m.rid = l.target_rid \
+                 WHERE l.link_type = 'supersedes' AND l.status = 'active' \
+                 AND l.selection_state = 'selected' AND l.created_at > ?1 \
+                 AND m.namespace = ?2 ORDER BY l.created_at ASC",
+            ),
+            None => (
+                "SELECT rid, text, importance, created_at, namespace FROM memories \
+                 WHERE created_at > ?1 AND consolidation_status = 'active' \
+                 ORDER BY created_at ASC",
+                "SELECT l.target_rid, l.source_rid, l.created_at \
+                 FROM record_links l \
+                 WHERE l.link_type = 'supersedes' AND l.status = 'active' \
+                 AND l.selection_state = 'selected' AND l.created_at > ?1 \
+                 ORDER BY l.created_at ASC",
+            ),
+        };
+
+        let mut rec_stmt = conn.prepare(rec_sql)?;
+        let map_rec = |r: &rusqlite::Row| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, f64>(2)?,
+                r.get::<_, f64>(3)?,
+                r.get::<_, String>(4)?,
+            ))
+        };
+        let rec_rows = match namespace {
+            Some(ns) => rec_stmt
+                .query_map(params![since, ns], map_rec)?
+                .collect::<std::result::Result<Vec<_>, _>>()?,
+            None => rec_stmt
+                .query_map(params![since], map_rec)?
+                .collect::<std::result::Result<Vec<_>, _>>()?,
+        };
+        drop(rec_stmt);
+
+        let mut tr_stmt = conn.prepare(transitions_sql)?;
+        let map_tr = |r: &rusqlite::Row| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, f64>(2)?,
+            ))
+        };
+        let tr_rows = match namespace {
+            Some(ns) => tr_stmt
+                .query_map(params![since, ns], map_tr)?
+                .collect::<std::result::Result<Vec<_>, _>>()?,
+            None => tr_stmt
+                .query_map(params![since], map_tr)?
+                .collect::<std::result::Result<Vec<_>, _>>()?,
+        };
+        drop(tr_stmt);
+        drop(conn);
+
+        for (rid, enc_text, importance, created_at, ns) in rec_rows {
+            let text = self.decrypt_text(&enc_text).unwrap_or(enc_text);
+            changes.new_records.push(DigestEntry {
+                snippet: snip(&text, snippet_chars),
+                rid,
+                importance,
+                created_at,
+                namespace: ns,
+                current_status: Default::default(),
+                superseded_by: None,
+                disputed: false,
+            });
+        }
+        for (target, source, at) in tr_rows {
+            changes.status_transitions.push(StatusTransition {
+                rid: target,
+                from: crate::types::RecordStatus::Active,
+                to: crate::types::RecordStatus::Superseded,
+                by_rid: Some(source),
+                at,
+            });
+        }
+        Ok(changes)
     }
 
     /// Task 40 — end-of-session auto-capture. Takes an agent-provided session

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -890,6 +890,7 @@ impl YantrikDB {
             source,
             certainty_min,
             order,
+            false,
         )?;
 
         if expand_links == 0 {
@@ -1520,6 +1521,9 @@ mod tests {
         )
         .unwrap();
 
+        // Fresh DBs exclude superseded records by default (status read
+        // policy), so the stamped-archaeology path is exercised via
+        // include_superseded = true.
         let results = db
             .recall(
                 &db.embed("what is the deploy target").unwrap(),
@@ -1535,12 +1539,13 @@ mod tests {
                 None,
                 None,
                 None,
+                true, // include_superseded — history query
             )
             .unwrap();
         let old_hit = results
             .iter()
             .find(|r| r.rid == old)
-            .expect("old record still in results (no exclusion policy yet)");
+            .expect("include_superseded re-admits the old record");
         assert_eq!(
             old_hit.current_status,
             crate::types::RecordStatus::Superseded
@@ -1549,6 +1554,163 @@ mod tests {
         let new_hit = results.iter().find(|r| r.rid == new).expect("head present");
         assert_eq!(new_hit.current_status, crate::types::RecordStatus::Active);
         assert!(new_hit.superseded_by.is_none());
+    }
+
+    /// Shared recall shim for the policy tests below: query with `seed`,
+    /// top_k 10, no filters, skip_reinforce, with the given
+    /// include_superseded flag.
+    fn recall_ids(db: &YantrikDB, seed: f32, include_superseded: bool) -> Vec<String> {
+        db.recall(
+            &vec_seed(seed, 8),
+            10,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+            include_superseded,
+        )
+        .unwrap()
+        .into_iter()
+        .map(|r| r.rid)
+        .collect()
+    }
+
+    #[test]
+    fn fresh_db_excludes_superseded_from_recall_by_default() {
+        // v0.10 Item 1 / trace T01: eligibility-not-demotion. On a fresh
+        // database the status read policy is on by default, and a
+        // superseded record never competes for top_k slots — its
+        // successor is returned, it is not.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        assert!(
+            db.status_read_policy(),
+            "fresh install defaults to the status-led read path"
+        );
+
+        let old = rec(&db, "old version of the fact", 1.0);
+        let new = rec(&db, "new version of the fact", 1.05);
+        supersede(&db, &new, &old).unwrap();
+
+        let ids = recall_ids(&db, 1.0, false);
+        assert!(ids.contains(&new), "successor is eligible");
+        assert!(
+            !ids.contains(&old),
+            "superseded record must be excluded from eligibility (T01 hard zero)"
+        );
+
+        // include_superseded re-admits it, stamped, for history queries.
+        let results = db
+            .recall(
+                &vec_seed(1.0, 8),
+                10,
+                None,
+                None,
+                false,
+                false,
+                None,
+                true,
+                None,
+                None,
+                None,
+                None,
+                None,
+                true,
+            )
+            .unwrap();
+        let old_hit = results
+            .iter()
+            .find(|r| r.rid == old)
+            .expect("include_superseded re-admits the superseded record");
+        assert_eq!(
+            old_hit.current_status,
+            crate::types::RecordStatus::Superseded
+        );
+        assert_eq!(old_hit.superseded_by.as_deref(), Some(new.as_str()));
+
+        // The builder exposes the same switch.
+        let via_builder = db
+            .query(crate::types::RecallQuery::new(vec_seed(1.0, 8)).include_superseded())
+            .unwrap();
+        assert!(via_builder.iter().any(|r| r.rid == old));
+
+        // Stats adoption surface.
+        let stats = db.stats(None).unwrap();
+        assert_eq!(stats.status_read_policy, "exclude_superseded");
+        assert_eq!(stats.superseded_records, 1);
+    }
+
+    #[test]
+    fn legacy_policy_serves_superseded_and_counts_nudge_until_opt_in() {
+        // v0.10 Item 1: a migrated (legacy) database keeps
+        // include-everything behavior — superseded results arrive
+        // stamped, the adoption-nudge counter ticks — until the
+        // operator opts in via set_status_read_policy(true).
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        db.set_status_read_policy(false).unwrap(); // simulate legacy DB
+        assert!(!db.status_read_policy());
+
+        let old = rec(&db, "old version of the fact", 1.0);
+        let new = rec(&db, "new version of the fact", 1.05);
+        supersede(&db, &new, &old).unwrap();
+
+        let ids = recall_ids(&db, 1.0, false);
+        assert!(
+            ids.contains(&old) && ids.contains(&new),
+            "legacy policy serves both, stamped"
+        );
+
+        let stats = db.stats(None).unwrap();
+        assert_eq!(stats.status_read_policy, "legacy");
+        assert!(
+            stats.superseded_served_since_boot >= 1,
+            "nudge counter ticks when a superseded result is served"
+        );
+
+        // Opt in: the same recall now excludes the superseded record.
+        db.set_status_read_policy(true).unwrap();
+        let ids = recall_ids(&db, 1.0, false);
+        assert!(ids.contains(&new));
+        assert!(!ids.contains(&old), "opt-in switches to exclusion");
+    }
+
+    #[test]
+    fn status_read_policy_persists_across_reopen() {
+        // The policy is durable meta, not a per-process flag: an opt-out
+        // written by one process must be honored by the next open.
+        let dir = std::env::temp_dir().join(format!(
+            "yantrik_policy_test_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("t").len()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("policy.db");
+        let path_str = path.to_str().unwrap();
+
+        {
+            let db = YantrikDB::new(path_str, 8).unwrap();
+            assert!(db.status_read_policy(), "fresh file DB defaults on");
+            db.set_status_read_policy(false).unwrap();
+        }
+        {
+            let db = YantrikDB::new(path_str, 8).unwrap();
+            assert!(
+                !db.status_read_policy(),
+                "explicit legacy opt-out survives reopen (not clobbered by the fresh-install seed)"
+            );
+            db.set_status_read_policy(true).unwrap();
+        }
+        {
+            let db = YantrikDB::new(path_str, 8).unwrap();
+            assert!(db.status_read_policy(), "opt-in survives reopen");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1788,7 +1950,14 @@ mod tests {
         // The redteam's motivating correctness scenario. A supersedes B.
         // A query close to B should, with expand_links, demote B and
         // surface A above it.
+        //
+        // v0.10 Item 1: score demotion is the LEGACY-policy mechanism —
+        // under the status read policy (fresh-DB default) B is excluded
+        // from eligibility entirely, which is strictly stronger (covered
+        // by fresh_db_excludes_superseded_from_recall_by_default). This
+        // test pins the demotion contract for pre-v0.10 databases.
         let db = YantrikDB::new(":memory:", 8).unwrap();
+        db.set_status_read_policy(false).unwrap();
         // B and the query are near-identical; A is also near but we rely
         // on the link, not similarity, to rank it.
         let b = rec(&db, "old fact about widgets", 5.0);
@@ -1853,6 +2022,7 @@ mod tests {
         let direct = db
             .recall(
                 &query, 5, None, None, false, false, None, true, None, None, None, None, None,
+                false,
             )
             .unwrap();
         assert_eq!(

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -465,6 +465,54 @@ impl YantrikDB {
         Ok(WalkOutcome::NotReached)
     }
 
+    /// **v0.10 Item 1 — resolve the CURRENT head of a record's supersedes
+    /// chain.** Walks selected active inbound successors from `rid` until a
+    /// record with no successor is found. Returns `(head_rid, status)` —
+    /// the status is that of the HEAD itself (consumer review R3: a chain
+    /// head that is itself Active is the normal case; the tuple shape
+    /// leaves room for richer head-status reporting as the status
+    /// vocabulary grows). `rid == head` when the record is not superseded.
+    ///
+    /// Under Phase-0 integrity each record has at most one selected
+    /// successor, so the walk is a straight line; the visited set + cap
+    /// guard against pre-Phase-0 legacy graphs (a corrupt component
+    /// returns [`YantrikDbError::ChainTraversalLimit`] rather than
+    /// silently picking a row — run [`Self::verify_chains`] and repair).
+    pub fn resolve_current(&self, rid: &str) -> Result<(String, crate::types::RecordStatus)> {
+        let conn = self.conn.lock();
+        let mut current = rid.to_string();
+        let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+        loop {
+            if visited.len() > CHAIN_WALK_CAP {
+                return Err(YantrikDbError::ChainTraversalLimit {
+                    start_rid: rid.to_string(),
+                    limit: CHAIN_WALK_CAP,
+                });
+            }
+            if !visited.insert(current.clone()) {
+                // Legacy cycle (pre-Phase-0 data): refuse to pick silently.
+                return Err(YantrikDbError::ChainTraversalLimit {
+                    start_rid: rid.to_string(),
+                    limit: visited.len(),
+                });
+            }
+            let successor: Option<String> = conn
+                .query_row(
+                    "SELECT source_rid FROM record_links WHERE target_rid = ?1 \
+                     AND link_type = 'supersedes' \
+                     AND status = 'active' AND selection_state = 'selected' \
+                     LIMIT 1",
+                    params![current],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            match successor {
+                Some(s) => current = s,
+                None => return Ok((current, crate::types::RecordStatus::Active)),
+            }
+        }
+    }
+
     /// **v0.10 Phase 0 — audit the selected supersedes graph** against the
     /// chain-integrity invariants. REPORT-ONLY: legacy databases (edges
     /// written before the write gate existed) may violate them; the engine
@@ -925,6 +973,10 @@ impl YantrikDB {
                     domain: mem.domain,
                     source: mem.source,
                     emotional_state: mem.emotional_state,
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                 });
             }
         }
@@ -1399,6 +1451,101 @@ mod tests {
             )
             .unwrap();
         assert_eq!(state_low, "selected", "next candidate promoted");
+    }
+
+    #[test]
+    fn resolve_current_walks_to_chain_head() {
+        // v0.10 Item 1 / trace T2: A→B→C chain resolves to C from any member.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "v1", 1.0);
+        let b = rec(&db, "v2", 2.0);
+        let c = rec(&db, "v3", 3.0);
+        supersede(&db, &b, &a).unwrap();
+        supersede(&db, &c, &b).unwrap();
+
+        for start in [&a, &b, &c] {
+            let (head, status) = db.resolve_current(start).unwrap();
+            assert_eq!(head, c, "from {start}, head is c");
+            assert_eq!(status, crate::types::RecordStatus::Active);
+        }
+        // A record with no chain resolves to itself.
+        let lone = rec(&db, "standalone", 9.0);
+        assert_eq!(db.resolve_current(&lone).unwrap().0, lone);
+    }
+
+    #[cfg(feature = "bundled-embedder")]
+    #[test]
+    fn recall_stamps_typed_status_superseded_and_disputed() {
+        // v0.10 Item 1 / trace T1 (typed half) + T5: a superseded record
+        // returned by recall carries current_status=superseded +
+        // superseded_by; a disputed record carries disputed_with. Typed
+        // fields, not prose parsing.
+        let db = YantrikDB::with_default(":memory:").unwrap();
+        let old = db
+            .record_text(
+                "the deploy target is the staging cluster",
+                "semantic",
+                0.7,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                "default",
+                0.8,
+                "work",
+                "user",
+                None,
+            )
+            .unwrap();
+        let new = db
+            .record_text(
+                "the deploy target is the production cluster",
+                "semantic",
+                0.7,
+                0.0,
+                604800.0,
+                &serde_json::json!({}),
+                "default",
+                0.8,
+                "work",
+                "user",
+                None,
+            )
+            .unwrap();
+        db.link(
+            &new,
+            &RecordLink {
+                target_rid: old.clone(),
+                link_type: LinkType::Supersedes,
+            },
+        )
+        .unwrap();
+
+        let results = db
+            .recall(
+                &db.embed("what is the deploy target").unwrap(),
+                10,
+                None,
+                None,
+                false,
+                false,
+                None,
+                true,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let old_hit = results
+            .iter()
+            .find(|r| r.rid == old)
+            .expect("old record still in results (no exclusion policy yet)");
+        assert_eq!(old_hit.current_status, crate::types::RecordStatus::Superseded);
+        assert_eq!(old_hit.superseded_by.as_deref(), Some(new.as_str()));
+        let new_hit = results.iter().find(|r| r.rid == new).expect("head present");
+        assert_eq!(new_hit.current_status, crate::types::RecordStatus::Active);
+        assert!(new_hit.superseded_by.is_none());
     }
 
     #[test]

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -1541,7 +1541,10 @@ mod tests {
             .iter()
             .find(|r| r.rid == old)
             .expect("old record still in results (no exclusion policy yet)");
-        assert_eq!(old_hit.current_status, crate::types::RecordStatus::Superseded);
+        assert_eq!(
+            old_hit.current_status,
+            crate::types::RecordStatus::Superseded
+        );
         assert_eq!(old_hit.superseded_by.as_deref(), Some(new.as_str()));
         let new_hit = results.iter().find(|r| r.rid == new).expect("head present");
         assert_eq!(new_hit.current_status, crate::types::RecordStatus::Active);

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -1681,6 +1681,69 @@ mod tests {
     }
 
     #[test]
+    fn disputed_records_both_returned_with_typed_cross_links() {
+        // v0.10 Item 1 / trace T05 "disputed-not-dropped": A contradicts
+        // B, neither superseded. Both must be returned, each carrying the
+        // other's rid in typed disputed_with — the engine NEVER silently
+        // picks a winner on an open dispute.
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let a = rec(&db, "the standup is at 9am", 1.0);
+        let b = rec(&db, "the standup is at 10am", 1.05);
+        crate::create_conflict(
+            &db,
+            &crate::types::ConflictType::Temporal,
+            &a,
+            &b,
+            None,
+            None,
+            "test fixture: contradictory standup times",
+        )
+        .unwrap();
+
+        let results = db
+            .recall(
+                &vec_seed(1.0, 8),
+                10,
+                None,
+                None,
+                false,
+                false,
+                None,
+                true,
+                None,
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .unwrap();
+
+        let hit_a = results
+            .iter()
+            .find(|r| r.rid == a)
+            .expect("disputed A still returned (not dropped)");
+        let hit_b = results
+            .iter()
+            .find(|r| r.rid == b)
+            .expect("disputed B still returned (not dropped)");
+        assert!(
+            hit_a.disputed_with.contains(&b),
+            "A carries B in disputed_with: {:?}",
+            hit_a.disputed_with
+        );
+        assert!(
+            hit_b.disputed_with.contains(&a),
+            "B carries A in disputed_with: {:?}",
+            hit_b.disputed_with
+        );
+        // No winner picked: both stay Active (dispute is orthogonal to
+        // the supersedes-derived status).
+        assert_eq!(hit_a.current_status, crate::types::RecordStatus::Active);
+        assert_eq!(hit_b.current_status, crate::types::RecordStatus::Active);
+    }
+
+    #[test]
     fn status_read_policy_persists_across_reopen() {
         // The policy is durable meta, not a per-process flag: an opt-out
         // written by one process must be honored by the next open.

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -170,6 +170,24 @@ pub struct YantrikDB {
     /// `Relaxed` atomic load instead of a Mutex<Connection> acquire +
     /// index scan + drop.
     pub(crate) pending_op_count: std::sync::atomic::AtomicI64,
+    /// **v0.10 Item 1 — status-led read path.** Cached
+    /// `meta.status_read_policy`: `true` means recall EXCLUDES superseded
+    /// records from result eligibility (the fresh-install default);
+    /// `false` is the legacy include-everything behavior for pre-v0.10
+    /// databases until the operator opts in via
+    /// [`YantrikDB::set_status_read_policy`]. Exclusion is
+    /// eligibility-not-demotion: superseded rows never compete for
+    /// top_k slots, rather than being score-penalized. Per-call
+    /// `include_superseded = true` re-admits them (stamped) for
+    /// history/archaeology queries.
+    pub(crate) exclude_superseded_reads: std::sync::atomic::AtomicBool,
+    /// **v0.10 Item 1 — adoption nudge.** Since-boot count of recall
+    /// results served while superseded (only possible on legacy-policy
+    /// databases or `include_superseded` calls). Surfaced in `stats()`
+    /// so operators of migrated DBs can see what the status read policy
+    /// would have excluded before opting in. In-memory by design — a
+    /// durable counter would put a write on the recall hot path.
+    pub(crate) superseded_served_since_boot: std::sync::atomic::AtomicU64,
     /// **Phase 6 RYW**: per-namespace high-water mark of applied seqs.
     /// Updated by record/record_with_rid (and siblings) after the write
     /// has materialized into the in-memory delta. `recall_with_seq` waits
@@ -537,6 +555,22 @@ impl YantrikDB {
             params![stamp.to_string()],
         )?;
 
+        // **v0.10 Item 1.** Fresh installs default to the status-led read
+        // path: superseded records are excluded from recall eligibility.
+        // `existing_version` is None only when the meta table didn't exist
+        // before this open — i.e. a brand-new database. Migrated/legacy
+        // DBs keep include-everything behavior until the operator opts in
+        // (set_status_read_policy); the stats() adoption-nudge counter
+        // shows them what the policy would have excluded. INSERT OR
+        // IGNORE keeps any operator-set value authoritative.
+        if existing_version.is_none() {
+            conn.execute(
+                "INSERT OR IGNORE INTO meta (key, value) \
+                 VALUES ('status_read_policy', 'exclude_superseded')",
+                [],
+            )?;
+        }
+
         // **v28 (issue #41 brainstorm-4 §6).** Seed meta.active_generation
         // on first install. INSERT OR IGNORE preserves the durable
         // value on subsequent opens — reembed Phase-2's swap
@@ -850,6 +884,15 @@ impl YantrikDB {
             ))
         };
 
+        // v0.10 Item 1: hydrate the cached status read policy from meta.
+        // Any value other than the exact 'exclude_superseded' opt-in reads
+        // as legacy (missing key on migrated DBs, or an operator writing
+        // e.g. 'legacy' to switch the policy back off).
+        let exclude_superseded_reads = matches!(
+            Self::get_meta(&conn, "status_read_policy")?.as_deref(),
+            Some("exclude_superseded")
+        );
+
         Ok(Self {
             conn: Mutex::new(conn),
             read_conns,
@@ -860,6 +903,8 @@ impl YantrikDB {
             scoring_cache: RwLock::new(scoring_cache),
             vec_seq: std::sync::atomic::AtomicU64::new(0),
             pending_op_count: std::sync::atomic::AtomicI64::new(initial_pending),
+            exclude_superseded_reads: std::sync::atomic::AtomicBool::new(exclude_superseded_reads),
+            superseded_served_since_boot: std::sync::atomic::AtomicU64::new(0),
             visible_seq: dashmap::DashMap::new(),
             visible_seq_cv: parking_lot::Condvar::new(),
             visible_seq_wait_mu: parking_lot::Mutex::new(()),
@@ -1068,6 +1113,37 @@ impl YantrikDB {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// **v0.10 Item 1.** Whether the status-led read path is active:
+    /// `true` = recall excludes superseded records from eligibility
+    /// (fresh-install default), `false` = legacy include-everything
+    /// (migrated DBs that haven't opted in yet). Mirrors
+    /// `meta.status_read_policy`, cached at open.
+    pub fn status_read_policy(&self) -> bool {
+        self.exclude_superseded_reads
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// **v0.10 Item 1.** Set the status read policy durably (writes
+    /// `meta.status_read_policy`) and update the cached flag. This is
+    /// the legacy-database opt-in: after migrating a pre-v0.10 DB,
+    /// review `stats().superseded_served_since_boot`, then call
+    /// `set_status_read_policy(true)` to switch recall to the
+    /// status-led read path. `false` returns to legacy behavior.
+    pub fn set_status_read_policy(&self, exclude_superseded: bool) -> Result<()> {
+        let value = if exclude_superseded {
+            "exclude_superseded"
+        } else {
+            "legacy"
+        };
+        self.conn().execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('status_read_policy', ?1)",
+            params![value],
+        )?;
+        self.exclude_superseded_reads
+            .store(exclude_superseded, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
     }
 
     /// Get a new HLC timestamp (ticks the clock forward).
@@ -1605,6 +1681,7 @@ impl YantrikDB {
             None,  // source
             None,  // certainty_min (#46)
             None,  // order (#46) — relevance
+            false, // include_superseded (v0.10 Item 1) — policy default
         )
     }
 
@@ -1633,8 +1710,9 @@ impl YantrikDB {
             None,  // namespace
             domain,
             source,
-            None, // certainty_min (#46)
-            None, // order (#46) — relevance
+            None,  // certainty_min (#46)
+            None,  // order (#46) — relevance
+            false, // include_superseded (v0.10 Item 1) — policy default
         )
     }
 }

--- a/crates/yantrikdb-core/src/engine/procedural.rs
+++ b/crates/yantrikdb-core/src/engine/procedural.rs
@@ -45,9 +45,10 @@ impl YantrikDB {
             true, // skip_reinforce — we'll reinforce manually below
             namespace,
             domain,
-            None, // no source filter
-            None, // no certainty_min (#46)
-            None, // default relevance order (#46)
+            None,  // no source filter
+            None,  // no certainty_min (#46)
+            None,  // default relevance order (#46)
+            false, // include_superseded (v0.10 Item 1) — policy default
         )
     }
 

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -2278,12 +2278,37 @@ impl YantrikDB {
             vec![]
         };
 
+        // v0.10 Item 1b (trace T08): typed coverage. The relevance gate is
+        // the per-database learned gate_tau — the same threshold the scorer
+        // uses to decide when a hit is similar enough for importance
+        // boosting to engage. Outcome classification:
+        //   scope empty                       -> NoMatchingRecord
+        //   results empty, or best under gate -> BelowThreshold
+        //   otherwise                         -> Matched
+        let threshold_tau = self.load_learned_weights()?.gate_tau;
+        let outcome = if candidate_count == 0 {
+            crate::types::CoverageOutcome::NoMatchingRecord
+        } else if results.is_empty() || top_similarity < threshold_tau {
+            crate::types::CoverageOutcome::BelowThreshold
+        } else {
+            crate::types::CoverageOutcome::Matched
+        };
+        let coverage = crate::types::SearchCoverage {
+            namespace: namespace.map(str::to_string),
+            memory_type: memory_type.map(str::to_string),
+            candidate_count,
+            threshold_tau,
+            top_similarity,
+            outcome,
+        };
+
         Ok(RecallResponse {
             results,
             confidence,
             certainty_reasons,
             retrieval_summary: summary,
             hints,
+            coverage,
         })
     }
 

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -453,10 +453,10 @@ impl YantrikDB {
                         domain: row.domain.clone(),
                         source: row.source.clone(),
                         emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                        current_status: Default::default(),
+                        superseded_by: None,
+                        disputed_with: Vec::new(),
+                        aged_last_verified: None,
                     });
                 }
             }
@@ -1053,10 +1053,10 @@ impl YantrikDB {
                                     domain: row.domain.clone(),
                                     source: row.source.clone(),
                                     emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                                    current_status: Default::default(),
+                                    superseded_by: None,
+                                    disputed_with: Vec::new(),
+                                    aged_last_verified: None,
                                 });
                             }
                         }
@@ -1181,10 +1181,10 @@ impl YantrikDB {
                         domain: row.domain.clone(),
                         source: row.source.clone(),
                         emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                        current_status: Default::default(),
+                        superseded_by: None,
+                        disputed_with: Vec::new(),
+                        aged_last_verified: None,
                     });
                 }
             }
@@ -1392,10 +1392,10 @@ impl YantrikDB {
                                     domain: row.domain.clone(),
                                     source: row.source.clone(),
                                     emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                                    current_status: Default::default(),
+                                    superseded_by: None,
+                                    disputed_with: Vec::new(),
+                                    aged_last_verified: None,
                                 });
                             }
                         }
@@ -1710,10 +1710,10 @@ impl YantrikDB {
                             domain: row.domain.clone(),
                             source: row.source.clone(),
                             emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                            current_status: Default::default(),
+                            superseded_by: None,
+                            disputed_with: Vec::new(),
+                            aged_last_verified: None,
                         });
                     }
                     drop(cache);
@@ -2742,10 +2742,10 @@ impl YantrikDB {
                         domain: row.domain.clone(),
                         source: row.source.clone(),
                         emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                        current_status: Default::default(),
+                        superseded_by: None,
+                        disputed_with: Vec::new(),
+                        aged_last_verified: None,
                     });
                 }
             }
@@ -3277,10 +3277,10 @@ impl YantrikDB {
                                     domain: row.domain.clone(),
                                     source: row.source.clone(),
                                     emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                                    current_status: Default::default(),
+                                    superseded_by: None,
+                                    disputed_with: Vec::new(),
+                                    aged_last_verified: None,
                                 });
                             }
                         }
@@ -3396,10 +3396,10 @@ impl YantrikDB {
                         domain: row.domain.clone(),
                         source: row.source.clone(),
                         emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                        current_status: Default::default(),
+                        superseded_by: None,
+                        disputed_with: Vec::new(),
+                        aged_last_verified: None,
                     });
                 }
             }
@@ -3597,10 +3597,10 @@ impl YantrikDB {
                                     domain: row.domain.clone(),
                                     source: row.source.clone(),
                                     emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                                    current_status: Default::default(),
+                                    superseded_by: None,
+                                    disputed_with: Vec::new(),
+                                    aged_last_verified: None,
                                 });
                             }
                         }
@@ -3903,10 +3903,10 @@ impl YantrikDB {
                                 domain: row.domain.clone(),
                                 source: row.source.clone(),
                                 emotional_state: row.emotional_state.clone(),
-                    current_status: Default::default(),
-                    superseded_by: None,
-                    disputed_with: Vec::new(),
-                    aged_last_verified: None,
+                                current_status: Default::default(),
+                                superseded_by: None,
+                                disputed_with: Vec::new(),
+                                aged_last_verified: None,
                             });
                         }
                     }

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 
 use crate::error::{Result, YantrikDbError};
 use crate::scoring;
@@ -347,6 +347,10 @@ impl YantrikDB {
                     domain: row.domain.clone(),
                     source: row.source.clone(),
                     emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                 });
             }
         } // drop cache borrow
@@ -449,6 +453,10 @@ impl YantrikDB {
                         domain: row.domain.clone(),
                         source: row.source.clone(),
                         emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                     });
                 }
             }
@@ -1045,6 +1053,10 @@ impl YantrikDB {
                                     domain: row.domain.clone(),
                                     source: row.source.clone(),
                                     emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                                 });
                             }
                         }
@@ -1169,6 +1181,10 @@ impl YantrikDB {
                         domain: row.domain.clone(),
                         source: row.source.clone(),
                         emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                     });
                 }
             }
@@ -1376,6 +1392,10 @@ impl YantrikDB {
                                     domain: row.domain.clone(),
                                     source: row.source.clone(),
                                     emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                                 });
                             }
                         }
@@ -1690,6 +1710,10 @@ impl YantrikDB {
                             domain: row.domain.clone(),
                             source: row.source.clone(),
                             emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                         });
                     }
                     drop(cache);
@@ -1907,29 +1931,43 @@ impl YantrikDB {
         const LOW_CONFIRMATION: i64 = 1;
         let now_ts = crate::time::now_secs();
         let conn = self.conn();
-        // Read created_at + access_count from the table (the source of truth),
-        // not the RecallResult, whose created_at comes from the scoring cache.
-        let mut access_stmt =
-            conn.prepare("SELECT created_at, access_count FROM memories WHERE rid = ?1")?;
+        // Read created_at/updated_at/access_count from the table (the source
+        // of truth), not the RecallResult, whose created_at comes from the
+        // scoring cache.
+        let mut access_stmt = conn
+            .prepare("SELECT created_at, updated_at, access_count FROM memories WHERE rid = ?1")?;
+        // v0.10 Item 1: fetch the SUCCESSOR rid (not just a count) so the
+        // typed status can name it.
         let mut superseded_stmt = conn.prepare(
-            "SELECT COUNT(*) FROM record_links WHERE target_rid = ?1 \
+            "SELECT source_rid FROM record_links WHERE target_rid = ?1 \
              AND link_type = 'supersedes' \
-             AND status = 'active' AND selection_state = 'selected'",
+             AND status = 'active' AND selection_state = 'selected' \
+             LIMIT 1",
         )?;
         for r in results.iter_mut() {
-            let (created_at, access_count): (f64, i64) = access_stmt
-                .query_row(params![r.rid], |row| Ok((row.get(0)?, row.get(1)?)))
-                .unwrap_or((now_ts, 0));
+            let (created_at, updated_at, access_count): (f64, f64, i64) = access_stmt
+                .query_row(params![r.rid], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })
+                .unwrap_or((now_ts, now_ts, 0));
             let age_days = (now_ts - created_at).max(0.0) / 86_400.0;
             if age_days > STALE_AGE_DAYS && access_count <= LOW_CONFIRMATION {
+                // v0.10 Item 1: typed aged flag (orthogonal to status —
+                // aged is a retrieval-age signal, not a truth status).
+                r.aged_last_verified = Some(updated_at);
                 r.why_retrieved.push(format!(
                     "⚠ {age_days:.0}d old, rarely confirmed — verify it is still current"
                 ));
             }
-            let superseded: i64 = superseded_stmt
+            let successor: Option<String> = superseded_stmt
                 .query_row(params![r.rid], |row| row.get(0))
-                .unwrap_or(0);
-            if superseded > 0 {
+                .optional()
+                .unwrap_or(None);
+            if let Some(successor_rid) = successor {
+                // v0.10 Item 1: exclusive chain-derived status, typed. The
+                // prose stamp stays for one release.
+                r.current_status = crate::types::RecordStatus::Superseded;
+                r.superseded_by = Some(successor_rid);
                 r.why_retrieved
                     .push("⚠ superseded by a newer record — likely outdated".to_string());
             }
@@ -2604,6 +2642,10 @@ impl YantrikDB {
                     domain: row.domain.clone(),
                     source: row.source.clone(),
                     emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                 });
             }
         }
@@ -2700,6 +2742,10 @@ impl YantrikDB {
                         domain: row.domain.clone(),
                         source: row.source.clone(),
                         emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                     });
                 }
             }
@@ -3231,6 +3277,10 @@ impl YantrikDB {
                                     domain: row.domain.clone(),
                                     source: row.source.clone(),
                                     emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                                 });
                             }
                         }
@@ -3346,6 +3396,10 @@ impl YantrikDB {
                         domain: row.domain.clone(),
                         source: row.source.clone(),
                         emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                     });
                 }
             }
@@ -3543,6 +3597,10 @@ impl YantrikDB {
                                     domain: row.domain.clone(),
                                     source: row.source.clone(),
                                     emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                                 });
                             }
                         }
@@ -3845,6 +3903,10 @@ impl YantrikDB {
                                 domain: row.domain.clone(),
                                 source: row.source.clone(),
                                 emotional_state: row.emotional_state.clone(),
+                    current_status: Default::default(),
+                    superseded_by: None,
+                    disputed_with: Vec::new(),
+                    aged_last_verified: None,
                             });
                         }
                     }

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -200,6 +200,15 @@ impl YantrikDB {
         // `confidence` order if it wants the user-facing rename.
         certainty_min: Option<f64>,
         order: Option<&str>,
+        // v0.10 Item 1: positive-named re-admission switch (per nuron's
+        // consumer review). When the status read policy is active,
+        // superseded records are EXCLUDED from result eligibility by
+        // default; `include_superseded = true` re-admits them — stamped
+        // with `current_status = Superseded` + `superseded_by` — for
+        // history/archaeology queries ("show me what I used to believe").
+        // On legacy-policy databases this flag is a no-op (everything is
+        // already included).
+        include_superseded: bool,
     ) -> Result<Vec<RecallResult>> {
         // Validate `order` upfront so callers get a clear error rather
         // than silently falling back to relevance when they typo a value.
@@ -1721,6 +1730,25 @@ impl YantrikDB {
             }
         }
 
+        // Step 3.4 (v0.10 Item 1): status-led eligibility filter.
+        //
+        // Eligibility, not demotion: when the status read policy is
+        // active and the caller didn't ask for history, superseded
+        // records leave the candidate pool HERE — before keyword slot
+        // reservation computes its cutoff and before MMR competes for
+        // top_k slots — so a stale fact can never outrank or crowd out
+        // its own successor (trace contract T01's hard-zero at k=1).
+        // Batched against the pool in one IN-clause query; databases
+        // with no supersedes edges pay one indexed probe per candidate
+        // and filter nothing.
+        if self.status_read_policy() && !include_superseded && !scored.is_empty() {
+            let pool_rids: Vec<&str> = scored.iter().map(|r| r.rid.as_str()).collect();
+            let superseded = self.superseded_rids_among(&pool_rids)?;
+            if !superseded.is_empty() {
+                scored.retain(|r| !superseded.contains(&r.rid));
+            }
+        }
+
         // Step 3.5: Keyword slot reservation
         //
         // Topic-relevant keyword matches (e.g., "yoga", "reading") often have
@@ -1970,6 +1998,13 @@ impl YantrikDB {
                 r.superseded_by = Some(successor_rid);
                 r.why_retrieved
                     .push("⚠ superseded by a newer record — likely outdated".to_string());
+                // v0.10 Item 1 adoption nudge: a superseded result was
+                // actually SERVED (legacy policy, or include_superseded).
+                // Counted here — the single point every returned result
+                // passes through — and surfaced in stats() so migrated
+                // DBs can see what the status read policy would exclude.
+                self.superseded_served_since_boot
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
         }
         Ok(())
@@ -2026,8 +2061,9 @@ impl YantrikDB {
             namespace,
             domain,
             source,
-            None, // certainty_min (#46) — recall_with_seq path defers to caller-side filtering
-            None, // order (#46) — default relevance
+            None,  // certainty_min (#46) — recall_with_seq path defers to caller-side filtering
+            None,  // order (#46) — default relevance
+            false, // include_superseded (v0.10 Item 1) — policy default; use query() builder for history
         )
     }
 
@@ -2055,6 +2091,7 @@ impl YantrikDB {
             q.source.as_deref(),
             q.certainty_min,
             q.order.as_deref(),
+            q.include_superseded,
         )
     }
 
@@ -2088,8 +2125,9 @@ impl YantrikDB {
             namespace,
             domain,
             source,
-            None, // certainty_min (#46) — recall_with_response defers to caller-side filtering
-            None, // order (#46) — default relevance
+            None,  // certainty_min (#46) — recall_with_response defers to caller-side filtering
+            None,  // order (#46) — default relevance
+            false, // include_superseded (v0.10 Item 1) — policy default; use query() builder for history
         )?;
 
         // Determine which retrieval sources were used
@@ -3915,6 +3953,18 @@ impl YantrikDB {
         }
         let graph_ms = t_graph.elapsed().as_secs_f64() * 1000.0;
 
+        // ── Phase 3.4: status-led eligibility filter (mirrors recall()) ──
+        // Profiled variant applies the policy default (no per-call
+        // include_superseded override) so timings stay representative
+        // of the real read path.
+        if self.status_read_policy() && !scored.is_empty() {
+            let pool_rids: Vec<&str> = scored.iter().map(|r| r.rid.as_str()).collect();
+            let superseded = self.superseded_rids_among(&pool_rids)?;
+            if !superseded.is_empty() {
+                scored.retain(|r| !superseded.contains(&r.rid));
+            }
+        }
+
         // ── Phase 3.5: Keyword slot reservation (mirrors recall()) ──
         {
             scored.sort_by(|a, b| b.score.total_cmp(&a.score));
@@ -4075,6 +4125,42 @@ impl YantrikDB {
     }
 
     /// Fetch only text and metadata for a set of RIDs (post-scoring hydration).
+    /// v0.10 Item 1 — which of `rids` are currently superseded, i.e.
+    /// have a SELECTED active inbound `supersedes` edge (edges are
+    /// stored NEW→OLD, so `target_rid` is the superseded record).
+    /// One batched IN-clause query against `idx_record_links_target_sel`.
+    pub(crate) fn superseded_rids_among(
+        &self,
+        rids: &[&str],
+    ) -> Result<std::collections::HashSet<String>> {
+        if rids.is_empty() {
+            return Ok(std::collections::HashSet::new());
+        }
+        let placeholders: String = (0..rids.len())
+            .map(|i| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT DISTINCT target_rid FROM record_links \
+             WHERE link_type = 'supersedes' \
+             AND status = 'active' AND selection_state = 'selected' \
+             AND target_rid IN ({placeholders})"
+        );
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        for r in rids {
+            param_values.push(Box::new(r.to_string()));
+        }
+        let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+
+        let conn = self.read_conn();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params_ref.as_slice(), |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<std::collections::HashSet<_>, _>>()?;
+        Ok(rows)
+    }
+
     pub(crate) fn fetch_text_metadata_by_rids(
         &self,
         rids: &[&str],

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -2388,7 +2388,7 @@ mod tests {
         let query = vec![0.99_f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let results = db
             .recall(
-                &query, 5, None, None, false, true, None, true, None, None, None, None, None,
+                &query, 5, None, None, false, true, None, true, None, None, None, None, None, false,
             )
             .unwrap();
         assert_eq!(

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -71,6 +71,15 @@ impl YantrikDB {
             [],
             |row| row.get(0),
         )?;
+        // v0.10 Item 1: how many records are currently superseded
+        // (selected active inbound supersedes edge).
+        let superseded_records = conn.query_row(
+            "SELECT COUNT(DISTINCT target_rid) FROM record_links \
+             WHERE link_type = 'supersedes' \
+             AND status = 'active' AND selection_state = 'selected'",
+            [],
+            |row| row.get(0),
+        )?;
         drop(conn);
 
         Ok(Stats {
@@ -89,6 +98,15 @@ impl YantrikDB {
             vec_index_entries: self.search_state.load().vec_index.len(),
             graph_index_entities: self.graph_index.read().entity_count(),
             graph_index_edges: self.graph_index.read().edge_count(),
+            status_read_policy: if self.status_read_policy() {
+                "exclude_superseded".to_string()
+            } else {
+                "legacy".to_string()
+            },
+            superseded_records,
+            superseded_served_since_boot: self
+                .superseded_served_since_boot
+                .load(std::sync::atomic::Ordering::Relaxed),
         })
     }
 

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -5313,6 +5313,64 @@ fn test_recall_with_response_structure() {
 }
 
 #[test]
+fn recall_with_response_reports_typed_search_coverage() {
+    // v0.10 Item 1b / trace T08 "absence-with-coverage": a consumer must
+    // be able to distinguish, from TYPED fields, (a) "this scope has no
+    // records" from (b) "candidates exist but none clears the relevance
+    // gate" from (c) a real match — nuron's false-retry loop came from
+    // reading an empty result as a transient failure.
+    use crate::types::CoverageOutcome;
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+
+    // One record along basis e0, in the default namespace.
+    let mut e0 = vec![0.0f32; 8];
+    e0[0] = 1.0;
+    let mut e1 = vec![0.0f32; 8];
+    e1[1] = 1.0;
+    db.record(
+        "the only fact in the store",
+        "semantic",
+        0.5,
+        0.0,
+        604800.0,
+        &empty_meta(),
+        &e0,
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap();
+
+    let respond = |query: &[f32], ns: Option<&str>| {
+        db.recall_with_response(
+            query, 5, None, None, false, false, None, true, ns, None, None,
+        )
+        .unwrap()
+    };
+
+    // (a) Scope with zero records: typed NoMatchingRecord, scope echoed.
+    let resp = respond(&e0, Some("empty_ns"));
+    assert_eq!(resp.coverage.outcome, CoverageOutcome::NoMatchingRecord);
+    assert_eq!(resp.coverage.candidate_count, 0);
+    assert_eq!(resp.coverage.namespace.as_deref(), Some("empty_ns"));
+
+    // (b) Candidates exist but the best hit is orthogonal to the query —
+    // similarity 0 sits under the gate (default gate_tau = 0.25).
+    let resp = respond(&e1, None);
+    assert_eq!(resp.coverage.outcome, CoverageOutcome::BelowThreshold);
+    assert!(resp.coverage.candidate_count > 0);
+    assert!(resp.coverage.top_similarity < resp.coverage.threshold_tau);
+
+    // (c) Query on the record's own axis: matched, gate cleared.
+    let resp = respond(&e0, None);
+    assert_eq!(resp.coverage.outcome, CoverageOutcome::Matched);
+    assert!(resp.coverage.top_similarity >= resp.coverage.threshold_tau);
+    assert!(resp.coverage.threshold_tau > 0.0, "tau reported");
+}
+
+#[test]
 fn test_high_confidence_no_hints() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let emb = vec_seed(5.0, 8);
@@ -10681,6 +10739,148 @@ fn session_digest_scopes_decisions_and_conflicts_to_namespace() {
         .map(|d| d.namespace.clone())
         .collect();
     assert!(namespaces.contains("tenant-a") && namespaces.contains("tenant-b"));
+}
+
+#[test]
+fn digest_packet_is_status_led_and_reports_changes_since() {
+    // v0.10 Item 1c / trace T10 "packet-correctness". Fixture: decisions
+    // A (superseded), B (head), C (open question), D (disputed, vs E) in
+    // one namespace. The packet main view carries B, C, D-with-flag; A
+    // exists only behind include_superseded; what_changed_since(T)
+    // returns exactly the records and status transitions after T.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rec = |text: &str, seed: f32| {
+        db.record(
+            text,
+            "semantic",
+            0.9,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(seed, 8),
+            "t10",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap()
+    };
+    let a = rec("decision A: deploy to staging", 1.0);
+    let b = rec("decision B: deploy to production (corrects A)", 1.05);
+    let c = rec("open question C: which region", 2.0);
+    let d = rec("decision D: use postgres", 3.0);
+    let e = rec("decision E: use sqlite (rival of D)", 3.05);
+
+    db.link(
+        &b,
+        &crate::types::RecordLink {
+            target_rid: a.clone(),
+            link_type: crate::types::LinkType::Supersedes,
+        },
+    )
+    .unwrap();
+    crate::create_conflict(
+        &db,
+        &crate::types::ConflictType::Preference,
+        &d,
+        &e,
+        None,
+        None,
+        "T10 fixture: D vs E",
+    )
+    .unwrap();
+
+    // Deterministic timeline (no wall-clock asserts): A predates T=1500,
+    // everything else follows it. The supersedes link keeps its real
+    // (post-T) commit time.
+    {
+        let conn = db.conn();
+        conn.execute(
+            "UPDATE memories SET created_at = 1000.0 WHERE rid = ?1",
+            rusqlite::params![a],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE memories SET created_at = 2000.0 WHERE rid IN (?1, ?2, ?3, ?4)",
+            rusqlite::params![b, c, d, e],
+        )
+        .unwrap();
+    }
+
+    // Main view: status-led (fresh DB → policy active).
+    let digest = db
+        .session_digest(&crate::SessionDigestConfig {
+            namespace: Some("t10".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    let rids: Vec<&str> = digest
+        .top_decisions
+        .iter()
+        .map(|x| x.rid.as_str())
+        .collect();
+    assert!(rids.contains(&b.as_str()), "head B in main view");
+    assert!(rids.contains(&c.as_str()), "open question C in main view");
+    assert!(
+        rids.contains(&d.as_str()),
+        "disputed D in main view (not dropped)"
+    );
+    assert!(
+        !rids.contains(&a.as_str()),
+        "superseded A absent from main view"
+    );
+    let d_entry = digest.top_decisions.iter().find(|x| x.rid == d).unwrap();
+    assert!(d_entry.disputed, "D carries the typed disputed flag");
+    let b_entry = digest.top_decisions.iter().find(|x| x.rid == b).unwrap();
+    assert!(!b_entry.disputed);
+    assert_eq!(b_entry.current_status, crate::types::RecordStatus::Active);
+
+    // Expansion: A re-admitted, stamped.
+    let expanded = db
+        .session_digest(&crate::SessionDigestConfig {
+            namespace: Some("t10".into()),
+            include_superseded: true,
+            ..Default::default()
+        })
+        .unwrap();
+    let a_entry = expanded
+        .top_decisions
+        .iter()
+        .find(|x| x.rid == a)
+        .expect("A only behind include_superseded");
+    assert_eq!(
+        a_entry.current_status,
+        crate::types::RecordStatus::Superseded
+    );
+    assert_eq!(a_entry.superseded_by.as_deref(), Some(b.as_str()));
+
+    // what_changed_since(T=1500): B/C/D/E are new, A is not; exactly one
+    // status transition (A → Superseded by B, committed after T).
+    let changes = db.what_changed_since(1500.0, Some("t10"), 240).unwrap();
+    let new_rids: Vec<&str> = changes.new_records.iter().map(|x| x.rid.as_str()).collect();
+    for rid in [&b, &c, &d, &e] {
+        assert!(new_rids.contains(&rid.as_str()), "{rid} is new since T");
+    }
+    assert!(!new_rids.contains(&a.as_str()), "A predates T");
+    assert_eq!(
+        changes.status_transitions.len(),
+        1,
+        "exactly one transition"
+    );
+    let tr = &changes.status_transitions[0];
+    assert_eq!(tr.rid, a);
+    assert_eq!(tr.from, crate::types::RecordStatus::Active);
+    assert_eq!(tr.to, crate::types::RecordStatus::Superseded);
+    assert_eq!(tr.by_rid.as_deref(), Some(b.as_str()));
+    assert!(tr.at > 1500.0, "transition committed after T");
+
+    // Nothing changed since a T after everything.
+    let quiet = db
+        .what_changed_since(crate::time::now_secs() + 10.0, Some("t10"), 240)
+        .unwrap();
+    assert!(quiet.new_records.is_empty());
+    assert!(quiet.status_transitions.is_empty());
 }
 
 #[cfg(feature = "bundled-embedder")]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -294,6 +294,7 @@ fn test_recall_basic() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     assert_eq!(results.len(), 2);
@@ -370,6 +371,7 @@ fn recall_survives_nan_embedding_in_candidate_pool() {
             None,
             None,
             None,
+            false,
         )
         .expect("recall must not panic with a NaN embedding in the candidate pool");
     assert!(
@@ -678,6 +680,7 @@ fn contract_gate_rejects_invalid_writes() {
         assert!(matches!(
             db.recall(
                 &bad_query, 5, None, None, false, false, None, true, None, None, None, None, None,
+                false,
             )
             .unwrap_err(),
             YantrikDbError::InvalidEmbedding { path: "recall", .. }
@@ -703,6 +706,7 @@ fn contract_gate_rejects_invalid_writes() {
             None,
             None,
             None,
+            false,
         )
         .unwrap()
         .len(),
@@ -729,6 +733,7 @@ fn test_recall_empty() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     assert!(results.is_empty());
@@ -3386,17 +3391,17 @@ fn test_recall_deterministic_with_skip_reinforce() {
 
     let r1 = db
         .recall(
-            &query, 5, None, None, false, false, None, true, None, None, None, None, None,
+            &query, 5, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     let r2 = db
         .recall(
-            &query, 5, None, None, false, false, None, true, None, None, None, None, None,
+            &query, 5, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     let r3 = db
         .recall(
-            &query, 5, None, None, false, false, None, true, None, None, None, None, None,
+            &query, 5, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
 
@@ -3454,6 +3459,7 @@ fn test_reinforce_mutates_but_skip_does_not() {
         None,
         None,
         None,
+        false,
     )
     .unwrap();
     let after_skip = db.get(&rid).unwrap().unwrap().half_life;
@@ -3474,6 +3480,7 @@ fn test_reinforce_mutates_but_skip_does_not() {
         None,
         None,
         None,
+        false,
     )
     .unwrap();
     let after_reinforce = db.get(&rid).unwrap().unwrap().half_life;
@@ -3535,6 +3542,7 @@ fn test_graph_expansion_off_no_graph_results() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     for r in &results {
@@ -3600,6 +3608,7 @@ fn test_graph_expansion_on_boosts_connected_memory() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
 
@@ -3710,6 +3719,7 @@ fn test_recall_scores_bounded() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     for r in &results {
@@ -3826,6 +3836,7 @@ fn test_recall_top_k_respected_with_graph_expansion() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
 
@@ -4052,6 +4063,7 @@ fn test_archive_memory() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     assert!(
@@ -4093,7 +4105,7 @@ fn test_hydrate_memory() {
     // Should be back in recall
     let results = db
         .recall(
-            &emb, 10, None, None, false, false, None, true, None, None, None, None, None,
+            &emb, 10, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     assert!(
@@ -4212,6 +4224,7 @@ fn test_evict() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     for r in &results {
@@ -4527,6 +4540,7 @@ fn test_encrypted_recall_roundtrip() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     assert_eq!(results.len(), 2);
@@ -4603,7 +4617,7 @@ fn test_encrypted_archive_hydrate() {
     // Should be findable in recall after hydration
     let results = db
         .recall(
-            &emb, 10, None, None, false, false, None, true, None, None, None, None, None,
+            &emb, 10, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     assert!(results.iter().any(|r| r.rid == rid));
@@ -4900,6 +4914,7 @@ fn test_domain_filter() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     assert_eq!(
@@ -4980,6 +4995,7 @@ fn test_source_filter() {
             Some("user"),
             None,
             None,
+            false,
         )
         .unwrap();
     assert_eq!(
@@ -5075,6 +5091,7 @@ fn test_domain_and_source_combined_filter() {
             Some("user"),
             None,
             None,
+            false,
         )
         .unwrap();
     assert_eq!(
@@ -5102,6 +5119,7 @@ fn test_domain_and_source_combined_filter() {
             Some("system"),
             None,
             None,
+            false,
         )
         .unwrap();
     assert_eq!(
@@ -5437,6 +5455,7 @@ fn test_recall_refine_excludes_originals() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     assert_eq!(first_results.len(), 2);
@@ -7859,6 +7878,7 @@ fn test_insert_vector_makes_recall_find_it() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
 
@@ -8186,7 +8206,7 @@ fn record_with_rid_makes_recall_find_it() {
 
     let results = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     assert!(
@@ -8440,7 +8460,7 @@ fn tombstone_with_rid_hides_from_recall() {
     // Sanity: visible before tombstone.
     let r = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     assert!(r.iter().any(|x| x.rid == rid), "visible before tombstone");
@@ -8451,7 +8471,7 @@ fn tombstone_with_rid_hides_from_recall() {
     // Hidden after.
     let r2 = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     assert!(!r2.iter().any(|x| x.rid == rid), "hidden after tombstone");
@@ -8845,7 +8865,7 @@ fn issue_8_tombstoned_memories_excluded_from_recall() {
     // Sanity: visible before forget.
     let before = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     assert!(
@@ -8858,7 +8878,7 @@ fn issue_8_tombstoned_memories_excluded_from_recall() {
     // After forget, should NOT appear in recall.
     let after = db
         .recall(
-            &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
+            &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
         )
         .unwrap();
     assert!(
@@ -8902,7 +8922,7 @@ fn issue_8_tombstoned_persists_across_engine_reopen() {
         let db2 = YantrikDB::new(path_str, 64).unwrap();
         let after = db2
             .recall(
-                &emb, 5, None, None, false, false, None, true, None, None, None, None, None,
+                &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
             )
             .unwrap();
         assert!(
@@ -10077,7 +10097,12 @@ fn draft_memories_from_summary_atomizes_and_flags_provisional() {
 fn recall_stamps_trust_metadata() {
     // Task 41. An aged, rarely-confirmed memory and a superseded memory each
     // arrive on recall with a trust hedge in why_retrieved.
+    //
+    // v0.10 Item 1: serving a superseded result at all is LEGACY-policy
+    // behavior (fresh DBs exclude it from eligibility), so this test pins
+    // the stamped-hedge contract for pre-v0.10 databases.
     let db = YantrikDB::with_default(":memory:").unwrap();
+    db.set_status_read_policy(false).unwrap();
 
     let aged = db
         .record_text(
@@ -10520,6 +10545,7 @@ fn recall_logs_demand_and_surfaces_gaps() {
             None,
             None,
             None,
+            false,
         )
         .unwrap();
     assert!(
@@ -14318,6 +14344,7 @@ fn recall_certainty_min_filters_low_certainty() {
             None,
             Some(0.5), // certainty_min
             None,
+            false,
         )
         .unwrap();
 
@@ -14359,6 +14386,7 @@ fn recall_order_certainty_returns_results_in_certainty_desc() {
             None,
             None,
             Some("certainty"),
+            false,
         )
         .unwrap();
 
@@ -14400,6 +14428,7 @@ fn recall_order_recency_returns_results_in_created_at_desc() {
             None,
             None,
             Some("recency"),
+            false,
         )
         .unwrap();
 
@@ -14440,6 +14469,7 @@ fn recall_order_invalid_string_returns_invalid_input_error() {
             None,
             None,
             Some("most_relevant"), // typo / not a valid order
+            false,
         )
         .expect_err("invalid order string must return error");
 
@@ -14477,6 +14507,7 @@ fn recall_default_order_is_relevance_unchanged() {
             None,
             None,
             None, // default order = relevance
+            false,
         )
         .unwrap();
 

--- a/crates/yantrikdb-core/src/lib.rs
+++ b/crates/yantrikdb-core/src/lib.rs
@@ -37,7 +37,7 @@ pub use consolidate::{consolidate, find_consolidation_candidates};
 pub use engine::conflict::ConflictBurndownReport;
 pub use engine::conversation::{Turn, DEFAULT_TURN_WINDOW};
 pub use engine::demand::KnowledgeGap;
-pub use engine::digest::{SessionDigest, SessionDigestConfig};
+pub use engine::digest::{ChangesSince, SessionDigest, SessionDigestConfig, StatusTransition};
 pub use engine::graph_ops::AutoRelateReport;
 pub use engine::importance::ImportanceRecalibrationReport;
 pub use engine::links::ChainAuditReport;

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -58,7 +58,7 @@ impl PyYantrikDB {
         .map_err(map_err)
     }
 
-    #[pyo3(signature = (query=None, query_embedding=None, top_k=10, time_window=None, memory_type=None, include_consolidated=false, expand_entities=true, skip_reinforce=false, namespace=None, domain=None, source=None, certainty_min=None, order=None))]
+    #[pyo3(signature = (query=None, query_embedding=None, top_k=10, time_window=None, memory_type=None, include_consolidated=false, expand_entities=true, skip_reinforce=false, namespace=None, domain=None, source=None, certainty_min=None, order=None, include_superseded=false))]
     #[allow(clippy::too_many_arguments)]
     fn recall(
         &self,
@@ -79,6 +79,10 @@ impl PyYantrikDB {
         // the final top_k: "relevance" (default) | "certainty" | "recency".
         certainty_min: Option<f64>,
         order: Option<&str>,
+        // v0.10 Item 1: re-admit superseded records (stamped with
+        // current_status="superseded" + superseded_by) for history /
+        // archaeology queries. No-op on legacy-policy databases.
+        include_superseded: bool,
     ) -> PyResult<Vec<PyObject>> {
         let db = self
             .inner
@@ -112,6 +116,7 @@ impl PyYantrikDB {
                 source,
                 certainty_min,
                 order,
+                include_superseded,
             )
             .map_err(map_err)?;
 
@@ -253,8 +258,9 @@ impl PyYantrikDB {
                 namespace,
                 domain,
                 source,
-                None, // certainty_min (#46)
-                None, // order (#46) — relevance default
+                None,  // certainty_min (#46)
+                None,  // order (#46) — relevance default
+                false, // include_superseded (v0.10 Item 1) — policy default
             )
             .map_err(map_err)?;
 

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -478,6 +478,25 @@ impl PyYantrikDB {
         stats_to_dict(py, &s)
     }
 
+    /// v0.10 Item 1 — whether the status-led read path is active
+    /// (superseded records excluded from recall eligibility). True by
+    /// default on fresh databases; False on migrated pre-v0.10
+    /// databases until opted in via `set_status_read_policy(True)`.
+    fn status_read_policy(&self) -> PyResult<bool> {
+        Ok(self.get_inner()?.status_read_policy())
+    }
+
+    /// v0.10 Item 1 — durably set the status read policy
+    /// (`meta.status_read_policy`). Legacy-database opt-in: review
+    /// `stats()["superseded_served_since_boot"]`, then call
+    /// `set_status_read_policy(True)` to exclude superseded records
+    /// from recall. `False` returns to legacy include-everything.
+    fn set_status_read_policy(&self, exclude_superseded: bool) -> PyResult<()> {
+        self.get_inner()?
+            .set_status_read_policy(exclude_superseded)
+            .map_err(map_err)
+    }
+
     /// Exposed for Python consolidate.py compatibility.
     #[pyo3(signature = (op_type, target_rid, payload))]
     fn _log_op(

--- a/crates/yantrikdb-python/src/py_engine/sync.rs
+++ b/crates/yantrikdb-python/src/py_engine/sync.rs
@@ -360,7 +360,8 @@ impl PyYantrikDB {
         max_conflicts = 5,
         max_triggers = 5,
         snippet_chars = 240,
-        namespace = None
+        namespace = None,
+        include_superseded = false
     ))]
     #[allow(clippy::too_many_arguments)]
     fn session_digest(
@@ -371,6 +372,7 @@ impl PyYantrikDB {
         max_triggers: usize,
         snippet_chars: usize,
         namespace: Option<String>,
+        include_superseded: bool,
     ) -> PyResult<String> {
         let db = self.get_inner()?;
         let cfg = yantrikdb_core::SessionDigestConfig {
@@ -382,9 +384,30 @@ impl PyYantrikDB {
             max_conflicts,
             max_triggers,
             snippet_chars,
+            // v0.10 Item 1c: history packets re-admit superseded records,
+            // stamped with current_status + superseded_by.
+            include_superseded,
         };
         let digest = db.session_digest(&cfg).map_err(map_err)?;
         Ok(serde_json::to_string(&digest).unwrap_or_else(|_| "{}".to_string()))
+    }
+
+    /// v0.10 Item 1c (trace T10) — what changed since `since` (epoch
+    /// seconds): records created and status transitions (supersessions)
+    /// committed after that instant, optionally scoped to a namespace.
+    /// Returns a JSON string with `new_records` and `status_transitions`.
+    #[pyo3(signature = (since, namespace = None, snippet_chars = 240))]
+    fn what_changed_since(
+        &self,
+        since: f64,
+        namespace: Option<&str>,
+        snippet_chars: usize,
+    ) -> PyResult<String> {
+        let db = self.get_inner()?;
+        let changes = db
+            .what_changed_since(since, namespace, snippet_chars)
+            .map_err(map_err)?;
+        Ok(serde_json::to_string(&changes).unwrap_or_else(|_| "{}".to_string()))
     }
 
     /// End-of-session auto-capture (task 40): atomize an agent-provided

--- a/crates/yantrikdb-python/src/py_types.rs
+++ b/crates/yantrikdb-python/src/py_types.rs
@@ -130,6 +130,25 @@ pub fn recall_response_to_dict(
     }
     dict.set_item("hints", hints_list)?;
 
+    // v0.10 Item 1b (trace T08): typed search coverage.
+    let coverage = PyDict::new(py);
+    coverage.set_item("namespace", &r.coverage.namespace)?;
+    coverage.set_item("memory_type", &r.coverage.memory_type)?;
+    coverage.set_item("candidate_count", r.coverage.candidate_count)?;
+    coverage.set_item("threshold_tau", r.coverage.threshold_tau)?;
+    coverage.set_item("top_similarity", r.coverage.top_similarity)?;
+    coverage.set_item(
+        "outcome",
+        match r.coverage.outcome {
+            yantrikdb_core::types::CoverageOutcome::Matched => "matched",
+            yantrikdb_core::types::CoverageOutcome::BelowThreshold => "below_threshold",
+            yantrikdb_core::types::CoverageOutcome::NoMatchingRecord => "no_matching_record",
+            // #[non_exhaustive] upstream; surface rather than crash.
+            _ => "unknown",
+        },
+    )?;
+    dict.set_item("coverage", coverage)?;
+
     Ok(dict.into())
 }
 

--- a/crates/yantrikdb-python/src/py_types.rs
+++ b/crates/yantrikdb-python/src/py_types.rs
@@ -68,6 +68,24 @@ pub fn recall_result_to_dict(
     dict.set_item("source", &r.source)?;
     dict.set_item("emotional_state", &r.emotional_state)?;
 
+    // v0.10 Item 1: typed status + orthogonal flags. Consumers branch on
+    // these fields instead of parsing why_retrieved prose (nuron's
+    // "prose-first stamps is how the stale verdict survived" incident).
+    dict.set_item(
+        "current_status",
+        match r.current_status {
+            yantrikdb_core::types::RecordStatus::Active => "active",
+            yantrikdb_core::types::RecordStatus::Superseded => "superseded",
+            // #[non_exhaustive] on the Rust side; future statuses must
+            // surface rather than crash an older binding.
+            _ => "unknown",
+        },
+    )?;
+    dict.set_item("superseded_by", &r.superseded_by)?;
+    let disputed: Vec<&str> = r.disputed_with.iter().map(|s| s.as_str()).collect();
+    dict.set_item("disputed_with", disputed)?;
+    dict.set_item("aged_last_verified", r.aged_last_verified)?;
+
     Ok(dict.into())
 }
 
@@ -167,6 +185,13 @@ pub fn stats_to_dict(py: Python<'_>, s: &yantrikdb_core::Stats) -> PyResult<PyOb
     dict.set_item("vec_index_entries", s.vec_index_entries)?;
     dict.set_item("graph_index_entities", s.graph_index_entities)?;
     dict.set_item("graph_index_edges", s.graph_index_edges)?;
+    // v0.10 Item 1: status-led read path adoption surface.
+    dict.set_item("status_read_policy", &s.status_read_policy)?;
+    dict.set_item("superseded_records", s.superseded_records)?;
+    dict.set_item(
+        "superseded_served_since_boot",
+        s.superseded_served_since_boot,
+    )?;
     Ok(dict.into())
 }
 

--- a/crates/yantrikdb-wasm/src/lib.rs
+++ b/crates/yantrikdb-wasm/src/lib.rs
@@ -216,7 +216,10 @@ impl WasmYantrikDB {
         top_k: usize,
     ) -> Result<JsValue, JsError> {
         let results = self.inner
-            .recall(&embedding, top_k, None, None, false, false, None, false, None, None, None)
+            .recall(
+                &embedding, top_k, None, None, false, false, None, false, None, None, None,
+                None, None, false,
+            )
             .map_err(|e| JsError::new(&e.to_string()))?;
 
         serde_wasm_bindgen::to_value(&results)

--- a/docs/V0.10_PLAN.md
+++ b/docs/V0.10_PLAN.md
@@ -1,0 +1,178 @@
+# v0.10 Plan — FINAL (three-seat reconciliation)
+
+*Engine seat: Claude (yantrikdb-core). Consumer seat: nuron (signed off on draft + 6
+amendments). Validity seat: gpt-5.6-sol (207k-token grounded audit; verdicts: items 1/3/5/7
+SOUND-WITH-FIXES, items 2/4/6 UNSOUND as drafted — all findings reconciled below). Draft
+history in docs/V0.10_PLAN_DRAFT.md; sol's full verdict in codex_collab rid 019f5e55.*
+
+**The reconciliation in one line:** sol found that the draft's unlocking primitive stood on
+an unenforced invariant (supersedes-chain integrity) and that half the traces were
+nondeterministic as specified — so v0.10 gains a Phase 0 that makes the substrate
+*testable and the invariant real*, the learned-ranking experiment moves to v0.11 behind a
+sealed protocol, and the anti-laundering gate is redesigned as a central mutation gate.
+
+---
+
+## Phase 0 — Determinism + integrity seams (NEW, from validity review; build FIRST)
+
+Nothing else in this plan can be honestly proven until these exist.
+
+- **Supersedes-chain integrity** (sol's highest-risk assumption, made an invariant):
+  single-successor enforcement at link creation, cycle rejection, namespace guard on link
+  endpoints, missing-target refusal; replication merge policy for concurrent successors
+  (deterministic winner + `disputed` flag on the loser, never a silent branch); a
+  `verify_chains()` audit + repair report for existing databases.
+- **Deterministic test seams**: seedable HNSW level RNG (config; `from_entropy` stays the
+  production default), `ORDER BY` on index rebuild scans, injectable clock for
+  decay/aged/rate-limiter logic, failpoint handshakes (child-process kill harness — no
+  sleep roulette).
+- **Trace contracts in-repo**: T1–T13 (+T13's sealed protocol) as versioned spec files
+  with fixtures, seeds, clocks, exact assertions, ownership — not shared-memory prose.
+- **Assertion style rule** (anti-flake): traces assert FILTERING/STATUS/TYPED-FIELD
+  invariants wherever possible; rank-equality assertions only where Phase-0 seams make
+  them deterministic. Scale/startup budgets run scheduled, not PR-blocking.
+
+**Size:** M. **Proof:** chain-integrity property tests incl. replication merge; trace
+specs land with their features disabled-but-parsed.
+
+## Item 1 — Status-led read path (rescoped per validity findings)
+
+- **Status model redesigned** (sol: the draft enum wasn't mutually exclusive):
+  `current_status: active | superseded` (exclusive, from chain state) + orthogonal typed
+  flags `disputed_with: Vec<rid>` (from open conflict rows; cleared on resolution) and
+  `aged { last_verified }` (retrieval-age signal, NOT a truth status). `#[non_exhaustive]`
+  on both. Defined precedence; no status-as-prose anywhere.
+- **Eligibility, not demotion**: with `include_superseded=false`, superseded records are
+  excluded BEFORE FTS insertion, fallback scans, graph/link expansion, MMR, and truncation
+  (hard eligibility rule — sol showed late filtering lets stale records eat candidate slots
+  or re-enter via other branches). With `include_superseded=true`, superseded items are
+  never boost-promoted past their head (keyword/graph boosts apply before the status cap).
+- **Coverage of ALL read surfaces**: recall, recall_profiled, recall_with_links,
+  recall_with_response, get/list, digest projections, Python + HTTP conversion.
+- **Upgrade safety** (sol: changelog ≠ migration contract): default-on exclusion for FRESH
+  databases only; existing databases keep old behavior until an explicit persisted opt-in
+  (`meta.status_read_policy`), with a pre-upgrade report (how many records would change
+  visibility) and legacy `metadata.supersedes` reification offered as a maintenance action.
+  **Adoption nudge (consumer final review):** stats/health on a legacy-policy database
+  reports `status_read_policy: legacy` plus a counter of superseded records that surfaced
+  in recall since last check, with the one-line upgrade instruction — defaults protect new
+  users; a visible counter migrates old ones.
+- `resolve_current(rid) -> (rid, status)`; `superseded_by` singular (earned by Phase-0
+  integrity); Item 1b SearchCoverage + Item 1c continuity-packet projection as amended by
+  the consumer review (T8/T10 owners), with 1c's what-changed-since using the injectable
+  clock.
+
+**Size:** L (sol: "no longer M" — accepted). **Proof:** T1, T2 (incl. branch/cycle
+fixtures), T5, T8, T10.
+
+## Item 2 — Ranking: heuristic rebalance NOW; learned weights = v0.11 experiment
+
+Validity verdict accepted: 40 golden queries cannot support fit + model selection + a
+credible held-out gate, and the suite is already contaminated by diagnosis. Split:
+
+- **v0.10 ships (deterministic, no learning):** composite-score rebalance as hand-set
+  policy — status eligibility/cap (Item 1), bounded recency+importance contribution so
+  additive boosts cannot exceed the similarity term's range, namespace-scoped IDF-weighted
+  keyword boosts (IDF computed per-namespace; disabled under encryption where the FTS path
+  differs), and a score-breakdown that reconciles with the final score including every new
+  transform. Golden suite gates as REGRESSION-ONLY (no fitting against it).
+- **v0.11 experiment (sealed):** learned linear weights per Pranab's learning-layer
+  directive, gated on: a 200+ labeled-query corpus built from T-trace generators plus
+  independent sources (never the diagnosis suite), frozen split + seed + comparator +
+  primary metric + margin + per-category floors + one-shot holdout evaluation (T13
+  redefined to be falsifiable), retrieval-time feature logging (the current learner
+  reconstructs features from old scores — exposure-biased; fix first), fitted defaults
+  applied to existing DBs only via the same persisted-policy mechanism as Item 1. Status
+  is a correctness policy and is NEVER a learnable weight.
+
+**Size:** v0.10 half M. **Sequencing:** lands AFTER Item 1 in a separate release-train
+step (sol: coupling ranking changes with status correctness makes regression attribution
+impossible — accepted).
+
+## Item 3 — RID-stable correction (resized, protocol specified)
+
+Correction becomes a staged protocol, not tombstone-then-resurrect: durable correction
+INTENT (oplog) written BEFORE SQL commit (sol boundary #6 — today log_op follows commit;
+a kill in between loses the replication event), participation in the write-router barrier
+(reembed concurrency, boundary #1), delta tombstone+append as one sealed operation with
+backpressure handled before any visible mutation, scoring-cache + visible_seq update in
+the same critical section, and replication of EXACT embedding bytes (follower re-embedding
+diverges by model version/quantization). Revision history gains prior embedding
+model/hash. Fault matrix covers all 8 sol boundaries × (error return | kill) plus
+correct/correct, correct/forget, correct/reembed races, compactor sealing, restart,
+follower replay — via Phase-0 failpoints.
+
+**Size:** M–L (accepted). **Proof:** T4 (+kill variant), old-topic/new-topic on BOTH
+delta-resident and cold-tier records under compaction.
+
+## Item 4 — Split: 4a central mutation gate; 4b idempotency keys
+
+- **4a — Epistemic provenance enforcement, redesigned as a CENTRAL MUTATION GATE** (sol:
+  the drafted record()-time check had seven bypasses). One chokepoint validates
+  source × kind × confidence_basis consistency on EVERY mutation: record, record_batch,
+  record_with_rid, record_with_links (record+links become atomic — today links commit
+  after the record), correct (metadata_merge attempting to change `kind` on an
+  inference-source record is REFUSED — the laundering-via-correct hole), queued-write
+  materialization, and import/repair. Replication: leader-side gating + follower trust
+  (documented), with the gate versioned in the payload. Transitive laundering handled by
+  BASIS PROPAGATION at write (a record deriving from basis=inference inherits
+  basis=inference unless an explicit confirmation edge upgrades it) — no graph walks at
+  read time. Closed vocabularies for source/kind/basis validated at the gate.
+- **4b — Idempotency keys as their own item**: scope = (namespace, key) uniqueness; same
+  key + different payload = typed conflict error (never silently return the first
+  result); duplicate check precedes calibration, RID allocation, session counters, links,
+  oplog, vector append, and certainty/feedback changes; retry returns original rid +
+  receipt; key + payload identity preserved through replication. T7 scoped honestly to
+  same-operation retries (semantic dedup remains out).
+
+**Size:** 4a M, 4b M (was hidden inside; sol called it out — accepted).
+**Proof:** T6 extended to attack every bypass path sol enumerated; T7 with whole-effect
+assertions behind worker barriers; T3.
+
+## Item 5 — Operational safety contract (proof matrix widened)
+
+As drafted, plus sol's matrix: truly-simultaneous opens (not sequential), lock lifetime +
+crash release, path aliasing/symlinks/junctions, Windows sharing semantics, read-only
+escape proven to disable every mutation/worker/index API; panic-poisoning catch boundary
+DEFINED to include worker threads (a materializer panic must poison, not vanish — worker
+guards report into the engine's poison flag), lock-held panics, and panic=abort builds
+documented; typed-error preservation proven for a representative specimen of every error
+family and through HTTP + MCP JSON-RPC, not just embedded Python. diagnostics() includes
+model epoch (consumer R6).
+
+**Size:** M–L (accepted). **Proof:** cross-platform two-process CI, worker-panic
+injection, error-taxonomy round-trip tests at all three boundaries.
+
+## Item 6 — Reliability gate (L; assembles from Phase 0 onward)
+
+T1–T13 as versioned in-repo contracts (Phase 0), each landing WITH its feature item,
+asserting invariants per the Phase-0 style rule. Thresholds: T1-class stale-at-k1 hard
+zero from day one; T3-class ratio + sample-size floor after one monitoring release;
+T12 computed from the same fixtures in CI. Kill harness via failpoint handshakes;
+`quick_check` for structure + semantic invariants for wholly-old-or-wholly-new; backup
+proof includes concurrent writes, WAL, pending oplog, encryption, reopen, semantic
+equivalence. Scale/startup budgets: scheduled runs with environment-normalized baselines,
+never PR wall-clock gates.
+
+## Item 7 — Hygiene
+
+Commit Cargo.lock AND enforce `--locked` in every CI/release workflow (reproducibility is
+the pair, not the file). potion-base-8M: repositioned as "candidate pending independent
+eval" (its +12.6% MRR is on the contaminated suite — sol) with platform/download costs
+documented; the v0.11 corpus doubles as its independent eval. Debug-build benchmark
+warning in eval docs.
+
+## Sequencing
+
+Phase 0 → Item 1 (status + chain, incl. 1b/1c) → Item 2's heuristic half (separate step,
+same release) → Items 3 and 4a/4b in parallel → Item 5 → Item 6 assembles throughout →
+release. v0.11: learned-weights experiment (sealed protocol), learning part 2 (reliance
+calibration + interruption policy on T-trace labels + censored-feedback bandit rule),
+write-yield prediction, advisory dedup, status-vocabulary extensions
+(expired/retracted/unresolved).
+
+## Out (carried + new)
+
+Everything from the draft's out-list, plus: learned ranking in v0.10 (moved to v0.11),
+read-time provenance graph walks (basis propagation instead), follower re-embedding
+(exact bytes instead), PR-blocking scale wall-clock gates.

--- a/docs/traces/T05.toml
+++ b/docs/traces/T05.toml
@@ -6,9 +6,9 @@ id = "T05"
 title = "disputed-not-dropped"
 item = "1"           # v0.10 plan item that must make this passable
 owner = "yantrikdb-core"
-status = "pending"
-# implemented_since = ""    # set on implementation (version string)
-# test_path = ""            # set on implementation (module::test_fn)
+status = "implemented"
+implemented_since = "0.10.0"
+test_path = "engine::links::tests::disputed_records_both_returned_with_typed_cross_links"
 seeds = "YANTRIKDB_HNSW_SEED via testing feature; fixtures declare exact vectors"
 clock = "injectable via testing feature (set_test_clock); no wall-clock asserts"
 

--- a/docs/traces/T08.toml
+++ b/docs/traces/T08.toml
@@ -6,9 +6,9 @@ id = "T08"
 title = "absence-with-coverage"
 item = "1b"           # v0.10 plan item that must make this passable
 owner = "yantrikdb-core"
-status = "pending"
-# implemented_since = ""    # set on implementation (version string)
-# test_path = ""            # set on implementation (module::test_fn)
+status = "implemented"
+implemented_since = "0.10.0"
+test_path = "engine::tests::recall_with_response_reports_typed_search_coverage"
 seeds = "YANTRIKDB_HNSW_SEED via testing feature; fixtures declare exact vectors"
 clock = "injectable via testing feature (set_test_clock); no wall-clock asserts"
 

--- a/docs/traces/T10.toml
+++ b/docs/traces/T10.toml
@@ -6,9 +6,9 @@ id = "T10"
 title = "packet-correctness"
 item = "1c"           # v0.10 plan item that must make this passable
 owner = "yantrikdb-core"
-status = "pending"
-# implemented_since = ""    # set on implementation (version string)
-# test_path = ""            # set on implementation (module::test_fn)
+status = "implemented"
+implemented_since = "0.10.0"
+test_path = "engine::tests::digest_packet_is_status_led_and_reports_changes_since"
 seeds = "YANTRIKDB_HNSW_SEED via testing feature; fixtures declare exact vectors"
 clock = "injectable via testing feature (set_test_clock); no wall-clock asserts"
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -260,8 +260,15 @@ class TestStats:
             "pending_triggers", "active_patterns",
             "scoring_cache_entries", "vec_index_entries",
             "graph_index_entities", "graph_index_edges",
+            # v0.10 Item 1: status-led read path adoption surface.
+            "status_read_policy", "superseded_records",
+            "superseded_served_since_boot",
         }
         assert set(s.keys()) == expected_keys
+        # Fresh databases default to the status-led read path.
+        assert s["status_read_policy"] == "exclude_superseded"
+        assert s["superseded_records"] == 0
+        assert s["superseded_served_since_boot"] == 0
 
     def test_stats_tracks_operations(self, db):
         db.record("op1", embedding=_vec(1.0))
@@ -273,6 +280,78 @@ class TestStats:
         # exact equality so the contract is "ops tracked" not "exactly
         # this many."
         assert s["operations"] >= 2, f"expected >= 2 ops, got {s['operations']}"
+
+
+# ── v0.10 Item 1: status-led read path ───────────────────
+
+class TestStatusReadPath:
+    def _seed_chain(self, db):
+        """Old fact superseded by a near-identical new fact."""
+        old = db.record("standup is at 9am", embedding=_vec(1.0))
+        new = db.record("standup is at 10am", embedding=_vec(1.0))
+        db.link(new, old, "supersedes")
+        return old, new
+
+    def test_fresh_db_excludes_superseded_by_default(self, db):
+        old, new = self._seed_chain(db)
+        assert db.status_read_policy() is True
+        rids = [r["rid"] for r in db.recall(query_embedding=_vec(1.0), top_k=10)]
+        assert new in rids
+        assert old not in rids, "superseded record must be excluded (T01 hard zero)"
+
+    def test_include_superseded_readmits_with_typed_fields(self, db):
+        old, new = self._seed_chain(db)
+        hits = db.recall(query_embedding=_vec(1.0), top_k=10, include_superseded=True)
+        by_rid = {r["rid"]: r for r in hits}
+        assert by_rid[old]["current_status"] == "superseded"
+        assert by_rid[old]["superseded_by"] == new
+        assert by_rid[new]["current_status"] == "active"
+        assert by_rid[new]["superseded_by"] is None
+
+    def test_legacy_policy_serves_stamped_and_counts_nudge(self, db):
+        old, new = self._seed_chain(db)
+        db.set_status_read_policy(False)  # simulate migrated pre-v0.10 DB
+        rids = [r["rid"] for r in db.recall(query_embedding=_vec(1.0), top_k=10)]
+        assert old in rids and new in rids
+        s = db.stats()
+        assert s["status_read_policy"] == "legacy"
+        assert s["superseded_records"] == 1
+        assert s["superseded_served_since_boot"] >= 1
+        db.set_status_read_policy(True)
+        rids = [r["rid"] for r in db.recall(query_embedding=_vec(1.0), top_k=10)]
+        assert old not in rids
+
+    def test_recall_with_response_typed_coverage(self, db):
+        # T08: empty scope vs below-threshold vs matched, typed.
+        resp = db.recall_with_response(
+            query_embedding=_vec(1.0), top_k=5, namespace="empty_ns"
+        )
+        cov = resp["coverage"]
+        assert cov["outcome"] == "no_matching_record"
+        assert cov["candidate_count"] == 0
+        assert cov["namespace"] == "empty_ns"
+
+        db.record("a stored fact", embedding=_vec(1.0))
+        resp = db.recall_with_response(query_embedding=_vec(1.0), top_k=5)
+        cov = resp["coverage"]
+        assert cov["outcome"] == "matched"
+        assert cov["top_similarity"] >= cov["threshold_tau"] > 0.0
+
+    def test_what_changed_since(self, db):
+        import json
+        old, new = self._seed_chain(db)
+        changes = json.loads(db.what_changed_since(0.0))
+        new_rids = [r["rid"] for r in changes["new_records"]]
+        assert old in new_rids and new in new_rids
+        transitions = changes["status_transitions"]
+        assert len(transitions) == 1
+        assert transitions[0]["rid"] == old
+        assert transitions[0]["to"] == "superseded"
+        assert transitions[0]["by_rid"] == new
+        # Nothing after the far future.
+        quiet = json.loads(db.what_changed_since(time.time() + 60.0))
+        assert quiet["new_records"] == []
+        assert quiet["status_transitions"] == []
 
 
 # ── Integration ──────────────────────────────────────────


### PR DESCRIPTION
## v0.10 Item 1: status-led read path

The unlocking primitive of the v0.10 reliability program (three-seat plan: engine/consumer/validity — docs/V0.10_PLAN.md).

### Typed status (not prose)
- `RecordStatus{Active, Superseded}` (`#[non_exhaustive]`) + orthogonal flags `superseded_by`, `disputed_with` (plural), `aged_last_verified` on every `RecallResult` — consumers branch on fields, never parse `why_retrieved` prose
- `resolve_current(rid)` walks selected supersedes edges to the chain head (cap-bounded)

### Eligibility, not demotion
- Superseded records leave the recall candidate pool **before** keyword-slot cutoff and MMR — a stale fact can never outrank or crowd out its successor
- Fresh DBs default on via `meta.status_read_policy`; legacy DBs keep include-everything + an adoption-nudge counter (`superseded_served_since_boot` in `stats()`) until `set_status_read_policy(true)`
- `include_superseded=true` re-admits them, stamped, for archaeology queries (recall param, `RecallQuery` builder, Python kwarg)

### Trace contracts flipped to implemented (registry-gated)
- **T05 disputed-not-dropped** — both records returned with typed cross-links; no silent winner
- **T08 absence-with-coverage** — typed `SearchCoverage` (scope, candidate_count, learned `gate_tau`, outcome ∈ matched | below_threshold | no_matching_record) kills the false-retry loop
- **T10 packet-correctness** — status-led `session_digest` (superseded excluded, disputed flagged, expansion re-admits stamped) + `what_changed_since(T)` returning new records and Active→Superseded transitions
- T01 held at pending until nuron supplies the verbatim incident fixture

### Verification
- 1631 Rust lib tests green; trace registry green; workspace check clean
- Full Python suite with extras: 215 passed, 1 skipped (built via maturin develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)