### PR TITLE
feat(v0.10-item4a.1): single-origin ingress guard for replication

### DIFF
--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -208,6 +208,28 @@ pub enum YantrikDbError {
     )]
     RecallContended { attempts: u32 },
 
+    /// **v0.10 Item 4a — single-origin ingress guard.** A protected write op
+    /// (`record` / `record_with_rid` / `correct` / `consolidate`) arrived via
+    /// replication from an origin actor that is not this database's configured
+    /// `authoritative_origin_actor`. In the single-writer Item 4a model,
+    /// provenance is admitted at ONE authority; applying a foreign origin's
+    /// record verbatim would let an ungated or malicious peer launder
+    /// provenance past the local gate. The ENTIRE incoming batch is rejected
+    /// before any HLC merge / oplog / memories / cache / vector change, so a
+    /// rejected apply leaves the engine byte-for-byte unchanged. Multi-origin
+    /// ingress is an Item 4b (multi-master) capability. The guard is inactive
+    /// unless `authoritative_origin_actor` is configured.
+    #[error(
+        "replicated `{op_type}` op rejected: origin '{origin_actor}' is not the \
+         authoritative origin '{authority}' (single-writer Item 4a; multi-origin \
+         is v0.11 Item 4b)"
+    )]
+    ForeignOriginRejected {
+        op_type: String,
+        origin_actor: String,
+        authority: String,
+    },
+
     /// **Phase 6 RYW**: caller-requested visible_seq was not reached within
     /// the timeout window. Either the write that should have bumped the seq
     /// has not yet materialized (legitimate timeout — caller should retry or

--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -200,23 +200,36 @@ impl YantrikDB {
     /// admits as authoritative, or `None` when the guard is inactive (legacy
     /// multi-origin behavior — the default). A single-writer deployment sets
     /// this to its own `actor_id` to reject foreign-origin provenance writes.
-    pub fn authoritative_origin(&self) -> Option<String> {
+    ///
+    /// **Fail-CLOSED (sol 4a.1 finding 1):** returns `Result` and distinguishes
+    /// "no authority configured" (`Ok(None)`) from a real read failure (`Err`).
+    /// A security guard must never be disabled by a malformed value or a query
+    /// error, so `apply_ops` propagates the `Err` and applies nothing rather
+    /// than silently falling open.
+    pub fn authoritative_origin(&self) -> Result<Option<String>> {
         use rusqlite::OptionalExtension;
-        self.conn()
+        Ok(self
+            .conn()
             .query_row(
                 "SELECT value FROM meta WHERE key = 'authoritative_origin_actor'",
                 [],
                 |r| r.get::<_, String>(0),
             )
-            .optional()
-            .ok()
-            .flatten()
+            .optional()?)
     }
 
     /// Designate the authoritative origin actor (Item 4a). Pass this database's
     /// own `actor_id` on a single-writer deployment to activate the ingress
     /// guard so foreign-origin `record` / `record_with_rid` / `correct` /
     /// `consolidate` ops are rejected by [`apply_ops`].
+    ///
+    /// **Configuration is init/quiescent-time only (sol 4a.1 finding 2).** The
+    /// authoritative origin is a deployment identity; set it before sync begins
+    /// (the v37 migration sets it to `self.actor_id` at open, before any
+    /// `apply_ops`). Changing it concurrently with an in-flight `apply_ops` is
+    /// not linearizable (the preflight read and the apply are separate conn
+    /// acquisitions) and is unsupported — a mid-flight change could let one
+    /// batch straddle the old/new authority.
     pub fn set_authoritative_origin(&self, actor_id: &str) -> Result<()> {
         self.conn().execute(
             "INSERT OR REPLACE INTO meta (key, value) VALUES ('authoritative_origin_actor', ?1)",
@@ -234,7 +247,7 @@ pub fn apply_ops(db: &YantrikDB, ops: &[OplogEntry]) -> Result<SyncStats> {
     // materialization: a single foreign-origin protected write rejects the
     // ENTIRE batch, leaving the engine byte-for-byte unchanged. Guard is
     // inactive (no-op) when no authority is set.
-    if let Some(authority) = db.authoritative_origin() {
+    if let Some(authority) = db.authoritative_origin()? {
         for op in ops {
             if is_protected_write(&op.op_type) && op.origin_actor != authority {
                 return Err(crate::error::YantrikDbError::ForeignOriginRejected {
@@ -1453,15 +1466,15 @@ mod tests {
     }
 
     #[test]
-    fn origin_guard_batch_atomic_c_relayed_through_b() {
-        // A C-origin op relayed in a batch that also carries an authority (A)
-        // op: the whole batch is rejected and NEITHER op applies.
+    fn origin_guard_batch_atomic_rejects_whole_mixed_batch() {
+        // A C-origin op in a batch that also carries an authority (A) op: the
+        // whole batch is rejected and NEITHER op applies (batch-atomicity).
         let a = YantrikDB::new_with_actor(":memory:", 8, "actor-A").unwrap();
         let a_rid = rec(&a, "from A");
         let mut batch = ops_of(&a);
         let c = YantrikDB::new_with_actor(":memory:", 8, "actor-C").unwrap();
         let c_rid = rec(&c, "from C");
-        batch.extend(ops_of(&c)); // B receives A's op + a relayed C op
+        batch.extend(ops_of(&c));
 
         let b = YantrikDB::new_with_actor(":memory:", 8, "actor-B").unwrap();
         b.set_authoritative_origin("actor-A").unwrap();
@@ -1477,6 +1490,41 @@ mod tests {
         assert!(
             b.get(&c_rid).unwrap().is_none(),
             "the foreign op must not apply"
+        );
+    }
+
+    #[test]
+    fn origin_guard_rejects_c_relayed_through_b() {
+        // TRUE relay (sol 4a.1 finding 3): C originates, B (unguarded) applies
+        // then re-exports it, and the guarded node G receives B's RELAYED
+        // batch. G must reject by the op's ORIGIN (C), not the deliverer (B) —
+        // which requires origin_actor to survive the relay hop.
+        let c = YantrikDB::new_with_actor(":memory:", 8, "actor-C").unwrap();
+        let c_rid = rec(&c, "from C");
+        let b = YantrikDB::new_with_actor(":memory:", 8, "actor-B").unwrap();
+        apply_ops(&b, &ops_of(&c)).unwrap(); // B relays (no authority set)
+        let relayed = ops_of(&b); // extracted FROM B
+        assert!(
+            relayed
+                .iter()
+                .any(|o| o.op_type == "record" && o.origin_actor == "actor-C"),
+            "relay must preserve origin_actor=C, got {:?}",
+            relayed.iter().map(|o| &o.origin_actor).collect::<Vec<_>>()
+        );
+
+        let g = YantrikDB::new_with_actor(":memory:", 8, "actor-G").unwrap();
+        g.set_authoritative_origin("actor-A").unwrap(); // G trusts only A
+        let err = apply_ops(&g, &relayed).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::error::YantrikDbError::ForeignOriginRejected { .. }
+            ),
+            "a C-origin op relayed through B must be rejected by G, got {err:?}"
+        );
+        assert!(
+            g.get(&c_rid).unwrap().is_none(),
+            "relayed foreign-origin op must not apply on the guarded node"
         );
     }
 

--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -182,9 +182,70 @@ pub fn extract_ops_since(
     Ok(entries)
 }
 
+/// **Item 4a single-origin guard.** Protected write op types create or mutate
+/// durable records carrying provenance (`source` / `kind` / `confidence_basis`).
+/// In the single-writer Item 4a model these may originate at exactly ONE
+/// authority; a foreign-origin protected write arriving via replication would
+/// launder provenance past the local gate. Non-record ops (relate / link /
+/// forget / trigger / …) are not provenance-bearing and are not guarded here.
+fn is_protected_write(op_type: &str) -> bool {
+    matches!(
+        op_type,
+        "record" | "record_with_rid" | "correct" | "consolidate"
+    )
+}
+
+impl YantrikDB {
+    /// **Item 4a single-origin guard.** The actor whose writes this database
+    /// admits as authoritative, or `None` when the guard is inactive (legacy
+    /// multi-origin behavior — the default). A single-writer deployment sets
+    /// this to its own `actor_id` to reject foreign-origin provenance writes.
+    pub fn authoritative_origin(&self) -> Option<String> {
+        use rusqlite::OptionalExtension;
+        self.conn()
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'authoritative_origin_actor'",
+                [],
+                |r| r.get::<_, String>(0),
+            )
+            .optional()
+            .ok()
+            .flatten()
+    }
+
+    /// Designate the authoritative origin actor (Item 4a). Pass this database's
+    /// own `actor_id` on a single-writer deployment to activate the ingress
+    /// guard so foreign-origin `record` / `record_with_rid` / `correct` /
+    /// `consolidate` ops are rejected by [`apply_ops`].
+    pub fn set_authoritative_origin(&self, actor_id: &str) -> Result<()> {
+        self.conn().execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('authoritative_origin_actor', ?1)",
+            params![actor_id],
+        )?;
+        Ok(())
+    }
+}
+
 /// Apply remote ops to a local YantrikDB instance. Idempotent via INSERT OR IGNORE on op_id.
 /// Returns the number of ops actually applied (newly inserted).
 pub fn apply_ops(db: &YantrikDB, ops: &[OplogEntry]) -> Result<SyncStats> {
+    // **Item 4a single-origin ingress guard.** If an authoritative origin is
+    // configured, PREFLIGHT the whole batch before any HLC merge / oplog /
+    // materialization: a single foreign-origin protected write rejects the
+    // ENTIRE batch, leaving the engine byte-for-byte unchanged. Guard is
+    // inactive (no-op) when no authority is set.
+    if let Some(authority) = db.authoritative_origin() {
+        for op in ops {
+            if is_protected_write(&op.op_type) && op.origin_actor != authority {
+                return Err(crate::error::YantrikDbError::ForeignOriginRejected {
+                    op_type: op.op_type.clone(),
+                    origin_actor: op.origin_actor.clone(),
+                    authority,
+                });
+            }
+        }
+    }
+
     let mut applied = 0;
     let mut skipped = 0;
     let mut has_relate_or_record = false;
@@ -1305,6 +1366,131 @@ mod tests {
             "emotional_state must survive replication"
         );
         assert_eq!(mem.namespace, "work");
+    }
+
+    // ── Item 4a.1 single-origin ingress guard ──
+
+    fn rec(db: &YantrikDB, text: &str) -> String {
+        db.record(
+            text,
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap()
+    }
+    fn ops_of(db: &YantrikDB) -> Vec<OplogEntry> {
+        extract_ops_since(&db.conn(), None, None, None, 100).unwrap()
+    }
+
+    #[test]
+    fn is_protected_write_classification() {
+        for t in ["record", "record_with_rid", "correct", "consolidate"] {
+            assert!(is_protected_write(t), "{t} must be protected");
+        }
+        for t in [
+            "relate",
+            "link",
+            "unlink",
+            "forget",
+            "think",
+            "trigger_fire",
+        ] {
+            assert!(!is_protected_write(t), "{t} must NOT be guarded");
+        }
+    }
+
+    #[test]
+    fn origin_guard_inactive_by_default_allows_foreign() {
+        // Backward-compat: no authority configured -> foreign ops apply (legacy).
+        let a = YantrikDB::new_with_actor(":memory:", 8, "actor-A").unwrap();
+        let rid = rec(&a, "from A");
+        let b = YantrikDB::new_with_actor(":memory:", 8, "actor-B").unwrap();
+        apply_ops(&b, &ops_of(&a)).unwrap();
+        assert!(
+            b.get(&rid).unwrap().is_some(),
+            "no authority set -> foreign-origin op applies"
+        );
+    }
+
+    #[test]
+    fn origin_guard_rejects_foreign_protected_write() {
+        let c = YantrikDB::new_with_actor(":memory:", 8, "actor-C").unwrap();
+        let c_rid = rec(&c, "from C");
+        let c_ops = ops_of(&c);
+        let b = YantrikDB::new_with_actor(":memory:", 8, "actor-B").unwrap();
+        b.set_authoritative_origin("actor-A").unwrap(); // B trusts only A
+        let err = apply_ops(&b, &c_ops).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::error::YantrikDbError::ForeignOriginRejected { .. }
+            ),
+            "foreign-origin protected write must be rejected, got {err:?}"
+        );
+        // State unchanged: no memory, and the op did not enter the oplog.
+        assert!(
+            b.get(&c_rid).unwrap().is_none(),
+            "rejected write leaves no memory"
+        );
+        let inserted: bool = b
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM oplog WHERE op_id = ?1",
+                params![c_ops[0].op_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(!inserted, "rejected op must not enter the oplog");
+    }
+
+    #[test]
+    fn origin_guard_batch_atomic_c_relayed_through_b() {
+        // A C-origin op relayed in a batch that also carries an authority (A)
+        // op: the whole batch is rejected and NEITHER op applies.
+        let a = YantrikDB::new_with_actor(":memory:", 8, "actor-A").unwrap();
+        let a_rid = rec(&a, "from A");
+        let mut batch = ops_of(&a);
+        let c = YantrikDB::new_with_actor(":memory:", 8, "actor-C").unwrap();
+        let c_rid = rec(&c, "from C");
+        batch.extend(ops_of(&c)); // B receives A's op + a relayed C op
+
+        let b = YantrikDB::new_with_actor(":memory:", 8, "actor-B").unwrap();
+        b.set_authoritative_origin("actor-A").unwrap();
+        let err = apply_ops(&b, &batch).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::YantrikDbError::ForeignOriginRejected { .. }
+        ));
+        assert!(
+            b.get(&a_rid).unwrap().is_none(),
+            "batch-atomic: the authority op must also NOT apply when the batch is rejected"
+        );
+        assert!(
+            b.get(&c_rid).unwrap().is_none(),
+            "the foreign op must not apply"
+        );
+    }
+
+    #[test]
+    fn origin_guard_allows_authority_origin() {
+        let a = YantrikDB::new_with_actor(":memory:", 8, "actor-A").unwrap();
+        let a_rid = rec(&a, "from A");
+        let b = YantrikDB::new_with_actor(":memory:", 8, "actor-B").unwrap();
+        b.set_authoritative_origin("actor-A").unwrap();
+        apply_ops(&b, &ops_of(&a)).unwrap();
+        assert!(
+            b.get(&a_rid).unwrap().is_some(),
+            "authority-origin op must apply"
+        );
     }
 
     #[test]

--- a/docs/V0.10_ITEM4_DESIGN.md
+++ b/docs/V0.10_ITEM4_DESIGN.md
@@ -1,0 +1,302 @@
+# v0.10 Item 4 — Typed-record chokepoints (anti-laundering write gate)
+
+Status: DESIGN v3 (post sol-r2). **DECOMPOSED** per Pranab's decision.
+Schema: introduces **v37** (current live = v36).
+
+- **Item 4a (v0.10, THIS doc's build scope):** the pure anti-laundering
+  provenance gate + `confidence_basis` + **local, single-writer, actor-scoped**
+  idempotency. Tractable, and it is the whole protection CT128 (single-writer)
+  needs.
+- **Item 4b (v0.11, deferred, scoped-not-built here):** multi-master key
+  reconciliation, peer-sync re-gate / quarantine convergence, cross-peer digest
+  with embedding bytes. This is where sol-r2's 4 "new holes" live; they are
+  distributed-systems problems that do not gate the single-writer protection.
+
+The split is chosen along a real seam: **admission is a local, single-authority
+decision; cross-peer convergence is a separate protocol.** 4a builds the former
+and lays forward-compatible schema/oplog so 4b extends it without migration.
+
+sol-r2 status is tracked per point below as `[r2 #N: resolved | 4a | 4b]`.
+
+---
+
+## Proof obligations (release-blocking traces)
+
+- **T06 anti-laundering-chokepoint** — typed refusal at write time via the
+  central gate; recall returns `source` verbatim; every bypass path covered
+  (`record`, `record_text`, `record_batch`, `record_with_rid`, `record_queued`,
+  `correct(metadata_merge)`, replicated consolidation, all `materialize_*`).
+  `[r2 #6: resolved]`
+- **T07 repetition-not-corroboration** — same key + same payload → one record,
+  certainty UNCHANGED; same key + **different payload → typed conflict**; no
+  silent near-dup merge without a key.
+- **T03 status-freshness** (shared w/ Item 1).
+
+---
+
+## Item 4a — build scope
+
+### A. The gate (pure, local) `[r2 #1: 4a-local, #6: resolved]`
+
+`admit_gate(&self, draft: &WriteDraft) -> Result<AdmittedWrite>` — one function
+every durable **origin** write funnels through, BEFORE any side effect
+(mirrors `validate.rs`'s "rejected write leaves the engine byte-for-byte
+unchanged"). Pure function of the draft's DECLARED fields (see purity below).
+
+Bypass fan-out (each gets a T06 fixture): `record` (record.rs:71 region),
+`record_text` (mod.rs:1671 — bypasses `record()`, gate here too), `record_batch`
+(per item), `record_with_rid`, `record_queued`, `correct` metadata path when it
+changes `kind`/`source`/`basis`, and local consolidation (already enters via
+`db.record`, consolidate.rs:385).
+
+**4a trust boundary (single-writer):** the gate runs at the ORIGIN. Replicated
+apply (`materialize_*`, `apply_replicated_*`) applies the leader's already-gated
+record VERBATIM — it carries `source`/`confidence_basis`/final `kind` in the op
+(extending the #69 pattern that already made `materialize_record` carry
+`source`), and does NOT re-gate. This is sound for a single-writer origin: one
+gate authority, no divergence. **4b** adds peer-sync re-gate / attestation /
+quarantine for multi-master; 4a explicitly documents that a second independent
+writer is out of scope and would need 4b. `[r2 #1 multi-master, #2 cross-peer,
+#5-quarantine: 4b]`
+
+### B. Typed provenance grammar `[r2 #5: 4a]`
+
+```rust
+enum Source { User, Inference, Document, System }         // closed
+enum ConfidenceBasis {
+    Observation, Asserted, Confirmation, Verification, Inference, Assumption,
+    Learned { model: String },
+}
+enum ClaimKind { Fact, Observation, Inference, Unspecified, Other(String) }
+```
+
+Grammar decisions (sol-r2 #5 — the gaps it named, now closed):
+
+- **Protected `kind` set = {fact, observation, inference}.** `ClaimKind::Other(s)`
+  is any *parseable* non-protected string; it is ACCEPTED and stored verbatim
+  (kinds are an open vocabulary — only the protected three participate in the
+  matrix). "Reject unknown" applies ONLY to the protected positions: a `kind`
+  that lexically collides with a protected term but mis-cased/whitespaced
+  normalizes into the protected variant (so `"Fact"`/`" fact "` → `Fact`), and a
+  `source`/`basis` that is non-empty-but-unparseable-as-a-known-variant is
+  REFUSED (a caller trying to smuggle `source="inferece"` [sic] to dodge the
+  matrix is rejected, not silently treated as Other).
+- **`learned(<model>)` grammar:** `^learned\((?P<model>[A-Za-z0-9._-]{1,64})\)$`
+  — model non-empty, ≤64 chars, `[A-Za-z0-9._-]` only, no nested parens/unicode.
+  Stored canonical form = the re-serialized `learned(<model>)`.
+- **Storage vs recall-verbatim (T06):** the gate PARSES (trim + normalize) for
+  the verdict, but the record stores the CANONICAL form of the accepted value
+  (`Source::User.as_str()` = `"user"`), and recall returns THAT. So "recall
+  returns source verbatim" means verbatim of the *canonical accepted* value, not
+  the raw pre-trim bytes. Callers already send canonical values; the normalize
+  step only rescues whitespace/case, and a value that needed rescuing is stored
+  in its canonical form (documented; no information loss for provenance).
+- **Closing `Source` to 4 variants is an API compat change.** The engine
+  `record*` API keeps `source: &str` at the boundary (no signature break) but
+  `admit_gate` parses it; an unparseable source is a typed refusal, matching the
+  v26 backfill's existing four-value contract (schema.rs:2255). Documented as a
+  behavior change: pre-v37, an arbitrary `source` string persisted; post-v37 it
+  is refused. Migration note in the release doc.
+
+### C. Consistency matrix (pure, declared fields)
+
+| source    | claim / basis                              | verdict                 |
+|-----------|--------------------------------------------|-------------------------|
+| Inference | basis = Observation                        | REFUSE (typed)          |
+| Inference | kind ∈ {Fact, Observation}, no override    | REFUSE (typed)          |
+| *         | unparseable protected `source`/`kind`      | REFUSE (typed)          |
+
+Reads **final plaintext merged metadata** (NOT the encrypted-NULL virtual `kind`
+column). For `correct(metadata_merge)`, gate the already-merged final metadata
+inside the correction path, before the revision insert and before the reembed
+path reserves a vector. `[r2 #3-plaintext: resolved]`
+
+**Escape hatch = "raise your basis", not "override the check" (nuron):** the
+documented path for a genuine fact is to set `confidence_basis` to
+`confirmation`/`verification` (with evidence). A pragmatic `override_kind: bool`
+remains but MUST be (1) deliberate+typed, (2) audit-traced, (3) STAMP the record
+so recall renders it "asserted-over-inference, not independently verified".
+Silent coercion rejected; untraced override not offered. `override_kind` is an
+input to the digest + verdict.
+
+**`asserted` is load-bearing (nuron):** "user said X" / "doc states X" —
+`source=user|document` — is neither observation nor inference nor confirmation.
+Without `asserted` the gate forces a false `observation` stamp on the majority
+case. source=WHO, basis=asserted="I'm taking their word." `assumption` =
+provisional/most-disposable (low-priority, included).
+
+**Stated limitation:** the gate prevents DECLARED contradictions; it cannot
+detect a caller that lies (`source=user` for an inference) or omits provenance.
+Omission still can't yield `source=inference ∧ kind=fact` (matrix keys off
+declared fields), but truthful provenance is not provable. `[r2 #3-omission:
+resolved as documented limitation]`
+
+### D. Canonical payload digest `[r2 #3: 4a]`
+
+`canonical_payload_digest(op_kind, draft) -> [u8; 32]` (blake3). **Variant-aware**
+(sol-r2 #3): the digest is a function of `(op_kind, fields)`.
+
+INCLUDED (all canonicalized):
+- `op_kind` discriminator (record / record_text / record_batch-item /
+  record_with_rid) — a same-key retry across DIFFERENT surfaces is a conflict.
+- `namespace` (post-normalize), `text` (post-`sanitize`, the STORED plaintext
+  bytes), `memory_type`, `source`, `confidence_basis`, `override_kind`, final
+  merged `metadata` (canonical JSON), `domain`, `emotional_state`.
+- **The mutable scalars `importance`, `valence`, `certainty`, `half_life`**
+  (sol-r2 #3 — they alter the first write's observable state, so same-key with a
+  different scalar is a CONFLICT, not a silent hit). Use the RAW caller
+  `importance` (pre-calibration) so the hit check precedes `calibrate_importance`.
+- The **caller-supplied embedding** (via existing `serde_helpers` `f32::to_le_bytes`,
+  serde_helpers.rs:1 — a deterministic byte rule that already exists) when
+  present. For `record_text` (engine embeds), the GENERATED embedding is
+  EXCLUDED so idempotency is decided BEFORE re-embedding.
+- An explicit **absent/present marker** for every optional field.
+
+EXCLUDED: generated `rid`/`created_at`/HLC, generated embeddings (record_text),
+encryption ciphertext, all generated columns (`kind` derived from metadata,
+already covered).
+
+Canonical JSON algorithm (fully specified): object keys sorted lexicographically
+by UTF-8 bytes; numbers as shortest round-trip decimal with `-0`→`0`; strings
+NFC-normalized UTF-8; arrays in given order; explicit type/length framing per
+field so `null` ≠ `""` ≠ absent.
+
+### E. Durable idempotency claim + claim-after-routing saga `[r2 #4, #7: 4a]`
+
+Schema v37 table:
+```sql
+CREATE TABLE idempotency_claims (
+    origin_actor    TEXT NOT NULL,      -- actor-scoped from day one (fwd-compat 4b)
+    namespace       TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    rid             TEXT NOT NULL,
+    payload_digest  BLOB NOT NULL,      -- 32-byte blake3
+    op_id           TEXT NOT NULL,      -- recovery evidence (authoritative op)
+    route           TEXT NOT NULL,      -- 'sync' | 'queued'
+    generation      INTEGER NOT NULL,   -- search generation at claim
+    state           TEXT NOT NULL,      -- 'pending' | 'committed'
+    created_at      REAL NOT NULL,
+    PRIMARY KEY (origin_actor, namespace, idempotency_key)
+);
+```
+Plus a partial unique index on `memories(namespace, idempotency_key) WHERE
+idempotency_key IS NOT NULL` as defense-in-depth.
+
+**Actor-scoped key** (sol-r2 #1 multi-master collision): the PK includes
+`origin_actor` so two writers can't collide their keys. In 4a there is ONE
+writer, so this is a forward-compatible no-op today; it means 4b needs no
+migration. `[r2 #1-keys: 4a-schema, 4b-reconciliation]`
+
+**Claim-after-routing saga** (sol-r2 #4 — the two concurrency holes it named):
+1. Pure validate + gate + compute digest (no side effect).
+2. **Enter the write-router FIRST** (`try_enter_sync_writer` → `sync`, else
+   `queued`) so the route is known before the claim (fixes "claim can't bind to
+   the eventual route").
+3. In ONE transaction on that route (`_in_tx` helper — `record_queued` commits
+   internally at record.rs:1105, so it needs the in-tx variant): insert the
+   claim `state='pending'` with `op_id`/`route`/`generation` via
+   `INSERT ... ON CONFLICT DO NOTHING` (the INSERT is the serialization point,
+   not a prior SELECT), AND write the authoritative durable op (the memories row
+   for `sync`, or the oplog op for `queued`).
+4. Flip `state='committed'` in the SAME tx as the materialization commit. A
+   `pending` claim is NOT externally returnable (a losing retry never returns a
+   not-yet-committed rid).
+5. **Recovery** is by COMPLETING or ROLLING BACK the authoritative op named by
+   `op_id`/`route`, never by testing memory-row existence (sol-r2 #4: `record`
+   commits the row before the vector append, and `queued` has no row, so
+   row-existence is not a commit proof). Startup sweep reconciles `pending`
+   claims against their op.
+
+**Idempotent-hit ordering** (sol-r2 #7): on `ON CONFLICT`, read the existing
+claim. Same digest → return existing rid BEFORE any calibration, vector, entity,
+session, cache, visible-seq, or oplog effect (incl. `record_with_rid`'s
+`was_new_row=false` path, which today still allocates seq/appends — must become a
+true no-op). Different digest → typed conflict (below).
+
+**Wrapper disposition** (sol-r2 #7): `record` returns an internal
+`{ rid, disposition: Inserted | IdempotentHit }`. Wrappers that apply effects
+after `record` returns (`record_with_links`, links.rs:118) MUST short-circuit
+their link effects on `IdempotentHit` (and the wrapper's links join the
+wrapper-level idempotency payload). Public API still returns just the rid.
+
+**Conflict error shape (nuron — make escaping cheaper than ignoring):**
+```rust
+IdempotencyConflict {
+    key: String, existing_rid: String, existing_payload_hash: String,
+    existing_created_at: f64, existing_source: String,
+    existing_confidence_basis: Option<String>,
+}
+```
+`existing_rid` lets the host pivot to `correct(existing_rid, new_text)` in one
+hop; `existing_payload_hash` lets it confirm "genuinely different" without a
+`get()`.
+
+**Same-batch duplicate ownership** (sol-r2 #4): within one `record_batch` tx,
+two items with the same key → the first inserts the claim, the second sees
+`ON CONFLICT` with its OWN in-flight claim; the batch defines "ours" by tracking
+inserted keys in-memory for the batch's duration, so an in-batch repeat is an
+idempotent hit (or a conflict if digests differ), and a batch rollback rolls
+back all its claims + rows together.
+
+### F. Verbatim field propagation (4a slice of r2 #2) `[r2 #2: 4a-partial]`
+
+Extend the #69 pattern: the oplog "record"/"record_with_rid" op payload and the
+`materialize_*` inserts carry `confidence_basis`, final `kind`/metadata,
+`idempotency_key`, `origin_actor`, `payload_digest`. This stamps the durable +
+replicated record so 4b can re-gate/attest without a migration. 4a followers
+apply verbatim (single-writer trust); the cross-peer embedding-BYTES-in-op and
+re-gate are 4b. `[r2 #2 embedding-bytes / peer re-gate: 4b]`
+
+---
+
+## Schema v37 `[r2 #5-migration: resolved-sound]`
+
+- `ALTER memories ADD COLUMN confidence_basis TEXT` (nullable; NULL = unspecified).
+- `ALTER memories ADD COLUMN idempotency_key TEXT` (nullable).
+- `CREATE TABLE idempotency_claims (...)`.
+- `CREATE UNIQUE INDEX ... ON memories(namespace, idempotency_key) WHERE
+  idempotency_key IS NOT NULL`.
+- `MIGRATE_V36_TO_V37` — additive nullable columns + new table + partial index;
+  clean under `run_migration_idempotent` (existing rows get NULL keys, excluded
+  from the partial index). Bump `SCHEMA_VERSION` 36→37; append
+  `(36, MIGRATE_V36_TO_V37)` after the current final migration (mod.rs).
+
+---
+
+## Explicitly DEFERRED to Item 4b / v0.11
+
+- Peer-sync re-gate at ingress, gate_policy_version + attestation, quarantine
+  with convergent replay (sol-r2 #1, #5-quarantine — "quarantine forks state").
+- Multi-master idempotency-key RECONCILIATION (the schema is actor-scoped now;
+  the cross-actor winner/merge protocol is 4b) (sol-r2 #1-keys).
+- Cross-peer digest requiring embedding BYTES in the oplog (today: hash only,
+  stats.rs:126) + plaintext-envelope→encrypt-locally boundary for peer re-gate
+  (sol-r2 #2, #3-plaintext-across-peers).
+
+4a is safe WITHOUT these because it assumes a single gate authority (single
+writer). The deferral is documented as an engine precondition, not hidden.
+
+---
+
+## Build sequencing
+
+1. Schema v37 (columns + claims table + index + migration) — isolated, testable.
+2. Typed `Source`/`ConfidenceBasis`/`ClaimKind` parsers + the pure matrix +
+   `ProvenanceInconsistent` error. Exhaustive matrix unit tests + grammar tests.
+3. `canonical_payload_digest` (variant-aware) + determinism tests (scalar-diff →
+   different digest; record_text excludes generated embedding; float bytes).
+4. `admit_gate` + claim-after-routing saga; route `record` through it; crash-point
+   + cross-process + retry-idempotency + scalar-conflict tests.
+5. Fan out to record_text / record_batch (incl. in-batch dup) / record_with_rid
+   (true no-op) / record_queued / correct — each with its T06 fixture.
+6. Verbatim field propagation into oplog + materialize_* (4a slice).
+7. T06 + T07 traces → implemented.
+
+## Re-consult (sol r3) — targeted questions
+- Is the 4a/4b seam sound: does "single-writer origin, followers apply verbatim"
+  hold given the engine can be a peer-sync node? (i.e. is there a config where a
+  4a-built engine receives writes from a second origin without 4b, and does the
+  precondition doc + a runtime guard suffice?)
+- Claim-after-routing saga: is `op_id`+`route`+`generation` sufficient recovery
+  evidence for both the sync (row-before-vector) and queued (no-row) crash points?
+- Digest completeness for T07 under the corrected (scalars-included) field-set.


### PR DESCRIPTION
First increment of **Item 4a** (anti-laundering write gate), decomposed per sol's r3 design review. This is the **release-blocking safety** piece.

## Why
sol showed the engine is bidirectional peer-sync — `apply_ops` does no origin check (replication.rs:187+), and the sync tests have A and B write independently. So Item 4a's "single-writer origin, followers apply verbatim" model is **unsafe without a hard runtime guard**: a foreign or ungated peer could launder provenance past the local gate by sending a `record` op that a follower materializes verbatim. sol was explicit — *"peer re-gating is not safely deferrable; it is currently compensating for an active multi-master ingress path."*

## What
- `YantrikDB::set_authoritative_origin(actor_id)` / `authoritative_origin()` — a meta key (`authoritative_origin_actor`), no schema bump.
- `apply_ops` **preflights the whole batch**: with an authority configured, a single foreign-origin **protected write** (`record` / `record_with_rid` / `correct` / `consolidate`) rejects the **entire batch** with the typed `ForeignOriginRejected`, before any HLC merge / oplog / materialize — a rejected apply leaves the engine byte-for-byte unchanged. Non-provenance ops (relate/link/forget/…) are not guarded.
- **Inactive by default** (no authority set) → full backward-compat; existing bidirectional-sync tests unchanged. A single-writer deployment activates it by setting its own `actor_id`. (4a.2's v37 migration will default the authority to self so v37 is single-writer-safe out of the box; multi-origin ingress → Item 4b / v0.11.)

## Tests (sol r3's required cases)
Foreign-origin protected write rejected + state-unchanged (no memory, not in oplog); **C-origin relayed through B** in a mixed batch → whole batch rejected, the authority op *also* not applied (batch-atomic); authority-origin op applies; guard-off default still applies foreign ops; `is_protected_write` classification.

Also lands `docs/V0.10_ITEM4_DESIGN.md` (v3, decomposed) — the living plan the 4a.N increments build against.

Full core lib suite **1669 passed**; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)