### PR TITLE
fix(replication): record_batch writes never replicated to peers

### DIFF
--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -462,6 +462,11 @@ impl YantrikDB {
                 .collect();
 
         let mut rids = Vec::with_capacity(inputs.len());
+        // One canonical "record" op per item, emitted after the savepoint
+        // releases. See `log_record_ops_batch`: the old single "record_batch" op
+        // was silently dropped by every peer, so batch writes never replicated.
+        let mut record_op_entries: Vec<(String, serde_json::Value, Vec<u8>)> =
+            Vec::with_capacity(inputs.len());
 
         // Lock conn once for the entire batch SQL work
         {
@@ -499,6 +504,32 @@ impl YantrikDB {
                     conn.execute_batch("ROLLBACK TO batch_record")?;
                     return Err(e.into());
                 }
+
+                // Byte-for-byte the payload `record()` emits (record.rs:325-340)
+                // so peers materialize batch items through the existing, tested
+                // "record" arm. Plaintext text/metadata, matching record() — the
+                // encrypted forms above are the at-rest representation, not the
+                // replication one.
+                record_op_entries.push((
+                    rid.clone(),
+                    serde_json::json!({
+                        "rid": rid,
+                        "type": input.memory_type,
+                        "text": sanitized_texts[idx].as_ref(),
+                        "importance": calibrated_importances[idx],
+                        "valence": input.valence,
+                        "half_life": input.half_life,
+                        "metadata": input.metadata,
+                        "created_at": ts,
+                        "updated_at": ts,
+                        "namespace": input.namespace,
+                        "certainty": input.certainty,
+                        "domain": input.domain,
+                        "source": input.source,
+                        "emotional_state": input.emotional_state,
+                    }),
+                    embedding_hash(&input.embedding),
+                ));
 
                 rids.push(rid);
             }
@@ -654,16 +685,15 @@ impl YantrikDB {
             }
         }
 
-        // Log a single batch op (log_op locks conn internally)
-        self.log_op(
-            "record_batch",
-            None,
-            &serde_json::json!({
-                "count": rids.len(),
-                "rids": rids,
-            }),
-            None,
-        )?;
+        // One canonical "record" op per item, under a single conn lock.
+        //
+        // This REPLACES a single `log_op("record_batch", {count, rids})`. That op
+        // was unreplicable twice over: replication has no "record_batch" arm, so
+        // peers hit the `_ =>` forward-compat catch-all and silently dropped it;
+        // and the payload carried no text/embedding/scalars, so it could not have
+        // rebuilt the memories even with an arm. Batch-written memories simply
+        // never reached peers. Nothing consumes the old op type locally.
+        self.log_record_ops_batch(&record_op_entries)?;
 
         Ok(rids)
     }

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -160,6 +160,75 @@ impl YantrikDB {
         )?;
         Ok(op_id)
     }
+    /// Batched sibling of [`Self::log_op`] that writes one canonical `"record"`
+    /// op per entry under a SINGLE connection lock.
+    ///
+    /// `record_batch` used to log one opaque `"record_batch"` op carrying only
+    /// `{count, rids}`. Replication has no arm for that op type, so peers hit the
+    /// `_ =>` catch-all and silently dropped it — and the payload could not have
+    /// reconstructed the memories anyway. Batch-written memories therefore never
+    /// replicated. Emitting the same canonical `"record"` op that `record()`
+    /// emits makes them replicate through the existing, tested materializer
+    /// rather than needing a new one.
+    ///
+    /// op_ids and HLCs are minted BEFORE the conn lock is taken: `log_op` ticks
+    /// the HLC and *then* locks the connection, so nothing in the codebase ever
+    /// holds `self.hlc` while acquiring `self.conn`. Pre-minting keeps it that
+    /// way and lets the whole batch share one lock instead of taking N.
+    /// HLCs are ticked in batch order, so the ops carry increasing timestamps
+    /// and replicate in their natural causal order.
+    pub(crate) fn log_record_ops_batch(
+        &self,
+        entries: &[(String, serde_json::Value, Vec<u8>)],
+    ) -> Result<Vec<String>> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+        let applied_generation: i64 = self.search_state.load().generation as i64;
+
+        // Pre-mint everything that needs a non-conn lock or can fail, so the
+        // critical section below is pure SQL.
+        let mut prepared: Vec<(String, Vec<u8>, String, &[u8], &str)> =
+            Vec::with_capacity(entries.len());
+        for (rid, payload, emb_hash) in entries {
+            let op_id = crate::id::new_id();
+            let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
+            let payload_str = serde_json::to_string(payload)?;
+            prepared.push((
+                op_id,
+                hlc_bytes,
+                payload_str,
+                emb_hash.as_slice(),
+                rid.as_str(),
+            ));
+        }
+
+        let ts = now();
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "INSERT INTO oplog (op_id, op_type, timestamp, target_rid, payload, \
+             actor_id, hlc, embedding_hash, origin_actor, applied, applied_generation) \
+             VALUES (?1, 'record', ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?9)",
+        )?;
+        for (op_id, hlc_bytes, payload_str, emb_hash, rid) in &prepared {
+            stmt.execute(params![
+                op_id,
+                ts,
+                rid,
+                payload_str,
+                self.actor_id,
+                hlc_bytes,
+                emb_hash,
+                self.actor_id,
+                applied_generation,
+            ])?;
+        }
+        drop(stmt);
+        drop(conn);
+
+        Ok(prepared.into_iter().map(|(op_id, ..)| op_id).collect())
+    }
+
     /// **Decoupled write path RFC, Phase 1.**
     ///
     /// Append a *pending* operation to the oplog (applied=0) carrying the

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -14909,6 +14909,68 @@ fn correction_clears_reembed_staging_columns() {
 
 #[cfg(feature = "bundled-embedder")]
 #[test]
+fn record_batch_replicates_to_a_peer() {
+    // REGRESSION: record_batch logged ONE opaque op — log_op("record_batch",
+    // {count, rids}) — and replication has no "record_batch" arm, so peers hit
+    // the `_ =>` forward-compat catch-all and silently dropped it. The payload
+    // carried no text/embedding/scalars, so it could not have rebuilt the rows
+    // even with an arm. Every memory written via the public record_batch() API
+    // therefore never reached any peer, with no error anywhere.
+    use crate::replication::{apply_ops, extract_ops_since};
+    let leader = YantrikDB::new(":memory:", 8).unwrap();
+    let follower = YantrikDB::new(":memory:", 8).unwrap();
+
+    let mk = |text: &str, seed: f32| RecordInput {
+        text: text.to_string(),
+        memory_type: "semantic".to_string(),
+        importance: 0.6,
+        valence: 0.25,
+        half_life: 604800.0,
+        metadata: serde_json::json!({"tag": text}),
+        embedding: vec_seed(seed, 8),
+        namespace: "default".to_string(),
+        certainty: 0.7,
+        domain: "general".to_string(),
+        source: "user".to_string(),
+        emotional_state: None,
+    };
+    let inputs = vec![mk("first batch item", 1.0), mk("second batch item", 2.0)];
+    let rids = leader.record_batch(&inputs).unwrap();
+    assert_eq!(rids.len(), 2);
+
+    let ops = extract_ops_since(&leader.conn(), None, None, None, 100).unwrap();
+    // One canonical "record" op per item — not one opaque batch op.
+    let record_ops: Vec<_> = ops.iter().filter(|o| o.op_type == "record").collect();
+    assert_eq!(
+        record_ops.len(),
+        2,
+        "expected one canonical record op per batch item, got {:?}",
+        ops.iter().map(|o| &o.op_type).collect::<Vec<_>>()
+    );
+    assert!(
+        !ops.iter().any(|o| o.op_type == "record_batch"),
+        "the unreplicable record_batch op must be gone"
+    );
+
+    apply_ops(&follower, &ops).unwrap();
+
+    // The follower actually has the memories, with content intact.
+    for (rid, input) in rids.iter().zip(inputs.iter()) {
+        let got = follower
+            .get(rid)
+            .unwrap()
+            .unwrap_or_else(|| panic!("batch item {rid} did not replicate"));
+        assert_eq!(got.text, input.text);
+        assert_eq!(got.source, "user");
+        assert_eq!(got.namespace, "default");
+        assert_eq!(got.certainty, input.certainty);
+        assert_eq!(got.valence, input.valence);
+        assert_eq!(got.metadata["tag"], input.text.as_str());
+    }
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
 fn follower_replay_applies_corrected_embedding() {
     // sol finding 6: a re-embedding correction replicates its EXACT bytes,
     // so a same-DEK follower's stored vector + recall track the new meaning


### PR DESCRIPTION
**Every memory written through the public `record_batch()` API was silently absent from every peer.** No error, no warning, no failed op — the writes simply never arrived.

## The bug

`record_batch` logged one opaque op for the whole batch:

```rust
log_op("record_batch", None, {"count": N, "rids": [...]}, None)
```

That op is unreplicable twice over:

1. **Replication has no `"record_batch"` arm.** It falls through to the `_ =>` forward-compatibility catch-all (replication.rs:520) that silently skips unknown op types — the exact mechanism meant to tolerate ops from *future* versions swallowed an op from the current one.
2. **Even with an arm, the payload couldn't rebuild anything**: `count` and `rids`, no text, no embedding, no metadata, no scalars.

And it wasn't filtered out of export — `extract_ops_since` only excludes `materialize_%` ops (replication.rs:78) — so peers dutifully received the op and dropped it on the floor.

Single `record()` writes were unaffected: replication has a real `"record"` arm (replication.rs:293). The batch path was the only hole.

## The fix

Emit **one canonical `"record"` op per batch item**, byte-for-byte the payload `record()` already emits (record.rs:325-340), so batch items materialize through the existing, tested arm rather than needing a new one. Nothing consumes the `"record_batch"` op type locally, so it's replaced, not supplemented.

New `log_record_ops_batch` writes all N ops under a **single conn lock** — calling `log_op` per item would take N locks and regress bulk-ingest throughput. op_ids and HLCs are minted *before* the lock: `log_op` ticks the HLC and *then* locks the connection, so nothing in the tree holds `self.hlc` while acquiring `self.conn`, and pre-minting keeps that ordering intact. HLCs tick in batch order, so ops replicate in their natural causal order.

## Scope

This restores replication. It deliberately does **not** make the ops atomic with the batch's `SAVEPOINT` — they're emitted after `RELEASE`, exactly where the old op was. `record_batch`'s oplog write has never been in its savepoint (`RELEASE` :546 vs `log_op` :658); fixing that is **Item 4a.6a**, which introduces the transactional write foundation for both routes.

## Verification

The regression test replicates a 2-item batch to a peer and asserts the follower **actually has both memories** with text/source/namespace/certainty/valence/metadata intact — not merely that an op exists.

Confirmed it fails on the unfixed code:
```
assertion `left == right` failed: expected one canonical record op per batch item, got ["record_batch"]
  left: 0
 right: 2
```
and passes with the fix.

Rust lib **1699 passed**; **FULL** Python suite **234 passed**; fmt clean.

Found by sol while reviewing the 4a.6 design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)