### PR TITLE
fix(correct): entity-graph coherence on text correction (Item-3 safety half)

### DIFF
--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -185,9 +185,13 @@ pub enum YantrikDbError {
     /// are unaffected and proceed during reembed.
     #[error(
         "correct(new_text=...) on {rid} deferred: a db.reembed() cutover is in progress, \
-         so the vector index cannot be updated against a stable generation. \
-         No state was changed; retry after the reembed completes. \
-         (Metadata / importance / valence corrections are not blocked by reembed.)"
+         so the vector index cannot be updated against a stable generation. No durable \
+         state was changed — BUT the OLD text remains ACTIVE and is still served as the \
+         record's CURRENT value until a retry succeeds; this is a not-yet-applied \
+         correction, not a harmless no-op. Retry after the reembed completes. To stop \
+         serving the old text in the meantime, issue a metadata/status correction (NOT \
+         blocked by reembed) marking the record correction_pending. (Metadata / \
+         importance / valence corrections are never blocked by reembed.)"
     )]
     CorrectionDeferredDuringReembed { rid: String },
 

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -1038,6 +1038,52 @@ impl YantrikDB {
     /// re-embedding — follower re-embedding diverges by model
     /// version/quantization. `None` for metadata/scalar corrections.
     #[allow(clippy::too_many_arguments)]
+    /// **Entity-graph coherence — the correction "safety half" (nuron, v0.10
+    /// Item-3 follow-up).** A text-changing `correct()` re-embeds the vector
+    /// but the `memory_entities` links were extracted from the OLD text. A link
+    /// whose entity surface string no longer appears in the corrected text is
+    /// STALE and keeps serving this record under its old association through
+    /// graph expansion (`why_retrieved = ["graph-connected via <old-entity>"]`)
+    /// — the reembed-independent, always-on face of the same "old meaning still
+    /// served" problem the vector path already closes. Drop those links.
+    ///
+    /// Matching reuses the SAME tokenizer/matcher entity EXTRACTION uses
+    /// (`graph::entity_matches_text` over `graph::tokenize`) so the two agree —
+    /// crucially, that is WORD-BOUNDARY (token-equality, not substring), so a
+    /// short entity can't false-KEEP by colliding inside a larger word
+    /// (`"Volkan"` tokens ≠ `"Volkanic"` tokens). A false-KEEP would silently
+    /// preserve the harm while the code looks like it ran; a false-DROP (entity
+    /// referred to by an alias) is benign under-retrieval. Err toward dropping.
+    ///
+    /// Runs in the correction's transaction so the removal is atomic with the
+    /// text change. Adding links for NEW entities (re-extraction) is the
+    /// deferrable "completeness half" and is intentionally NOT done here.
+    fn drop_stale_memory_entity_links_in_tx(
+        tx: &rusqlite::Transaction<'_>,
+        rid: &str,
+        new_text_plain: &str,
+    ) -> Result<()> {
+        let linked: Vec<String> = {
+            let mut stmt =
+                tx.prepare("SELECT entity_name FROM memory_entities WHERE memory_rid = ?1")?;
+            let rows = stmt.query_map(params![rid], |r| r.get::<_, String>(0))?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        if linked.is_empty() {
+            return Ok(());
+        }
+        let tokens = crate::graph::tokenize(new_text_plain);
+        for entity in &linked {
+            if !crate::graph::entity_matches_text(entity, &tokens) {
+                tx.execute(
+                    "DELETE FROM memory_entities WHERE memory_rid = ?1 AND entity_name = ?2",
+                    params![rid, entity],
+                )?;
+            }
+        }
+        Ok(())
+    }
+
     fn insert_correct_op_in_tx(
         &self,
         tx: &rusqlite::Transaction<'_>,
@@ -1408,6 +1454,15 @@ impl YantrikDB {
                             rid,
                         ],
                     )?;
+                    // **Entity-graph coherence — safety half (nuron finding).**
+                    // The vector is re-embedded above, but the memory→entity
+                    // links were extracted from the OLD text; a link whose
+                    // entity no longer appears in the corrected text keeps
+                    // serving this record under its old association via graph
+                    // expansion. Drop those stale links IN this tx (atomic with
+                    // the text change). Adding links for NEW entities is the
+                    // deferrable completeness half, not done here.
+                    Self::drop_stale_memory_entity_links_in_tx(&tx, rid, new_text)?;
                     self.insert_correct_op_in_tx(
                         &tx,
                         rid,
@@ -1747,6 +1802,14 @@ impl YantrikDB {
                             rid,
                         ],
                     )?;
+                }
+                // Entity-graph coherence safety half (nuron) — mirror the
+                // leader: on a text-changing correction, drop memory→entity
+                // links whose entity no longer appears in the corrected text,
+                // so a follower's graph expansion stays coherent with the
+                // corrected text just like the leader's.
+                if let Some(t) = new_text {
+                    Self::drop_stale_memory_entity_links_in_tx(&tx, rid, t)?;
                 }
                 // Provenance stamp (minor r3): every replication-apply site
                 // records into replication_apply_log (schema contract).

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -14431,6 +14431,75 @@ fn correct_with_embedding_rejects_stale_generation() {
 
 #[cfg(feature = "bundled-embedder")]
 #[test]
+fn correct_new_text_drops_stale_entity_links() {
+    // nuron finding (v0.10 Item-3 follow-up): correct(new_text) must drop
+    // memory->entity links whose entity no longer appears (WORD-BOUNDARY) in
+    // the corrected text — else graph expansion keeps serving the record under
+    // its OLD association (why_retrieved=["graph-connected via <old-entity>"]).
+    // Reproduces the Volkan/Aurelian case AND the substring-collision false-keep
+    // guard: "Volkan" must drop even when the new text contains "Volkanic".
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let rid = db
+        .record_text(
+            "The Volkan salt marshes are cold",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    // Seed links deterministically (extraction is async + heuristic; we test the
+    // DROP, not extraction): an entity present in the NEW text ("Aurelian") must
+    // be kept; one absent must drop; and "Volkan" is a substring of the new
+    // text's "Volkanic" — naive substring would false-KEEP it, word-boundary
+    // must drop it.
+    {
+        let conn = db.conn();
+        for e in ["Volkan", "Aurelian"] {
+            conn.execute(
+                "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) VALUES (?1, ?2)",
+                params![rid, e],
+            )
+            .unwrap();
+        }
+    }
+    db.correct(
+        &rid,
+        Some("The Aurelian highland lakes near Volkanic rock"),
+        None,
+        None,
+        None,
+        "winter grounds moved",
+    )
+    .unwrap();
+    let links: Vec<String> = {
+        let conn = db.conn();
+        let mut stmt = conn
+            .prepare("SELECT entity_name FROM memory_entities WHERE memory_rid = ?1")
+            .unwrap();
+        stmt.query_map(params![rid], |r| r.get::<_, String>(0))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert!(
+        links.contains(&"Aurelian".to_string()),
+        "entity present in corrected text must be kept: {links:?}"
+    );
+    assert!(
+        !links.contains(&"Volkan".to_string()),
+        "stale entity absent from corrected text must be dropped (and NOT false-kept by 'Volkanic'): {links:?}"
+    );
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
 fn correct_correct_revision_chain_records_true_prior_state() {
     // sol finding 7: two successive text corrections must chain — the
     // second revision records the FIRST correction's state as its prior,


### PR DESCRIPTION
## Entity-graph coherence on text correction (Item-3 follow-up)

nuron's consumer-seat verification against the live engine found — and I confirmed in code — that Item 3's `correct(new_text)` is **vector-coherent but not entity-graph-coherent**.

### The gap
`correct(new_text)` re-embeds the vector and updates FTS, but `memory_entities` links were extracted from the **old** text and were never revisited. So a corrected record kept being pulled through **graph expansion under its old association** — `why_retrieved=["graph-connected via <old-entity>"]`, with no semantic or keyword match. nuron's live repro on CT128: wrote about *"Volkan salt marshes"*, corrected to *"Aurelian highland lakes"* → a query for *"coastal salt marsh Volkan"* still returned it (score 0.857) purely via the stale `Volkan` link; the new `Aurelian` entity was never extracted.

It's the **reembed-independent, always-on** face of the same "old meaning still served" problem the vector path closes, and it **shipped with Item 3** (before Item 3, `correct()` refused text changes). Confirmed **indefinite**: `backfill_memory_entities` only matches *existing* entities and only *adds* links; extraction happens solely in `record()`. For the false-accusation class, the `Person-X ↔ Bad-Thing` edge outlives the corrected text.

### The fix — the "safety half"
`correct_with_reembed` (leader) and `apply_replicated_correct` (follower) now drop, **in the correction transaction**, any `memory→entity` link whose entity no longer appears in the corrected text. Matching reuses the **same** `graph::entity_matches_text` / `graph::tokenize` that entity extraction uses — which is **word-boundary** (token equality, not substring), so a short entity can't false-**keep** by colliding inside a larger word (`"Volkan"` ≠ `"Volkanic"`). A false-keep would silently preserve the harm while the code looks like it ran; a false-drop (alias) is benign under-retrieval — so we **err toward dropping**.

Adding links for *new* entities (re-extraction) is the deferrable **completeness half** — intentionally not done here (a missing new link under-retrieves; it never serves a wrong association).

### Also: Half-B honest docs
`CorrectionDeferredDuringReembed` now states plainly that the **old text stays active and served as current until a retry succeeds** — a not-yet-applied correction, not a harmless no-op — and points at the metadata/status path (never blocked by reembed) to demote the record meanwhile. (Consumer decision: typed-retry is sufficient for v0.10; engine-native synchronous Half-B → v0.11 durable-materializer.)

### Tests
`correct_new_text_drops_stale_entity_links` reproduces the Volkan/Aurelian case including the substring-collision guard (drops `"Volkan"` even when the corrected text contains `"Volkanic"`). Full core lib suite **1664 passed**; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
