### PR TITLE
docs(v0.10-item4): commit the Item 4 design + correct its write-path assumptions

### DIFF
--- a/docs/V0.10_ITEM4_DESIGN.md
+++ b/docs/V0.10_ITEM4_DESIGN.md
@@ -187,13 +187,56 @@ idempotency_key IS NOT NULL` as defense-in-depth.
 writer, so this is a forward-compatible no-op today; it means 4b needs no
 migration. `[r2 #1-keys: 4a-schema, 4b-reconciliation]`
 
+**Write-path reality (verified 2026-07-15 — corrects this section's earlier
+assumptions; 4a.6 is materially bigger than they implied):**
+
+- **The sync route has NO transaction at all.** `self.conn()` (mod.rs:1396)
+  returns a `MutexGuard<Connection>` — a mutex, not a transaction. `record()`'s
+  memories INSERT (record.rs:218-243), the session-link updates (:246-255), the
+  `log_op` (:321-342) and the pending-op enqueue (:361-367) are FOUR independent
+  autocommits, and `calibrate_importance` (:101) already wrote before routing.
+  "Insert the claim in one transaction with the authoritative op" therefore has
+  nothing to join on the sync route — the transaction must be INTRODUCED. This
+  is the single largest piece of 4a.6, not a helper.
+- **`log_op` cannot join a caller's transaction.** It re-acquires `self.conn`
+  (stats.rs:143), and `parking_lot::Mutex` is NOT reentrant — calling it while
+  holding a conn guard DEADLOCKS. A `log_op_in_tx(&Connection, …)` is required.
+- **`record_queued` commits at record.rs:1111**, the `INSERT OR IGNORE INTO
+  oplog` inside `log_op_pending_for_reembed_queue` — NOT :1105 (that is the
+  backpressure check). No `_in_tx` variant exists anywhere in the tree. The
+  queued route writes NO memories row (invariants at :995-998), so "claim + write
+  atomically" there means "claim + oplog op atomically".
+- **`record_batch` never consults the write_router** — no guard, no queued path
+  (it reads `search_state` unguarded at :436). Its `SAVEPOINT batch_record`
+  (:469→RELEASE :546) covers the row INSERTs, session links and entities, but
+  the vector appends (:598-630) and its `log_op` (:658-666) sit OUTSIDE it.
+- **PRECEDENT — copy `link_core` (links.rs:247-351), not `record()`.** v0.10
+  Phase 0 already solved exactly this atomicity for edges: mint id + HLC before
+  the txn (:268-270), take `conn.lock()` ONCE (:272), idempotency pre-check that
+  returns the ORIGINAL id with no new op (:275-285), then `SAVEPOINT` (:303) →
+  row INSERT (:305) → oplog INSERT with `op_id == link_id` (:324-338) → `RELEASE`
+  (:343). Its doc comment states the goal verbatim: "a crash can no longer leave
+  a local edge with no replication event."
+- **The vector append can never be inside the DB txn** — `vec_index` is an
+  in-memory DeltaIndex, not SQLite. Best achievable is row + claim + oplog
+  atomic, with the append outside and still compensated by DELETE.
+  ⚠️ OPEN TENSION for 4a.6: today `log_op` runs AFTER the append (:321 vs :278),
+  so an append failure compensates cleanly. If the oplog op commits WITH the row,
+  a later append failure would DELETE a row whose oplog op peers may already have
+  replicated → divergence. Resolve before building: either keep the oplog op
+  after the append (and accept that the claim binds to the row, not the op), or
+  make the compensation replicate a tombstone.
+
 **Claim-after-routing saga** (sol-r2 #4 — the two concurrency holes it named):
 1. Pure validate + gate + compute digest (no side effect).
 2. **Enter the write-router FIRST** (`try_enter_sync_writer` → `sync`, else
    `queued`) so the route is known before the claim (fixes "claim can't bind to
-   the eventual route").
-3. In ONE transaction on that route (`_in_tx` helper — `record_queued` commits
-   internally at record.rs:1105, so it needs the in-tx variant): insert the
+   the eventual route"). Verified sound: the route decision at record.rs:105-106
+   is a pure in-memory mutex/counter and touches no connection, so it genuinely
+   precedes all DB work. Note the guard does NOT serialize writers — N can hold
+   it at once; it only blocks reembed cutover.
+3. In ONE transaction on that route (see "write-path reality" above — this
+   transaction does not exist yet on either route and must be built): insert the
    claim `state='pending'` with `op_id`/`route`/`generation` via
    `INSERT ... ON CONFLICT DO NOTHING` (the INSERT is the serialization point,
    not a prior SELECT), AND write the authoritative durable op (the memories row
@@ -204,20 +247,57 @@ migration. `[r2 #1-keys: 4a-schema, 4b-reconciliation]`
 5. **Recovery** is by COMPLETING or ROLLING BACK the authoritative op named by
    `op_id`/`route`, never by testing memory-row existence (sol-r2 #4: `record`
    commits the row before the vector append, and `queued` has no row, so
-   row-existence is not a commit proof). Startup sweep reconciles `pending`
-   claims against their op.
+   row-existence is not a commit proof — CONFIRMED: row commits at record.rs:243,
+   conn drops at :256, append at :278, oplog at :321). Startup sweep reconciles
+   `pending` claims against their op.
+   - **Commit evidence that already exists**: `oplog.applied = 1`, flipped by
+     `mark_op_applied` (stats.rs:280-296) whose `AND applied = 0` filter is a
+     real durable, race-safe, exactly-once claim primitive — `Ok(true)` means
+     this worker won. But it is NOT atomic with the work it claims (work runs,
+     then the flag flips, in a separate txn). The real replay loop is
+     `apply_pending_ops_once` (stats.rs:316-461), not the materializer's test
+     code.
+   - **There is NO startup sweep to extend — one must be added.** The only
+     boot-time oplog touch is mod.rs:929-933, a `SELECT COUNT(*) … WHERE
+     applied = 0` seeding the `pending_op_count` atomic (and it `unwrap_or(0)`s,
+     swallowing errors). It counts; it fixes nothing. Recovery today is implicit:
+     the materializer's query is stateless, so pending ops get picked up whenever
+     workers next spawn.
 
 **Idempotent-hit ordering** (sol-r2 #7): on `ON CONFLICT`, read the existing
 claim. Same digest → return existing rid BEFORE any calibration, vector, entity,
-session, cache, visible-seq, or oplog effect (incl. `record_with_rid`'s
-`was_new_row=false` path, which today still allocates seq/appends — must become a
-true no-op). Different digest → typed conflict (below).
+session, cache, visible-seq, or oplog effect. Different digest → typed conflict
+(below).
+⚠️ `calibrate_importance` (record.rs:101) runs BEFORE the route decision (:105)
+and mutates `namespace_importance_stats` via its own conn (importance.rs:88), so
+"before any calibration effect" means the claim check must move AHEAD of :101 —
+which is ahead of the router. That contradicts step 2 (route first, so the claim
+can bind to the route). Resolve in 4a.6: either make the pre-check a cheap
+read-only probe before :101 (racy, but only an optimization — the authoritative
+decision stays the `ON CONFLICT` INSERT), or make calibration idempotent/deferred.
+
+`record_with_rid`'s `was_new_row=false` path (record.rs:813) is NOT a no-op
+today and must be made one: it gates session links (:815-828), the compensating
+DELETE (:874), `cache_insert` (:895) and `log_op` (:925) — but `assign_seq`
+(:860), `vec_index.append` (:870-873) and `bump_visible_seq` (:891) all run
+UNCONDITIONALLY, so a replay burns a seq, re-appends to the delta index and
+bumps the watermark. NOTE its only production caller is replication's apply path
+(replication.rs:1560) — every other caller is a test — so this is a replication-
+idempotency fix, not a foreground-write one.
 
 **Wrapper disposition** (sol-r2 #7): `record` returns an internal
 `{ rid, disposition: Inserted | IdempotentHit }`. Wrappers that apply effects
 after `record` returns (`record_with_links`, links.rs:118) MUST short-circuit
 their link effects on `IdempotentHit` (and the wrapper's links join the
 wrapper-level idempotency payload). Public API still returns just the rid.
+Confirmed shape: `record_with_links` (links.rs:102-136) calls `record()` at :118
+— which fully commits row+vector+oplog and returns — then loops `self.link()` at
+:132-134 FAIL-FAST, so link #2 failing already leaves link #1 applied and the
+record committed, returning an Err the caller cannot interpret. Sibling
+`record_with_links_partial` (:150-202) collects per-link `LinkResult` instead.
+This is the T06 "links-after-record" bypass path and the T07 wrapper hazard in
+one: without the short-circuit, a retried `record_with_links` no-ops the record
+but RE-APPLIES the links.
 
 **Conflict error shape (nuron — make escaping cheaper than ignoring):**
 ```rust


### PR DESCRIPTION
This design doc has been driving 4a.1–4a.5 while sitting **untracked** in my working tree. Committing it — and correcting the write-path section against the actual source, because several load-bearing assumptions were wrong in a way that made **4a.6 look smaller than it is**.

## Verified corrections

| Doc claimed | Reality |
|---|---|
| insert the claim "in ONE transaction on that route" | **The sync route has no transaction at all.** `self.conn()` returns a `MutexGuard`, not a transaction. The memories INSERT (record.rs:243), session links, `log_op` (:321-342) and the pending enqueue (:361) are **four independent autocommits**, and `calibrate_importance` (:101) already wrote before routing. There is nothing to join — it must be built. That, not a helper, is the bulk of 4a.6. |
| `_in_tx` helper is a small addition | `log_op` re-acquires `self.conn` (stats.rs:143) and `parking_lot::Mutex` isn't reentrant → calling it under a held guard **deadlocks**. `log_op_in_tx` is a prerequisite. |
| `record_queued` commits at record.rs:**1105** | It commits at **:1111** (`INSERT OR IGNORE INTO oplog` inside `log_op_pending_for_reembed_queue`). :1105 is the backpressure check. No `_in_tx` variant exists anywhere. |
| `record_with_rid` is the materializer replaying queued ops (materializer.rs:377/460) | Those lines are inside `#[cfg(test)]` (starts at :344). Its **only** production caller is replication's apply path (replication.rs:1560). The real replay loop is `apply_pending_ops_once` (stats.rs:316-461). *This also corrects the same misattribution in #76.* |
| — | `record_batch` **never consults the write_router**, and its savepoint (:469-546) excludes both the vector appends and its own `log_op` (:658). |
| "startup sweep reconciles pending claims" | **There is no startup sweep to extend.** mod.rs:929-933 only *counts* pending ops (and `unwrap_or(0)`s the error). One must be added. |

## Two open tensions — recorded, not papered over

Both need a call **before** 4a.6 is built:

1. **The vector append can never join the DB txn** (in-memory `DeltaIndex`, not SQLite). Today `log_op` runs *after* the append, so an append failure compensates cleanly by DELETEing the row. If the oplog op commits *with* the row, a later append failure would delete a row whose op **peers may already have replicated** → divergence. Either keep the op after the append, or replicate a tombstone.
2. **`calibrate_importance` runs before the route decision** and mutates `namespace_importance_stats`, so "return the existing rid before any calibration effect" (sol-r2 #7) requires the claim check to *precede* routing — which contradicts "route first so the claim binds to the route" (sol-r2 #4). Likely resolution: a cheap read-only probe up front (racy — an optimization only), with the `ON CONFLICT` INSERT staying authoritative.

## The precedent 4a.6 should copy

`link_core` (links.rs:247-351) already does exactly this atomicity for edges: mint id+HLC before the txn → one `conn.lock()` → idempotency pre-check returning the original id with no new op → `SAVEPOINT` → row INSERT → oplog INSERT with `op_id == link_id` → `RELEASE`. Its own comment states the goal: *"a crash can no longer leave a local edge with no replication event."* **Model the claim on `link_core`, not on `record()`.**

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)