### PR TITLE
fix(correct): evict dropped entity links from in-memory graph_index (live-recall fix for #70)

### DIFF
--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -1084,6 +1084,39 @@ impl YantrikDB {
         Ok(())
     }
 
+    /// **Entity-graph coherence — in-memory index eviction (nuron live-verify
+    /// finding, v0.10 Item-3 follow-up).** `drop_stale_memory_entity_links_in_tx`
+    /// deletes the DURABLE `memory_entities` rows, but recall's `expand_entities`
+    /// reads the in-memory `graph_index`, which the correction transaction never
+    /// touches (graph_ops.rs documents "graph_index retains the edge until the
+    /// next engine reload"). So durable-only dropping left the corrected record
+    /// still served under its OLD association through graph expansion — a
+    /// green-unit-test/red-live-recall index-staleness bug the durable-table
+    /// assertion could not catch.
+    ///
+    /// Re-derive this memory's in-memory links from the now-committed,
+    /// authoritative durable rows: clear its links and re-link the survivors.
+    /// Cheap (O(links for this one memory)) and atomic to recall readers under
+    /// the graph_index write lock. Call AFTER the correction commits and its
+    /// conn lock is released — the brief re-lock here keeps `conn` and
+    /// `graph_index` from being held simultaneously (record's graph path also
+    /// releases conn before taking graph_index, so the lock order is preserved).
+    fn resync_memory_graph_links_after_correction(&self, rid: &str) -> Result<()> {
+        let survivors: Vec<String> = {
+            let conn = self.conn.lock();
+            let mut stmt =
+                conn.prepare("SELECT entity_name FROM memory_entities WHERE memory_rid = ?1")?;
+            let rows = stmt.query_map(params![rid], |r| r.get::<_, String>(0))?;
+            rows.collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        let mut gi = self.graph_index.write();
+        gi.unlink_memory(rid);
+        for e in &survivors {
+            gi.link_memory(rid, e);
+        }
+        Ok(())
+    }
+
     fn insert_correct_op_in_tx(
         &self,
         tx: &rusqlite::Transaction<'_>,
@@ -1546,6 +1579,19 @@ impl YantrikDB {
             drop(conn);
             drop(sync_guard);
 
+            // Entity-graph coherence: propagate the durable stale-link drop to
+            // the in-memory graph_index recall reads (nuron). Done AFTER conn is
+            // released so conn + graph_index are never held together. A failure
+            // here degrades to the pre-fix "stale until reload" behavior rather
+            // than failing an already-committed correction.
+            if let Err(e) = self.resync_memory_graph_links_after_correction(rid) {
+                tracing::warn!(
+                    rid,
+                    error = %e,
+                    "graph-index resync after correction failed; stale entity links until reload"
+                );
+            }
+
             // Outcome anchor (Item 2): a successful correction is an
             // independent caller action targeting the rid.
             self.note_caller_used(rid);
@@ -1836,6 +1882,20 @@ impl YantrikDB {
                     row.importance = new_importance;
                     row.valence = new_valence;
                 }
+            }
+            // Release the epoch (restores even) then conn — both held across
+            // commit + publish + cache like the leader — BEFORE the graph
+            // resync re-locks conn. Then propagate the durable stale-link drop
+            // to the in-memory graph_index on the follower too (nuron), so a
+            // follower's graph expansion stays coherent with the corrected text.
+            drop(_epoch);
+            drop(conn);
+            if let Err(e) = self.resync_memory_graph_links_after_correction(rid) {
+                tracing::warn!(
+                    rid,
+                    error = %e,
+                    "graph-index resync after replicated correction failed; stale links until reload"
+                );
             }
             return Ok(());
         }

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -14469,6 +14469,16 @@ fn correct_new_text_drops_stale_entity_links() {
             .unwrap();
         }
     }
+    // Also seed the IN-MEMORY graph_index — this is what recall's
+    // expand_entities actually reads. nuron's live verification showed a
+    // durable-only drop leaves this index stale, so the corrected record keeps
+    // being served under its old association. The durable-table assertion alone
+    // gave a false green; this test now covers the live path.
+    {
+        let mut gi = db.graph_index.write();
+        gi.link_memory(&rid, "Volkan");
+        gi.link_memory(&rid, "Aurelian");
+    }
     db.correct(
         &rid,
         Some("The Aurelian highland lakes near Volkanic rock"),
@@ -14490,11 +14500,29 @@ fn correct_new_text_drops_stale_entity_links() {
     };
     assert!(
         links.contains(&"Aurelian".to_string()),
-        "entity present in corrected text must be kept: {links:?}"
+        "durable entity present in corrected text must be kept: {links:?}"
     );
     assert!(
         !links.contains(&"Volkan".to_string()),
-        "stale entity absent from corrected text must be dropped (and NOT false-kept by 'Volkanic'): {links:?}"
+        "durable stale entity absent from corrected text must be dropped (and NOT false-kept by 'Volkanic'): {links:?}"
+    );
+    // The in-memory graph_index (what recall's expand_entities reads) must ALSO
+    // reflect the drop — the assertion that would have caught nuron's live
+    // finding.
+    let gi_entities: Vec<String> = db
+        .graph_index
+        .read()
+        .entities_for_memory(&rid)
+        .iter()
+        .map(|s| s.to_lowercase())
+        .collect();
+    assert!(
+        gi_entities.iter().any(|e| e == "aurelian"),
+        "in-memory graph_index must keep the surviving entity: {gi_entities:?}"
+    );
+    assert!(
+        !gi_entities.iter().any(|e| e == "volkan"),
+        "in-memory graph_index must EVICT the stale entity (recall's expand_entities reads it): {gi_entities:?}"
     );
 }
 


### PR DESCRIPTION
Follow-up to #70. **nuron's consumer live-verification caught that the entity-link drop didn't actually fire on the recall path** — a green-unit-test / red-live-recall gap.

## Why #70 looked fixed but wasn't
#70 deletes the durable `memory_entities` rows (and my 1664 unit tests assert exactly that table). But recall's `expand_entities` reads the **in-memory `graph_index`**, which #70 never touched — `graph_ops.rs` even documents it: *"graph_index retains the edge until the next engine reload."*

So on the live engine, a corrected record kept being served under its **old** association via graph expansion (`why_retrieved=["graph-connected via Volkan"]`), even though vector + FTS reflected the correction immediately. That vector-fresh / graph-stale asymmetry is what localized it to missing in-memory index invalidation. nuron confirmed with clean-removal corrections (ruling out the word-boundary guard) and a control showing retained entities are correctly kept.

## Fix
After a text-changing correction commits, resync this memory's in-memory `graph_index` links from the now-authoritative durable rows (clear its links, re-link survivors). On **both** leader (`correct_with_reembed`) and follower (`apply_replicated_correct`), done **after** the epoch + conn are released so `conn` and `graph_index` are never held together (matching `record()`'s lock order), and **non-fatal** — a resync failure degrades to the pre-fix "stale until reload" rather than failing an already-committed correction.

## Test hardening
`correct_new_text_drops_stale_entity_links` now seeds **and asserts** the in-memory `graph_index` (via `entities_for_memory`), not just the durable table — the assertion that would have caught the original miss. Keeps the surviving entity, evicts the stale one. Full core lib suite **1664 passed**; fmt clean.

**Lesson:** durable-state unit tests give false-green on index-staleness bugs; the consumer live-recall verification is what caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)