### PR TITLE
fix(materializer): replaying a record op inflated entities.mention_count

### DIFF
--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -342,10 +342,22 @@ impl YantrikDB {
     /// **Returns** `Ok(true)` iff this caller transitioned the row from
     /// `applied=0` to `applied=1`. `Ok(false)` means another worker
     /// already applied it (race on shared oplog, normal under N workers).
-    /// The race-safety filter `WHERE applied = 0` is what makes
-    /// `apply_pending_ops_once` exactly-once across N concurrent workers
-    /// — the work is idempotent so double-execution is safe; this filter
-    /// just decides which worker gets to claim the apply count.
+    ///
+    /// **This is a completion ACKNOWLEDGEMENT, not a pre-work claim.** The
+    /// distinction is load-bearing and was previously documented backwards
+    /// ("the work is idempotent so double-execution is safe; this filter just
+    /// decides which worker gets to claim the apply count"). Callers do the work
+    /// FIRST and only then race on `WHERE applied = 0`, so the filter does not
+    /// prevent duplicate execution — N workers draining the same pending op all
+    /// perform the work, and it merely picks which one gets to record it.
+    /// Retries after an error re-execute it too.
+    ///
+    /// So `apply_pending_ops_once` is exactly-once in its BOOKKEEPING and
+    /// at-least-once in its EFFECTS. Every op handler must therefore be
+    /// genuinely idempotent on its own; that is a real obligation, not a
+    /// property this function confers. It was violated by the mention-count
+    /// bump in `apply_materialize_record_post` (see the note there).
+    /// Making this a true pre-work lease is v0.10 Item 4a.6.
     pub fn mark_op_applied(&self, op_id: &str) -> Result<bool> {
         use std::sync::atomic::Ordering;
         let conn = self.conn.lock();
@@ -767,21 +779,53 @@ impl YantrikDB {
         let text_tokens = crate::graph::tokenize(text);
         let heuristic_entities = crate::graph::extract_heuristic_entities(text);
 
-        // Loop A: seed heuristic entities (idempotent INSERT ... ON CONFLICT).
+        // Loop A: seed heuristic entities.
+        //
+        // The mention bump is gated on `memory_entities` so replaying this op is
+        // a no-op for the counter. It previously ran unconditionally under a
+        // comment calling the statement "idempotent" — the INSERT does not FAIL
+        // on conflict, but `mention_count = mention_count + 1` is not idempotent
+        // at all, and this op is genuinely executed more than once:
+        //
+        //   - `mark_op_applied` is a completion ACKNOWLEDGEMENT, not a pre-work
+        //     claim. Workers do the work and only THEN race on
+        //     `UPDATE ... WHERE applied = 0`, so N workers draining the same
+        //     pending op all run this loop; the filter merely picks who counts it.
+        //   - on error the op stays pending and is retried, re-running the loop.
+        //
+        // Each duplicate inflated every heuristic entity's mention_count, which
+        // feeds the IDF term in `patterns.rs` (`total_entities / (1 + mention_count)`),
+        // so the drift silently skewed salience scoring.
+        //
+        // `memory_entities` is PK'd on (memory_rid, entity_name) and carries no
+        // FK, so `INSERT OR IGNORE` + `changes()` is an exact, durable answer to
+        // "is this the first time this memory's mention of this entity has been
+        // recorded?" — which is precisely what the counter is supposed to count.
+        // It is per-entity, so a run that died midway through the loop still
+        // replays correctly: entities already counted are skipped, the rest are
+        // counted once.
         if !heuristic_entities.is_empty() {
             let conn = self.conn();
             for entity in &heuristic_entities {
                 let entity_type = crate::graph::classify_entity_type(entity);
+                // Claim the mention first; Loop B's INSERT OR IGNORE below is a
+                // no-op for anything already claimed here.
+                let first_mention = conn.execute(
+                    "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) \
+                     VALUES (?1, ?2)",
+                    params![rid, entity],
+                )? > 0;
+                let inc: i64 = if first_mention { 1 } else { 0 };
                 conn.execute(
                     "INSERT INTO entities (name, entity_type, first_seen, last_seen, mention_count) \
-                     VALUES (?1, ?2, ?3, ?3, 1) \
+                     VALUES (?1, ?2, ?3, ?3, ?4) \
                      ON CONFLICT(name) DO UPDATE SET \
                         last_seen = ?3, \
-                        mention_count = mention_count + 1, \
+                        mention_count = mention_count + ?4, \
                         entity_type = CASE \
                             WHEN entity_type = 'unknown' AND ?2 != 'unknown' THEN ?2 \
                             ELSE entity_type END",
-                    params![entity, entity_type, ts_secs],
+                    params![entity, entity_type, ts_secs, inc],
                 )?;
             }
         }

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -14909,6 +14909,82 @@ fn correction_clears_reembed_staging_columns() {
 
 #[cfg(feature = "bundled-embedder")]
 #[test]
+fn replaying_materialize_record_post_does_not_inflate_mention_count() {
+    // REGRESSION: apply_materialize_record_post bumped entities.mention_count
+    // unconditionally, under a comment calling the statement "idempotent". The
+    // INSERT does not FAIL on conflict, but `mention_count = mention_count + 1`
+    // is not idempotent — and this op really is executed more than once:
+    // mark_op_applied is a completion ACK, not a pre-work claim, so N workers
+    // draining the same op all do the work and only then race on
+    // `WHERE applied = 0`; and an op that errors stays pending and is retried.
+    // Each duplicate inflated the count, which feeds the IDF term in patterns.rs
+    // and silently skewed salience.
+    //
+    // Resetting applied=0 and draining again is exactly the retry/duplicate-worker
+    // shape, and is the only way to reach the private handler from here.
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    db.record_text(
+        "Alice and Bob shipped the Acme project",
+        "semantic",
+        0.5,
+        0.0,
+        604800.0,
+        &empty_meta(),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap();
+
+    db.apply_pending_ops_once(100).unwrap();
+    let counts_after_first: Vec<(String, i64)> = {
+        let conn = db.conn();
+        let mut stmt = conn
+            .prepare("SELECT name, mention_count FROM entities ORDER BY name")
+            .unwrap();
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        rows
+    };
+    assert!(
+        !counts_after_first.is_empty(),
+        "test needs at least one extracted entity to be meaningful"
+    );
+
+    // Simulate the duplicate execution: put the op back to pending and drain again.
+    db.conn()
+        .execute(
+            "UPDATE oplog SET applied = 0 WHERE op_type = ?1",
+            rusqlite::params![crate::engine::op_types::OP_MATERIALIZE_RECORD_POST],
+        )
+        .unwrap();
+    db.apply_pending_ops_once(100).unwrap();
+
+    let counts_after_replay: Vec<(String, i64)> = {
+        let conn = db.conn();
+        let mut stmt = conn
+            .prepare("SELECT name, mention_count FROM entities ORDER BY name")
+            .unwrap();
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        rows
+    };
+    assert_eq!(
+        counts_after_first, counts_after_replay,
+        "replaying materialize_record_post must not re-count mentions"
+    );
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
 fn record_batch_replicates_to_a_peer() {
     // REGRESSION: record_batch logged ONE opaque op — log_op("record_batch",
     // {count, rids}) — and replication has no "record_batch" arm, so peers hit


### PR DESCRIPTION
`apply_materialize_record_post` bumped `entities.mention_count` **unconditionally**, under a comment describing the statement as *"idempotent"*. The INSERT doesn't *fail* on conflict — but `mention_count = mention_count + 1` isn't idempotent at all, and this op is genuinely executed more than once:

- **`mark_op_applied` is a completion acknowledgement, not a pre-work claim.** Workers do the work and only *then* race on `UPDATE ... WHERE applied = 0`. So N workers draining the same pending op all run the loop; the filter merely decides which one gets to record it.
- An op that errors is left pending and **retried**, re-running the loop.

Each duplicate re-counted every heuristic entity. `mention_count` feeds the IDF term in patterns.rs (`total_entities / (1 + mention_count)`), so the drift **silently skewed salience scoring** — nothing errors, the numbers are just wrong.

## Fix

Gate the bump on `memory_entities`, which is PK'd on `(memory_rid, entity_name)` and carries no FK — so `INSERT OR IGNORE` + `changes()` is an exact, durable answer to *"is this the first time this memory's mention of this entity has been recorded?"* Which is precisely what the counter is supposed to count.

The gate is **per-entity**, so a run that died midway through the loop still replays correctly: entities already counted are skipped, the rest counted once. Loop B's `INSERT OR IGNORE` is now a no-op for anything Loop A already claimed.

## Also: the doc comment that caused this

`mark_op_applied` documented the invariant **backwards** — *"the work is idempotent so double-execution is safe; this filter just decides which worker gets to claim the apply count."* That reads as a guarantee the function provides; it isn't one. Corrected to state the real contract:

> `apply_pending_ops_once` is exactly-once in its **bookkeeping** and at-least-once in its **effects**. Every op handler must be genuinely idempotent on its own — that's an obligation on handlers, not a property this function confers.

Making it a true pre-work lease is Item 4a.6.

## Verification

The regression test fails on the unfixed code — one record mentioning Alice/Bob/Acme **once each**, replayed once:

```
assertion `left == right` failed: replaying materialize_record_post must not re-count mentions
  left:  [("Acme", 1), ("Alice", 1), ("Bob", 1)]
 right:  [("Acme", 2), ("Alice", 2), ("Bob", 2)]
```

and passes with the fix. Resetting `applied=0` and draining again is exactly the retry/duplicate-worker shape (and the only way to reach the private handler from the test module).

Rust lib **1701 passed**; **FULL** Python suite **234 passed**; fmt clean.

Found by sol while reviewing the 4a.6 design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)