### PR TITLE
fix(record_batch): bypassed the write-router and could write a doomed generation

### DIFF
--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -195,6 +195,26 @@ pub enum YantrikDbError {
     )]
     CorrectionDeferredDuringReembed { rid: String },
 
+    /// **v0.10 Item 4a.** `record_batch` could not acquire a `SyncWriteGuard`
+    /// because a `db.reembed()` cutover is in flight (the write-router is in
+    /// Queueing state), so its `SearchState` snapshot could be swapped out from
+    /// under the batch mid-write. Retryable: the batch touched NO durable state
+    /// and can be reissued verbatim once the reembed completes.
+    ///
+    /// `record()` handles this by falling back to its queued path; there is no
+    /// queued-batch primitive yet (v0.10 Item 4a.6c), and routing items
+    /// independently would break the batch's all-or-nothing contract. Failing
+    /// the whole batch with a typed retryable error is the honest option in the
+    /// meantime — the alternative is what this replaced: silently committing
+    /// rows stamped with a generation that is being discarded.
+    #[error(
+        "record_batch({count} inputs) deferred: a db.reembed() cutover is in progress, \
+         so the batch cannot be committed against a stable generation. No durable state \
+         was changed — retry the batch verbatim once the reembed completes. (Single \
+         record() writes are not blocked; they route through the queued path.)"
+    )]
+    BatchDeferredDuringReembed { count: usize },
+
     /// **v0.10 Item 3 (correction seqlock, sol r5).** A recall could not
     /// obtain a coherent snapshot within its retry budget because
     /// text-changing corrections kept interleaving with its candidate

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -430,9 +430,36 @@ impl YantrikDB {
             .map(|i| self.calibrate_importance(&i.namespace, i.importance))
             .collect::<Result<Vec<_>>>()?;
 
+        // **Issue #41 layer 3.** Enter the write-router BEFORE snapshotting
+        // SearchState, exactly as `record()` does (record.rs:105/138).
+        //
+        // record_batch used to skip the router entirely and load the snapshot
+        // below unguarded. Nothing then stopped a `db.reembed()` cutover from
+        // completing its swap mid-batch, so the batch could commit rows and
+        // appends stamped with `embedding_generation` from a generation that was
+        // being discarded — the exact corruption the guard exists to prevent.
+        // The comment below claimed "every append lands on the same
+        // generation-anchored DeltaIndex" while nothing enforced it.
+        //
+        // Unlike `record()`, there is no queued fallback: no queued-batch
+        // primitive exists yet (v0.10 Item 4a.6c), and routing items
+        // independently would break the batch's all-or-nothing contract. So the
+        // whole batch defers with a typed retryable error, following the Item 3
+        // precedent (`CorrectionDeferredDuringReembed`) — nothing durable has
+        // happened at this point, so the caller can reissue verbatim.
+        let Some(_sync_guard) = self.write_router.try_enter_sync_writer() else {
+            return Err(crate::error::YantrikDbError::BatchDeferredDuringReembed {
+                count: inputs.len(),
+            });
+        };
+
         // **Issue #41 brainstorm-4 §1.** SearchState snapshot for the
         // batch — every append in this batch lands on the same
-        // generation-anchored DeltaIndex.
+        // generation-anchored DeltaIndex. Loaded AFTER the guard above, which is
+        // what actually makes that true: with the guard held, reembed cannot
+        // complete its swap for the rest of this call. `_sync_guard` drops via
+        // RAII at function exit (panic-safe), covering the SQL work AND the
+        // vector appends.
         let state = self.search_state.load_full();
 
         // Clone active sessions map before acquiring conn

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -14909,6 +14909,55 @@ fn correction_clears_reembed_staging_columns() {
 
 #[cfg(feature = "bundled-embedder")]
 #[test]
+fn record_batch_defers_during_reembed_instead_of_writing_a_doomed_generation() {
+    // REGRESSION: record_batch never consulted the write_router. It loaded its
+    // SearchState snapshot unguarded, so a reembed cutover could complete its
+    // swap mid-batch and the batch would commit rows + appends stamped with an
+    // `embedding_generation` that was being discarded. record() has always
+    // guarded this (record.rs:105 before :138); batch silently did not, while
+    // its own comment claimed every append lands on one anchored generation.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let inputs = vec![RecordInput {
+        text: "written during a cutover".to_string(),
+        memory_type: "semantic".to_string(),
+        importance: 0.5,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: empty_meta(),
+        embedding: vec_seed(1.0, 8),
+        namespace: "default".to_string(),
+        certainty: 0.8,
+        domain: "general".to_string(),
+        source: "user".to_string(),
+        emotional_state: None,
+    }];
+
+    // Simulate a reembed cutover in flight.
+    db.write_router.switch_to_queueing();
+
+    let err = db.record_batch(&inputs).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::BatchDeferredDuringReembed { count: 1 }
+        ),
+        "batch must defer rather than write against a doomed generation, got {err:?}"
+    );
+    // Retryable means exactly that: NO durable state was touched.
+    let count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0, "a deferred batch must write nothing");
+
+    // Once the cutover finishes the same batch succeeds verbatim.
+    db.write_router.switch_to_normal();
+    let rids = db.record_batch(&inputs).unwrap();
+    assert_eq!(rids.len(), 1);
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
 fn record_batch_replicates_to_a_peer() {
     // REGRESSION: record_batch logged ONE opaque op — log_op("record_batch",
     // {count, rids}) — and replication has no "record_batch" arm, so peers hit


### PR DESCRIPTION
`record_batch` **never consulted the write_router**. It loaded its `SearchState` snapshot unguarded (record.rs:436), so nothing stopped a `db.reembed()` cutover from completing its swap mid-batch — the batch could commit rows and vector appends stamped with an `embedding_generation` from a generation that was *being discarded*.

That's precisely the corruption Issue #41 layer 3 introduced the guard to prevent. `record()` has always respected it:

```rust
let sync_guard = self.write_router.try_enter_sync_writer();  // :105
...
let state = self.search_state.load_full();                   // :138
```

> "Load SearchState AFTER the guard is acquired. With the guard held, reembed cannot complete its swap, so the loaded state is the published active generation for the entire critical section."

Batch did the second half without the first — while its own comment claimed *"every append in this batch lands on the same generation-anchored DeltaIndex."* Nothing enforced it.

## Fix

Enter the router before snapshotting, exactly as `record()` does. The guard drops via RAII at function exit, covering the SQL work **and** the vector appends.

Unlike `record()`, there's no queued fallback: no queued-batch primitive exists yet (Item 4a.6c), and routing items independently would break the batch's all-or-nothing contract. So the whole batch defers with a typed retryable error, following the Item 3 precedent (`CorrectionDeferredDuringReembed`) — nothing durable has happened at the guard check, so the caller can reissue verbatim.

## This is a new failure mode, deliberately

Bulk ingest issued *during a reembed* now returns `BatchDeferredDuringReembed` where it previously "succeeded". That's the correct trade: the previous success **silently committed rows against a doomed generation**. The window is a reembed cutover, and the error names the retry explicitly:

> `record_batch(N inputs) deferred: a db.reembed() cutover is in progress, so the batch cannot be committed against a stable generation. No durable state was changed — retry the batch verbatim once the reembed completes. (Single record() writes are not blocked; they route through the queued path.)`

## Verification

The test asserts the deferral is genuinely retryable — **zero rows written**, not merely an `Err` — and that the identical batch succeeds verbatim once the cutover finishes.

Rust lib **1700 passed**; **FULL** Python suite **234 passed**; fmt clean.

Found by sol while reviewing the 4a.6 design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)