### PR TITLE
feat(v0.10-item4a.4b): fan out the anti-laundering gate to batch + correct

### DIFF
--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -918,6 +918,14 @@ impl YantrikDB {
             }
             None => cur_metadata_val.clone(),
         };
+        // **v0.10 Item 4a.4b — anti-laundering gate on the correction path
+        // (T06 fan-out).** A `metadata_merge` can flip `kind` to fact/observation
+        // on an inference-sourced record, so the gate must see the FINAL MERGED
+        // plaintext metadata (not the caller's patch) paired with the record's
+        // existing `source` — `correct()` cannot change `source` itself. Runs
+        // before the revision insert / UPDATE below, inside the tx, so a refusal
+        // rolls back leaving the row untouched.
+        self.gate_provenance(&original.source, &new_metadata_val)?;
         let stored_new_text = self.encrypt_text(&new_text_val)?;
         let stored_new_metadata = self.encrypt_text(&serde_json::to_string(&new_metadata_val)?)?;
 

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -408,6 +408,21 @@ impl YantrikDB {
                     ("half_life", input.half_life),
                 ],
             )?;
+            // v0.10 Item 4a.4b — anti-laundering gate (T06 fan-out). Runs in
+            // the batch PREVALIDATION loop, so an inconsistent element late in
+            // the batch rejects the whole batch before any side effect rather
+            // than half-committing the earlier ones — the same contract the
+            // embedding/scalar gates above rely on.
+            self.gate_provenance(&input.source, &input.metadata)
+                .map_err(|e| match e {
+                    crate::error::YantrikDbError::ProvenanceInconsistent { path, reason } => {
+                        crate::error::YantrikDbError::ProvenanceInconsistent {
+                            path,
+                            reason: format!("inputs[{i}]: {reason}"),
+                        }
+                    }
+                    other => other,
+                })?;
         }
 
         // Task 29 (Ingest Integrity): strip any leaked tool-call

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -1618,6 +1618,71 @@ fn gate_batch_rejects_inconsistent_element_atomically() {
 
 #[cfg(feature = "bundled-embedder")]
 #[test]
+fn gate_covers_links_after_record() {
+    // T06 names "links-after-record" as a bypass path that must be covered.
+    // record_with_links (links.rs:118) delegates to record() with `?`, so the
+    // gate refusal propagates BEFORE the link loop at :132 and no edge is
+    // applied. That is the right behavior, but it is a TRANSITIVE guarantee —
+    // it holds only as long as the wrapper keeps going through record(). If
+    // someone later inlines the insert here, the gate silently stops covering
+    // this path, so pin it.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let target = db
+        .record(
+            "an existing target",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    let links = [RecordLink {
+        target_rid: target.clone(),
+        link_type: LinkType::Supports,
+    }];
+    let err = db
+        .record_with_links(
+            "laundered via the wrapper",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({"kind": "fact"}),
+            &vec_seed(2.0, 8),
+            "default",
+            0.8,
+            "general",
+            "inference",
+            None,
+            &links,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::ProvenanceInconsistent { .. }
+        ),
+        "record_with_links must refuse an inference claiming kind=fact, got {err:?}"
+    );
+    // Refused before ANY link effect: the target gained no inbound edge.
+    let inbound = db
+        .linked_records(&target, LinkDirection::Inbound, None)
+        .unwrap();
+    assert!(
+        inbound.is_empty(),
+        "a refused record_with_links must apply no links, found {inbound:?}"
+    );
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
 fn gate_correct_metadata_merge_cannot_flip_kind_to_fact() {
     // Item 4a.4b: a metadata_merge can flip `kind` on an existing record, so
     // correct() gates the FINAL MERGED metadata against the record's source —

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -1570,6 +1570,106 @@ fn gate_source_is_free_form_matrix_binds_only_recognized_inference() {
     assert_eq!(db.stats(None).unwrap().provenance_flagged_since_boot, 0);
 }
 
+#[cfg(feature = "bundled-embedder")]
+#[test]
+fn gate_batch_rejects_inconsistent_element_atomically() {
+    // Item 4a.4b: the gate runs in record_batch's PREVALIDATION loop, so an
+    // inconsistent element LATE in the batch rejects the whole batch before any
+    // side effect — earlier elements must not be half-committed.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let mk = |text: &str, source: &str, meta: serde_json::Value| RecordInput {
+        text: text.to_string(),
+        memory_type: "semantic".to_string(),
+        importance: 0.5,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: meta,
+        embedding: vec_seed(1.0, 8),
+        namespace: "default".to_string(),
+        certainty: 0.8,
+        domain: "general".to_string(),
+        source: source.to_string(),
+        emotional_state: None,
+    };
+    let batch = vec![
+        mk("good one", "user", empty_meta()),
+        // late bad element: inference claiming fact
+        mk(
+            "laundered",
+            "inference",
+            serde_json::json!({"kind": "fact"}),
+        ),
+    ];
+    let err = db.record_batch(&batch).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::ProvenanceInconsistent { .. }
+        ),
+        "batch with an inconsistent element must be refused, got {err:?}"
+    );
+    // Atomic: the GOOD element must not have been written either.
+    let count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0, "a rejected batch must write nothing");
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
+fn gate_correct_metadata_merge_cannot_flip_kind_to_fact() {
+    // Item 4a.4b: a metadata_merge can flip `kind` on an existing record, so
+    // correct() gates the FINAL MERGED metadata against the record's source —
+    // otherwise correct() is a trivial laundering bypass of record()'s gate.
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let rid = db
+        .record_text(
+            "an inferred conclusion",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({"kind": "inference"}),
+            "default",
+            0.8,
+            "general",
+            "inference",
+            None,
+        )
+        .unwrap();
+    // Laundering attempt: promote the inference to a fact via metadata_merge.
+    let err = db
+        .correct(
+            &rid,
+            None,
+            Some(&serde_json::json!({"kind": "fact"})),
+            None,
+            None,
+            "promote",
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::ProvenanceInconsistent { .. }
+        ),
+        "correct(metadata_merge) must not flip an inference to kind=fact, got {err:?}"
+    );
+    // Refused before any side effect: no revision, kind unchanged.
+    assert_eq!(db.history(&rid).unwrap().len(), 0, "no revision recorded");
+    // Raising the basis is the documented escape and IS allowed.
+    db.correct(
+        &rid,
+        None,
+        Some(&serde_json::json!({"kind": "fact", "confidence_basis": "verification"})),
+        None,
+        None,
+        "verified independently",
+    )
+    .unwrap();
+}
+
 #[test]
 fn gate_mode_parse_is_fail_closed() {
     // A malformed persisted mode must NOT silently disable the gate (the


### PR DESCRIPTION
Follow-on to #75. 4a.4 wired the T06 gate into `record()`/`record_text()`; this closes the remaining public-API doors and pins the paths that are only covered *transitively*.

T06's contract names the bypass paths that must be covered: **`correct(metadata_merge)`, `record_with_rid`, `batch`, `links-after-record`, `replication`**. This PR accounts for all five.

## Closed

| Path | Bypass it allowed |
|---|---|
| `record_batch()` | bulk ingress skipped the gate entirely |
| `correct()` | `metadata_merge` can flip `kind` on an existing record — `record(source=inference, kind=inference)` then `correct(metadata_merge={"kind":"fact"})` laundered an inference into a fact without ever tripping `record()`'s gate |

`record_batch` gates in the **prevalidation loop**, so a bad element late in the batch refuses the *whole* batch before any side effect — the test asserts zero rows written, not merely an `Err`.

`correct_impl` gates the **final merged** metadata paired with the record's **existing `source`** (merged, because the pre-merge view can't see what the caller is actually asserting; original source, because `correct()` can't change source). Raising `confidence_basis` to `confirmation`/`verification` is still the documented escape.

## Pinned (already correct, but only transitively)

**`links-after-record`** — `record_with_links` (links.rs:118) delegates to `record()` with `?`, so a refusal propagates *before* the link loop at :132 and no edge is applied. Correct today, but it holds only as long as the wrapper keeps going through `record()`; if it's ever changed to insert directly, the gate silently stops covering this path and nothing fails. The test asserts the **effect** — a refused `record_with_links` leaves the target with no inbound edge — so it catches a refactor that refuses the record but still applies the links.

## Deliberately NOT gated — the load-bearing part

**`record_with_rid()`** — its **only production caller is replication's apply path** (`distributed/replication.rs:1560`); every other caller is a test. It's where a peer's *already-admitted* write gets applied locally, so re-gating would re-litigate a decision the originating actor already made: under a mode change, this node would reject a write its peer accepted and the replicas would **silently diverge**. That path is already protected in the right place — #69's origin guard (`is_protected_write` + the `apply_ops` preflight), which refuses foreign provenance at *ingress* rather than re-running the matrix at *apply*. This covers T06's `record_with_rid` **and** `replication` entries with one mechanism. Admit-vs-apply stays split: gate at admission, never at replay.

> Correction: an earlier revision cited `materializer.rs:377/460` as the caller and called it "replaying already-admitted queued ops". Those lines are inside `#[cfg(test)]` (starts at :344) — tests, not production. The decision is unchanged and the real justification is cleaner, but the stated fact was wrong, so it's fixed here and in the commit message.

**`record_queued()`** — called only from `record()` (record.rs:110) and `record_text()` (mod.rs:1805), both of which already gate. Transitively covered; gating again would double-count in warn mode and inflate the adoption nudge.

## Verification

Rust lib **1701 passed**; **FULL** Python suite **234 passed** (the whole suite, not a subset — the lesson from #75's 4-platform CI failure); fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)