### PR TITLE
feat(v0.10-item4a.6a): make record() durably atomic (reserve → commit → publish)

### DIFF
--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -1125,6 +1125,12 @@ impl YantrikDB {
         Ok(())
     }
 
+    /// Thin wrapper over the generalized [`YantrikDB::log_op_in_tx`] (Item 4a.6a).
+    ///
+    /// This function WAS the only in-transaction oplog writer in the tree; 4a.6a
+    /// generalized its body so `record()` could adopt the same protocol. Kept as
+    /// a named wrapper because `correct()`'s call site reads better for it, and
+    /// because it pins `op_type` to `'correct'` at one place.
     fn insert_correct_op_in_tx(
         &self,
         tx: &rusqlite::Transaction<'_>,
@@ -1134,26 +1140,14 @@ impl YantrikDB {
         embedding: Option<&[u8]>,
         applied_generation: i64,
     ) -> Result<()> {
-        let op_id = crate::id::new_id();
-        let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
-        let payload_str = serde_json::to_string(payload)?;
-        tx.execute(
-            "INSERT INTO oplog \
-             (op_id, op_type, timestamp, target_rid, payload, actor_id, hlc, \
-              embedding_hash, origin_actor, applied, applied_generation, embedding) \
-             VALUES (?1, 'correct', ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?9, ?10)",
-            params![
-                op_id,
-                now(),
-                rid,
-                payload_str,
-                self.actor_id,
-                hlc_bytes,
-                emb_hash,
-                self.actor_id,
-                applied_generation,
-                embedding,
-            ],
+        self.log_op_in_tx(
+            tx,
+            "correct",
+            Some(rid),
+            payload,
+            emb_hash,
+            embedding,
+            applied_generation,
         )?;
         Ok(())
     }

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -926,11 +926,19 @@ impl YantrikDB {
         // The partial idx_oplog_pending makes this single boot read O(N_pending)
         // — a fixed cost we pay once, in exchange for never paying it again
         // on the foreground hot path.
-        let initial_pending: i64 = conn
-            .query_row("SELECT COUNT(*) FROM oplog WHERE applied = 0", [], |row| {
+        //
+        // **Fail-CLOSED (v0.10 Item 4a.6a, sol review).** This used to
+        // `.unwrap_or(0)`, which is the wrong direction for a queue ceiling: a
+        // failed count would seed the counter at zero, so the engine would believe
+        // the ingest queue was empty no matter how many pending ops were really in
+        // SQL, and `MAX_PENDING_OPS` would never fire — unbounded ingest, silently.
+        // A boot read that cannot be trusted must fail the open, not invent a
+        // permissive answer. (Same class as the fail-open defaults in 4a.1 and
+        // 4a.4.)
+        let initial_pending: i64 =
+            conn.query_row("SELECT COUNT(*) FROM oplog WHERE applied = 0", [], |row| {
                 row.get(0)
-            })
-            .unwrap_or(0);
+            })?;
 
         // Build the DeltaIndex once, wrap in Arc, and move it into the
         // initial `SearchState`. After issue #41 brainstorm-4 §1, the

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -212,10 +212,91 @@ impl YantrikDB {
         // search_state cannot advance under us until the guard drops.
         let embedding_generation: i64 = state.generation as i64;
 
-        // Acquire conn, do all SQL, then drop before other locks
-        {
-            let conn = self.conn();
-            conn.execute(
+        // **v0.10 Item 4a.6a — durable sync acceptance.**
+        //
+        // This path used to be four independent autocommit windows: the memories
+        // row, the session updates, `log_op("record")`, and the
+        // `log_op_pending(materialize_record_post)` enqueue, with a plain
+        // `vec_index.append` in the middle. A crash or an error between them left
+        // a committed row with NO oplog provenance — the leak the old comment
+        // here recorded as "23k rows over 39 days on trader's `default` DB" — and
+        // the fix was a best-effort compensating DELETE (plus a second patch to
+        // reverse the session `memory_count` the DELETE left behind).
+        //
+        // It now follows the reserve → commit → publish protocol `correct()` has
+        // used since Item 3 (lifecycle.rs): reserve vector capacity BEFORE any
+        // durable mutation, commit every durable effect in ONE transaction, then
+        // publish (infallible). Backpressure and dim errors now surface having
+        // touched nothing, so the orphan-on-Backpressure class is structurally
+        // impossible rather than compensated — the DELETE and the memory_count
+        // reversal are both deleted below, not relocated.
+        //
+        // Lock order is CONCURRENCY.md Rule 1 (`conn → … → vec_index`): conn is
+        // held across the reservation, the transaction, and the publish. That is
+        // load-bearing, exactly as in `correct()` — the conn lock is the only
+        // thing serializing append order with commit order (the SyncWriteGuard is
+        // a counter, not a mutex). It does not offend Rule 4, whose concern is
+        // holding conn across non-O(1) work; a delta reserve/publish is an O(1)
+        // Vec push / flag flip.
+
+        // Admission check BEFORE any side effect. `log_op_pending_in_tx` cannot
+        // do this itself — inside the tx it would fire after the row exists.
+        self.check_pending_backpressure()?;
+
+        let emb_hash = embedding_hash(embedding);
+        let record_payload = serde_json::json!({
+            "rid": rid,
+            "type": memory_type,
+            "text": text,
+            "importance": importance,
+            "valence": valence,
+            "half_life": half_life,
+            "metadata": metadata,
+            "created_at": ts,
+            "updated_at": ts,
+            "namespace": namespace,
+            "certainty": certainty,
+            "domain": domain,
+            "source": source,
+            "emotional_state": emotional_state,
+        });
+        // **Phase 4.3 Commit B (saga task 3, 2026-05-08).** The unbounded entity
+        // / memory_entities / claims loops that used to run inline are enqueued
+        // for the materializer thread instead. See docs/phase_4_3_design.md.
+        // 4a.6a moves this enqueue INSIDE the transaction: it was previously its
+        // own failure boundary, so a crash after the row committed but before the
+        // enqueue landed meant that record's entity materialization was skipped
+        // FOREVER, with nothing left to indicate it was owed.
+        let post_payload = serde_json::json!({
+            "rid": rid,
+            "text": stored_text,
+            "namespace": namespace,
+            "ts_secs": ts,
+            "domain": domain,
+            "source": source,
+        });
+
+        let conn = self.conn();
+
+        // Mint the seq UNDER the conn lock. Search resolves a rid to its HIGHEST
+        // seq, not the most recently appended one, so minting outside the
+        // serialized region would let a stalled writer holding seq N append after
+        // a writer with seq N+1 committed — serving one writer's vector with
+        // another's text. Same reasoning as lifecycle.rs's correction path.
+        let seq = self.assign_seq(None);
+
+        // RESERVE: consumes delta capacity and validates dim, but stays invisible
+        // to search until published. This is where Backpressure surfaces — before
+        // a single durable byte has been written.
+        state
+            .vec_index
+            .append_reserved(rid.clone(), embedding.to_vec(), seq)?;
+
+        // ONE transaction: row + session links + the record op + the
+        // post-materialization enqueue. Either all of it is durable or none is.
+        let committed = (|| -> Result<bool> {
+            let tx = conn.unchecked_transaction()?;
+            tx.execute(
                 "INSERT INTO memories \
                  (rid, type, text, embedding, created_at, updated_at, importance, \
                   half_life, last_access, valence, metadata, namespace, \
@@ -242,59 +323,83 @@ impl YantrikDB {
                 ],
             )?;
 
-            // Auto-link to active session for this namespace
+            // Auto-link to active session for this namespace.
             if let Some(session_id) = &session_id {
-                conn.execute(
+                tx.execute(
                     "UPDATE memories SET session_id = ?1 WHERE rid = ?2",
                     params![session_id, rid],
                 )?;
-                conn.execute(
+                tx.execute(
                     "UPDATE sessions SET memory_count = memory_count + 1 WHERE session_id = ?1",
                     params![session_id],
                 )?;
             }
-        }
-        // conn dropped here
 
-        // Insert into vector index (lock ordering: conn already dropped)
-        let seq = self
-            .vec_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
-        // **Issue surfaced in CT 132 bench post-v0.7.18 (2026-05-20):
-        // orphan-on-Backpressure pattern.** If the vec_index.append
-        // returns Err (Backpressure when delta is full, dim mismatch,
-        // etc.), the memories row inserted above is already committed
-        // but the rest of the critical section (vec_index, oplog,
-        // visible_seq, materializer enqueue) is skipped. The caller
-        // sees an Err and assumes the write failed — but the row
-        // exists in SQL with no oplog provenance. Over 39 days on
-        // trader's `default` DB, this leaked 23k rows.
-        //
-        // The compensating DELETE here runs only on the rare failure
-        // path. On Backpressure (the common error), the DELETE
-        // immediately reclaims the row so SQL state matches what the
-        // caller observes (write rejected, no row created).
-        if let Err(e) = state.vec_index.append(rid.clone(), embedding.to_vec(), seq) {
-            let conn = self.conn();
-            let _ = conn.execute("DELETE FROM memories WHERE rid = ?1", params![rid]);
-            // **v0.7.23 residual fix.** The compensating DELETE above
-            // reclaims the orphaned memories row, but the session
-            // `memory_count` bumped in the conn block above survives the
-            // delete and over-counts by 1 per backpressure-rejected
-            // record. Reverse it so the session stat matches the rows
-            // that actually exist.
-            if let Some(session_id) = &session_id {
-                let _ = conn.execute(
-                    "UPDATE sessions SET memory_count = memory_count - 1 WHERE session_id = ?1",
-                    params![session_id],
-                );
+            // Kill boundary. Before 4a.6a the row above was already committed by
+            // its own autocommit at this point, while the oplog op below had not
+            // been written — a process death here left exactly the orphan the
+            // "23k rows over 39 days" comment described. Inside the transaction,
+            // dying here rolls back BOTH. `kill_record_boundary.rs` proves it.
+            crate::testing::fail_point("record.between_row_and_oplog");
+
+            // The user-facing "record" op goes in FIRST so external consumers
+            // (replication extract_ops_since, oplog inspectors) see the natural
+            // causal order: the record precedes any materialization queued in its
+            // wake. `applied_generation` is the guard-pinned snapshot generation,
+            // which is the generation the reserved delta entry was written
+            // against.
+            self.log_op_in_tx(
+                &tx,
+                "record",
+                Some(&rid),
+                &record_payload,
+                Some(&emb_hash),
+                None,
+                embedding_generation,
+            )?;
+
+            let (pending_inserted, _op_id) = self.log_op_pending_in_tx(
+                &tx,
+                crate::engine::op_types::OP_MATERIALIZE_RECORD_POST,
+                Some(&rid),
+                &post_payload,
+                None,
+                None,
+            )?;
+
+            tx.commit()?;
+            Ok(pending_inserted)
+        })();
+
+        let pending_inserted = match committed {
+            Ok(v) => v,
+            Err(e) => {
+                // Nothing durable exists. Drop the reservation and leave. Removal
+                // always succeeds: reserved entries are skipped by seal/compaction
+                // precisely so this path cannot lose the race. Note this is a
+                // removal, NOT a tombstone — a tombstone would suppress the rid
+                // and hide a still-valid older vector.
+                state.vec_index.remove_appended(&rid, seq);
+                drop(conn);
+                return Err(e);
             }
-            return Err(e);
-        }
-        self.bump_visible_seq(namespace, seq);
+        };
 
-        // Insert into scoring cache (conn and vec_index dropped)
+        // Durable. PUBLISH makes the vector visible; it is infallible, so there
+        // is no failure window between "committed" and "visible". A crash here
+        // rebuilds the index from `memories` on next open — the row is
+        // authoritative.
+        state.vec_index.publish(&rid, seq);
+
+        // Only NOW may the pending counter move. Incrementing inside the tx would
+        // leak it upward on rollback with no row for `mark_op_applied` to
+        // decrement, and that drift is monotonic — at MAX_PENDING_OPS it wedges
+        // every foreground write into Backpressure with an empty queue in SQL.
+        if pending_inserted {
+            self.pending_op_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+
         self.cache_insert(
             rid.clone(),
             ScoringRow {
@@ -314,59 +419,11 @@ impl YantrikDB {
             },
         );
 
-        // Log the user-facing "record" op FIRST so external consumers
-        // (replication extract_ops_since, oplog inspectors) see records
-        // in their natural causal order: the record came before any
-        // post-record materialization queued in its wake.
-        let emb_hash = embedding_hash(embedding);
-        self.log_op(
-            "record",
-            Some(&rid),
-            &serde_json::json!({
-                "rid": rid,
-                "type": memory_type,
-                "text": text,
-                "importance": importance,
-                "valence": valence,
-                "half_life": half_life,
-                "metadata": metadata,
-                "created_at": ts,
-                "updated_at": ts,
-                "namespace": namespace,
-                "certainty": certainty,
-                "domain": domain,
-                "source": source,
-                "emotional_state": emotional_state,
-            }),
-            Some(&emb_hash),
-        )?;
+        // LAST: a read-your-write waiter must not wake against a half-applied
+        // record (CONCURRENCY.md: bump visible_seq AFTER the delta append).
+        self.bump_visible_seq(namespace, seq);
 
-        // **Phase 4.3 Commit B (saga task 3, 2026-05-08).** The
-        // unbounded entity / memory_entities / claims loops that used
-        // to live here are now enqueued for the materializer thread to
-        // run off the request path. See docs/phase_4_3_design.md for
-        // the contract change (synchronous read-after-write of
-        // entity-graph queries shifts from immediate to ms-scale; the
-        // delta-recall path is unaffected since DeltaIndex.append
-        // happened above on the foreground thread).
-        {
-            let post_payload = serde_json::json!({
-                "rid": rid,
-                "text": stored_text,
-                "namespace": namespace,
-                "ts_secs": ts,
-                "domain": domain,
-                "source": source,
-            });
-            self.log_op_pending(
-                crate::engine::op_types::OP_MATERIALIZE_RECORD_POST,
-                Some(&rid),
-                &post_payload,
-                None,
-                None,
-            )?;
-        }
-
+        drop(conn);
         Ok(rid)
     }
 
@@ -1169,7 +1226,7 @@ impl YantrikDB {
         let payload_str = serde_json::to_string(payload)?;
 
         // Backpressure check (mirrors log_op_pending's contract).
-        const MAX_PENDING_OPS: i64 = 10_000;
+        use crate::engine::stats::MAX_PENDING_OPS;
         let pending_now = self.pending_op_count.load(Ordering::Relaxed);
         if pending_now >= MAX_PENDING_OPS {
             return Err(crate::error::YantrikDbError::Backpressure {

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -9,40 +9,85 @@ use super::reembed::SearchState;
 use super::write_router::SyncWriteGuard;
 use super::{embedding_hash, now, sanitize, YantrikDB};
 
-/// RAII cleanup for an unpublished delta reservation (v0.10 Item 4a.6a,
-/// sol review finding 3).
+/// Which obligation the write currently owes (v0.10 Item 4a.6a).
+enum ResPhase {
+    /// Reserved, nothing durable. Owe: remove the reservation.
+    Reserved,
+    /// Durable. Owe: publish the vector AND count the pending op.
+    Committed,
+    /// All obligations discharged.
+    Done,
+}
+
+/// PHASE-AWARE RAII for the reserve → commit → publish protocol (sol 4a.6a
+/// findings 3 and r2-2).
 ///
-/// `append_reserved` consumes delta capacity with an entry that search skips and
-/// — critically — that compaction deliberately RETAINS rather than seals
-/// (`delta_index.rs`, so the removal path can never lose a race). That retention
-/// is what makes the reservation safe to roll back, and also what makes a LEAKED
-/// reservation permanent: an unpublished entry nobody removes holds capacity
-/// until the process restarts, and enough of them wedge every writer into
-/// Backpressure.
+/// The obligation this guard carries INVERTS at commit, and both halves must
+/// survive an unwinding panic:
 ///
-/// Manual cleanup on the `Err` path is therefore not sufficient — an unwinding
-/// panic between the reservation and the commit would skip it. This guard removes
-/// the reservation on ANY unwind, and is defused by `commit()` once the write is
-/// durable (after which the entry must be published, not removed).
+/// - **Before commit** — nothing durable exists, so the reservation must be
+///   REMOVED. `append_reserved` consumes delta capacity with an entry search
+///   skips and compaction deliberately RETAINS rather than seals (the property
+///   that makes rollback safe). So a leaked reservation is permanent: nobody
+///   else will ever remove it, it holds capacity until restart, and enough of
+///   them wedge every writer into Backpressure.
+/// - **After commit** — the row is durable, so the reservation must be
+///   PUBLISHED and the pending op COUNTED. A panic here previously left a
+///   durable row whose vector was invisible until an index rebuild, plus a
+///   pending row missing from `pending_op_count`. The first version defused the
+///   guard AT commit, before both — and the `debug_assert!` added to be careful
+///   was itself a panic point in that window.
+///
+/// Restart repairs both (the index rebuilds from `memories`; the counter
+/// re-seeds), but the engine deliberately uses non-poisoning locks so a
+/// `catch_unwind` process CONTINUES — and that process is the exposure.
 struct ReservationGuard<'a> {
     state: &'a SearchState,
+    pending_op_count: &'a std::sync::atomic::AtomicI64,
     rid: &'a str,
     seq: u64,
-    live: bool,
+    phase: ResPhase,
 }
 
 impl ReservationGuard<'_> {
-    /// The write is durable; the reservation must survive to be published.
-    fn commit(mut self) {
-        self.live = false;
+    /// The transaction committed: from here the obligation is publish+count.
+    fn mark_committed(&mut self) {
+        self.phase = ResPhase::Committed;
+    }
+
+    /// Discharge the post-commit obligations exactly once. Returns whether
+    /// `publish` found the reservation.
+    fn complete(&mut self) -> bool {
+        let published = self.discharge_committed();
+        self.phase = ResPhase::Done;
+        published
+    }
+
+    /// publish + count. Idempotent-by-phase: only ever run once, either from
+    /// `complete()` or from `Drop` on a post-commit unwind.
+    fn discharge_committed(&self) -> bool {
+        let published = self.state.vec_index.publish(self.rid, self.seq);
+        self.pending_op_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        published
     }
 }
 
 impl Drop for ReservationGuard<'_> {
     fn drop(&mut self) {
-        if self.live {
-            // Always succeeds: reserved entries are never sealed.
-            self.state.vec_index.remove_appended(self.rid, self.seq);
+        match self.phase {
+            // Always succeeds: reserved entries are never sealed. A removal, NOT
+            // a tombstone — a tombstone would suppress the rid and hide a
+            // still-valid older vector.
+            ResPhase::Reserved => {
+                self.state.vec_index.remove_appended(self.rid, self.seq);
+            }
+            // Unwound after commit. The write IS durable, so finish the job
+            // rather than strand it.
+            ResPhase::Committed => {
+                self.discharge_committed();
+            }
+            ResPhase::Done => {}
         }
     }
 }
@@ -353,11 +398,12 @@ impl YantrikDB {
         // From here until commit, ANY exit — including an unwinding panic —
         // must drop the reservation, or its capacity is held forever
         // (compaction retains unpublished entries by design).
-        let reservation = ReservationGuard {
+        let mut reservation = ReservationGuard {
             state: &state,
+            pending_op_count: &self.pending_op_count,
             rid: &rid,
             seq,
-            live: true,
+            phase: ResPhase::Reserved,
         };
 
         // ONE transaction: row + session links + the record op + the
@@ -443,9 +489,11 @@ impl YantrikDB {
         })();
 
         match committed {
-            // Durable. Defuse the guard: the reservation must now be PUBLISHED,
-            // not removed.
-            Ok(()) => reservation.commit(),
+            // Durable. The guard's obligation INVERTS here: from "remove the
+            // reservation" to "publish it and count the pending op". It is not
+            // defused — an unwind between here and complete() must still finish
+            // the job, because the row is already committed.
+            Ok(()) => reservation.mark_committed(),
             Err(e) => {
                 // Nothing durable exists. `reservation` drops here and removes the
                 // entry — a removal, NOT a tombstone (a tombstone would suppress
@@ -459,10 +507,23 @@ impl YantrikDB {
         // is no failure window between "committed" and "visible". A crash here
         // rebuilds the index from `memories` on next open — the row is
         // authoritative.
-        // publish() is infallible but returns whether it found the reservation.
-        // Discarding that would silently hide a protocol violation (a reservation
-        // removed or never made), leaving a durable row whose vector is invisible.
-        let published = state.vec_index.publish(&rid, seq);
+        // Discharge both post-commit obligations — publish the vector and count
+        // the pending op — in one place the guard also performs on an unwind, so
+        // a caught panic cannot strand a durable write with an invisible vector
+        // or an uncounted pending row.
+        let published = reservation.complete();
+
+        // The counter moved inside complete() above — only after the tx
+        // committed. Incrementing inside the tx would leak it upward on rollback
+        // with no row for `mark_op_applied` to decrement; that drift is monotonic
+        // and at MAX_PENDING_OPS wedges every write into Backpressure with an
+        // empty queue in SQL. It is unconditional because the enqueue is a plain
+        // INSERT in the committed tx, so reaching here means exactly one pending
+        // row landed.
+        //
+        // The assert comes AFTER the counter is discharged: as a post-commit panic
+        // point it would otherwise be exactly the hazard the guard exists to
+        // close (sol 4a.6a r2 finding 2).
         debug_assert!(
             published,
             "reservation for {rid} seq {seq} vanished before publish"
@@ -471,21 +532,15 @@ impl YantrikDB {
             tracing::error!(
                 rid = %rid,
                 seq,
-                "reserved vector entry missing at publish — row is durable but                  unsearchable until the index is rebuilt from SQL"
+                "reserved vector entry missing at publish — row is durable but \
+                 unsearchable until the index is rebuilt from SQL"
             );
         }
-
-        // Only NOW may the pending counter move. Incrementing inside the tx would
-        // leak it upward on rollback with no row for `mark_op_applied` to
-        // decrement, and that drift is monotonic — at MAX_PENDING_OPS it wedges
-        // every foreground write into Backpressure with an empty queue in SQL.
-        //
-        // Unconditional: the enqueue is a plain INSERT inside the committed tx, so
-        // reaching here means exactly one pending row landed. (It was conditional
-        // on an `OR IGNORE` no-op until sol's finding 4 established that an
-        // ignored insert here is a bug, not an outcome to account for.)
-        self.pending_op_count
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // All obligations are discharged (phase == Done), so this Drop is a no-op.
+        // It is explicit only to release the guard's borrow of `rid` before we
+        // return it — and it must stay AFTER complete(), which is what makes the
+        // drop inert.
+        drop(reservation);
 
         self.cache_insert(
             rid.clone(),
@@ -1312,18 +1367,14 @@ impl YantrikDB {
         let hlc_bytes = hlc_ts.to_bytes().to_vec();
         let payload_str = serde_json::to_string(payload)?;
 
-        // Backpressure check (mirrors log_op_pending's contract).
-        use crate::engine::stats::MAX_PENDING_OPS;
-        let pending_now = self.pending_op_count.load(Ordering::Relaxed);
-        if pending_now >= MAX_PENDING_OPS {
-            return Err(crate::error::YantrikDbError::Backpressure {
-                pending: pending_now,
-                max: MAX_PENDING_OPS,
-                retry_after_ms: 50,
-            });
-        }
+        // Advisory fast reject (unlocked); the AUTHORITATIVE check is under the
+        // lock below. Same TOCTOU, same fix as log_op_pending (sol 4a.6a r2
+        // finding 1): two queued writers at MAX_PENDING_OPS-1 could both pass an
+        // unlocked load and then serialize their inserts past the ceiling.
+        self.check_pending_backpressure_fast()?;
 
         let conn = self.conn.lock();
+        self.check_pending_backpressure_locked()?;
         conn.execute(
             "INSERT OR IGNORE INTO oplog \
              (op_id, op_type, timestamp, target_rid, payload, \

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -9,6 +9,44 @@ use super::reembed::SearchState;
 use super::write_router::SyncWriteGuard;
 use super::{embedding_hash, now, sanitize, YantrikDB};
 
+/// RAII cleanup for an unpublished delta reservation (v0.10 Item 4a.6a,
+/// sol review finding 3).
+///
+/// `append_reserved` consumes delta capacity with an entry that search skips and
+/// — critically — that compaction deliberately RETAINS rather than seals
+/// (`delta_index.rs`, so the removal path can never lose a race). That retention
+/// is what makes the reservation safe to roll back, and also what makes a LEAKED
+/// reservation permanent: an unpublished entry nobody removes holds capacity
+/// until the process restarts, and enough of them wedge every writer into
+/// Backpressure.
+///
+/// Manual cleanup on the `Err` path is therefore not sufficient — an unwinding
+/// panic between the reservation and the commit would skip it. This guard removes
+/// the reservation on ANY unwind, and is defused by `commit()` once the write is
+/// durable (after which the entry must be published, not removed).
+struct ReservationGuard<'a> {
+    state: &'a SearchState,
+    rid: &'a str,
+    seq: u64,
+    live: bool,
+}
+
+impl ReservationGuard<'_> {
+    /// The write is durable; the reservation must survive to be published.
+    fn commit(mut self) {
+        self.live = false;
+    }
+}
+
+impl Drop for ReservationGuard<'_> {
+    fn drop(&mut self) {
+        if self.live {
+            // Always succeeds: reserved entries are never sealed.
+            self.state.vec_index.remove_appended(self.rid, self.seq);
+        }
+    }
+}
+
 /// Coerce a blank namespace to the canonical default (v0.7.23).
 ///
 /// The schema column default and the Python/MCP bindings all use
@@ -239,9 +277,21 @@ impl YantrikDB {
         // holding conn across non-O(1) work; a delta reserve/publish is an O(1)
         // Vec push / flag flip.
 
-        // Admission check BEFORE any side effect. `log_op_pending_in_tx` cannot
-        // do this itself — inside the tx it would fire after the row exists.
-        self.check_pending_backpressure()?;
+        // Advisory early reject: cheap, unlocked, and NOT authoritative — the
+        // binding check happens under the conn lock below. Doing it here too just
+        // avoids the embed/serialize work on an obviously-full queue.
+        //
+        // KNOWN GAP, deliberately not closed here (sol 4a.6a finding 2): this is
+        // not "before any side effect". `calibrate_importance` (record.rs:101)
+        // already ran and autocommitted an update to `namespace_importance_stats`
+        // (importance.rs:88) BEFORE routing, so a write rejected below — by
+        // backpressure, by delta capacity, or by a transaction failure — has
+        // already advanced this namespace's calibration distribution permanently.
+        // That is a real defect and it predates 4a.6a; sol's own increment plan
+        // puts the fix in 4a.6b ("winner-only, transactional calibration"), where
+        // the claim decides who is allowed to advance it. It is called out here so
+        // nobody reads this path as fully side-effect-free before then.
+        self.check_pending_backpressure_fast()?;
 
         let emb_hash = embedding_hash(embedding);
         let record_payload = serde_json::json!({
@@ -278,6 +328,14 @@ impl YantrikDB {
 
         let conn = self.conn();
 
+        // THE authoritative admission check: under the lock, before the
+        // reservation and before any durable write. The pre-lock check above is a
+        // TOCTOU on its own (sol 4a.6a finding 1) — at MAX_PENDING_OPS-1, N
+        // writers can all read "under the limit", then serialize here and each
+        // commit an enqueue, overshooting the ceiling. Re-reading under the lock
+        // serializes the read with the commit that acts on it, so the bound holds.
+        self.check_pending_backpressure_locked()?;
+
         // Mint the seq UNDER the conn lock. Search resolves a rid to its HIGHEST
         // seq, not the most recently appended one, so minting outside the
         // serialized region would let a stalled writer holding seq N append after
@@ -292,9 +350,19 @@ impl YantrikDB {
             .vec_index
             .append_reserved(rid.clone(), embedding.to_vec(), seq)?;
 
+        // From here until commit, ANY exit — including an unwinding panic —
+        // must drop the reservation, or its capacity is held forever
+        // (compaction retains unpublished entries by design).
+        let reservation = ReservationGuard {
+            state: &state,
+            rid: &rid,
+            seq,
+            live: true,
+        };
+
         // ONE transaction: row + session links + the record op + the
         // post-materialization enqueue. Either all of it is durable or none is.
-        let committed = (|| -> Result<bool> {
+        let committed = (|| -> Result<()> {
             let tx = conn.unchecked_transaction()?;
             tx.execute(
                 "INSERT INTO memories \
@@ -358,7 +426,10 @@ impl YantrikDB {
                 embedding_generation,
             )?;
 
-            let (pending_inserted, _op_id) = self.log_op_pending_in_tx(
+            // Plain INSERT: if this cannot land, the whole write must fail
+            // rather than commit a record whose entity materialization is owed
+            // to nobody. See log_op_pending_in_tx.
+            self.log_op_pending_in_tx(
                 &tx,
                 crate::engine::op_types::OP_MATERIALIZE_RECORD_POST,
                 Some(&rid),
@@ -368,37 +439,53 @@ impl YantrikDB {
             )?;
 
             tx.commit()?;
-            Ok(pending_inserted)
+            Ok(())
         })();
 
-        let pending_inserted = match committed {
-            Ok(v) => v,
+        match committed {
+            // Durable. Defuse the guard: the reservation must now be PUBLISHED,
+            // not removed.
+            Ok(()) => reservation.commit(),
             Err(e) => {
-                // Nothing durable exists. Drop the reservation and leave. Removal
-                // always succeeds: reserved entries are skipped by seal/compaction
-                // precisely so this path cannot lose the race. Note this is a
-                // removal, NOT a tombstone — a tombstone would suppress the rid
-                // and hide a still-valid older vector.
-                state.vec_index.remove_appended(&rid, seq);
+                // Nothing durable exists. `reservation` drops here and removes the
+                // entry — a removal, NOT a tombstone (a tombstone would suppress
+                // the rid and hide a still-valid older vector).
                 drop(conn);
                 return Err(e);
             }
-        };
+        }
 
         // Durable. PUBLISH makes the vector visible; it is infallible, so there
         // is no failure window between "committed" and "visible". A crash here
         // rebuilds the index from `memories` on next open — the row is
         // authoritative.
-        state.vec_index.publish(&rid, seq);
+        // publish() is infallible but returns whether it found the reservation.
+        // Discarding that would silently hide a protocol violation (a reservation
+        // removed or never made), leaving a durable row whose vector is invisible.
+        let published = state.vec_index.publish(&rid, seq);
+        debug_assert!(
+            published,
+            "reservation for {rid} seq {seq} vanished before publish"
+        );
+        if !published {
+            tracing::error!(
+                rid = %rid,
+                seq,
+                "reserved vector entry missing at publish — row is durable but                  unsearchable until the index is rebuilt from SQL"
+            );
+        }
 
         // Only NOW may the pending counter move. Incrementing inside the tx would
         // leak it upward on rollback with no row for `mark_op_applied` to
         // decrement, and that drift is monotonic — at MAX_PENDING_OPS it wedges
         // every foreground write into Backpressure with an empty queue in SQL.
-        if pending_inserted {
-            self.pending_op_count
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
+        //
+        // Unconditional: the enqueue is a plain INSERT inside the committed tx, so
+        // reaching here means exactly one pending row landed. (It was conditional
+        // on an `OR IGNORE` no-op until sol's finding 4 established that an
+        // ignored insert here is a bug, not an outcome to account for.)
+        self.pending_op_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
         self.cache_insert(
             rid.clone(),

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -224,17 +224,17 @@ impl YantrikDB {
     ///
     /// Writes an `applied=0` oplog row in the caller's transaction.
     ///
-    /// **Returns `(really_inserted, op_id)` and deliberately does NOT touch
-    /// `pending_op_count`.** That split is load-bearing, not laziness. The
-    /// counter may only be incremented AFTER the enclosing transaction commits:
-    /// increment it here and a later rollback leaves the row gone but the
-    /// counter raised, with nothing to bring it back down —
-    /// [`Self::mark_op_applied`] only decrements rows it actually transitions,
-    /// and there is no row. The drift is monotonic, and at `MAX_PENDING_OPS` of
-    /// net drift [`Self::log_op_pending`]'s admission check wedges EVERY
-    /// foreground write into `Backpressure` forever, with zero pending ops in
-    /// SQL. That is the v0.7.1 counter-leak class, and it is why this returns
-    /// the flag instead of acting on it.
+    /// **Deliberately does NOT touch `pending_op_count`.** That split is
+    /// load-bearing, not laziness. The counter may only be incremented AFTER the
+    /// enclosing transaction commits: increment it here and a later rollback
+    /// leaves the row gone but the counter raised, with nothing to bring it back
+    /// down — [`Self::mark_op_applied`] only decrements rows it actually
+    /// transitions, and there is no row. The drift is monotonic, and at
+    /// `MAX_PENDING_OPS` of net drift the admission check wedges EVERY foreground
+    /// write into `Backpressure` forever, with zero pending ops in SQL. That is
+    /// the v0.7.1 counter-leak class. The caller owns the increment, and must run
+    /// it only on the committed path (in `record()` the `ReservationGuard` owns
+    /// it, so a post-commit unwind cannot skip it).
     ///
     /// Uses a plain `INSERT`, NOT `INSERT OR IGNORE` — and that difference is
     /// deliberate (sol, 4a.6a review finding 4).
@@ -429,16 +429,18 @@ impl YantrikDB {
         // + index scan + drop just to check the bound. Cached counter
         // is maintained by `log_op_pending` (fetch_add on insert) and
         // `mark_op_applied` (fetch_sub on apply-win).
-        let pending_now = self.pending_op_count.load(Ordering::Relaxed);
-        if pending_now >= MAX_PENDING_OPS {
-            return Err(crate::error::YantrikDbError::Backpressure {
-                pending: pending_now,
-                max: MAX_PENDING_OPS,
-                retry_after_ms: 50,
-            });
-        }
+        // Advisory fast reject (unlocked). NOT authoritative on its own.
+        self.check_pending_backpressure_fast()?;
 
         let conn = self.conn.lock();
+        // THE authoritative check (sol 4a.6a r2 finding 1). The unlocked load
+        // above is a TOCTOU: at MAX_PENDING_OPS-1, N producers all read "under the
+        // limit", then serialize here and each insert, overshooting the ceiling.
+        // Re-reading under the SAME lock that guards the INSERT serializes the
+        // read with the write it authorizes, so the bound actually holds. 4a.6a
+        // first fixed only record()'s copy of this race and left this one — the
+        // instance, not the class.
+        self.check_pending_backpressure_locked()?;
         conn.execute(
             "INSERT OR IGNORE INTO oplog \
              (op_id, op_type, timestamp, target_rid, payload, \

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -5,6 +5,15 @@ use crate::types::Stats;
 
 use super::{now, YantrikDB};
 
+/// Ceiling on the bounded global ingest queue (`oplog` rows with `applied=0`).
+///
+/// Single source of truth as of v0.10 Item 4a.6a. This was previously declared
+/// three times as a function-local `const` (`log_op_pending`,
+/// `log_op_pending_for_reembed_queue`, and now the shared admission check) — a
+/// value that gates every foreground write should not be able to drift between
+/// its copies.
+pub(crate) const MAX_PENDING_OPS: i64 = 10_000;
+
 impl YantrikDB {
     /// Get engine statistics. Optionally filter memory counts by namespace.
     pub fn stats(&self, namespace: Option<&str>) -> Result<Stats> {
@@ -160,6 +169,133 @@ impl YantrikDB {
         )?;
         Ok(op_id)
     }
+    /// In-transaction sibling of [`Self::log_op`] (v0.10 Item 4a.6a).
+    ///
+    /// Writes an `applied=1` oplog row using the CALLER'S transaction instead of
+    /// re-locking `self.conn`. This is the primitive that lets a write path
+    /// commit its row and its oplog provenance ATOMICALLY. `log_op` cannot do
+    /// that: it re-acquires `self.conn` (see [`Self::log_op`]), and
+    /// `parking_lot::Mutex` is not reentrant, so calling it while holding a conn
+    /// guard deadlocks.
+    ///
+    /// Generalized from `insert_correct_op_in_tx`, which `correct()` has used
+    /// since Item 3 — the shape is proven, this just parameterizes `op_type`.
+    ///
+    /// `applied_generation` is passed IN rather than read from `search_state`
+    /// here: the caller holds a `SyncWriteGuard` pinning the generation for its
+    /// whole critical section, and must stamp the same generation its vector
+    /// entry was written against.
+    pub(crate) fn log_op_in_tx(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+        op_type: &str,
+        target_rid: Option<&str>,
+        payload: &serde_json::Value,
+        emb_hash: Option<&[u8]>,
+        embedding: Option<&[u8]>,
+        applied_generation: i64,
+    ) -> Result<String> {
+        let op_id = crate::id::new_id();
+        let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
+        let payload_str = serde_json::to_string(payload)?;
+        tx.execute(
+            "INSERT INTO oplog \
+             (op_id, op_type, timestamp, target_rid, payload, actor_id, hlc, \
+              embedding_hash, origin_actor, applied, applied_generation, embedding) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1, ?10, ?11)",
+            params![
+                op_id,
+                op_type,
+                now(),
+                target_rid,
+                payload_str,
+                self.actor_id,
+                hlc_bytes,
+                emb_hash,
+                self.actor_id,
+                applied_generation,
+                embedding,
+            ],
+        )?;
+        Ok(op_id)
+    }
+
+    /// In-transaction sibling of [`Self::log_op_pending`] (v0.10 Item 4a.6a).
+    ///
+    /// Writes an `applied=0` oplog row in the caller's transaction.
+    ///
+    /// **Returns `(really_inserted, op_id)` and deliberately does NOT touch
+    /// `pending_op_count`.** That split is load-bearing, not laziness. The
+    /// counter may only be incremented AFTER the enclosing transaction commits:
+    /// increment it here and a later rollback leaves the row gone but the
+    /// counter raised, with nothing to bring it back down —
+    /// [`Self::mark_op_applied`] only decrements rows it actually transitions,
+    /// and there is no row. The drift is monotonic, and at `MAX_PENDING_OPS` of
+    /// net drift [`Self::log_op_pending`]'s admission check wedges EVERY
+    /// foreground write into `Backpressure` forever, with zero pending ops in
+    /// SQL. That is the v0.7.1 counter-leak class, and it is why this returns
+    /// the flag instead of acting on it.
+    ///
+    /// `really_inserted` is `tx.changes() > 0` because the INSERT is
+    /// `OR IGNORE` on the `op_id` PK — a cluster-replay caller re-using an op_id
+    /// inserts nothing and must not be counted.
+    ///
+    /// The `MAX_PENDING_OPS` admission check is likewise NOT here: it is a
+    /// pre-mutation gate and belongs before the caller's first side effect,
+    /// beside the vector reservation. Inside the transaction it would fire after
+    /// the row already exists.
+    pub(crate) fn log_op_pending_in_tx(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+        op_type: &str,
+        target_rid: Option<&str>,
+        payload: &serde_json::Value,
+        emb_hash: Option<&[u8]>,
+        embedding: Option<&[u8]>,
+    ) -> Result<(bool, String)> {
+        let op_id = crate::id::new_id();
+        let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
+        let payload_str = serde_json::to_string(payload)?;
+        tx.execute(
+            "INSERT OR IGNORE INTO oplog \
+             (op_id, op_type, timestamp, target_rid, payload, actor_id, hlc, \
+              embedding_hash, origin_actor, applied, embedding) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0, ?10)",
+            params![
+                op_id,
+                op_type,
+                now(),
+                target_rid,
+                payload_str,
+                self.actor_id,
+                hlc_bytes,
+                emb_hash,
+                self.actor_id,
+                embedding,
+            ],
+        )?;
+        Ok((tx.changes() > 0, op_id))
+    }
+
+    /// The `MAX_PENDING_OPS` admission check, split out of
+    /// [`Self::log_op_pending`] so a reserve-then-commit write path can run it
+    /// BEFORE its first side effect (v0.10 Item 4a.6a).
+    ///
+    /// Backpressure must surface before anything visible has happened, so the
+    /// caller can bail having touched nothing.
+    pub(crate) fn check_pending_backpressure(&self) -> Result<()> {
+        use std::sync::atomic::Ordering;
+        let pending = self.pending_op_count.load(Ordering::Relaxed);
+        if pending >= MAX_PENDING_OPS {
+            return Err(crate::error::YantrikDbError::Backpressure {
+                pending,
+                max: MAX_PENDING_OPS,
+                retry_after_ms: 100,
+            });
+        }
+        Ok(())
+    }
+
     /// Batched sibling of [`Self::log_op`] that writes one canonical `"record"`
     /// op per entry under a SINGLE connection lock.
     ///
@@ -265,7 +401,6 @@ impl YantrikDB {
         // + index scan + drop just to check the bound. Cached counter
         // is maintained by `log_op_pending` (fetch_add on insert) and
         // `mark_op_applied` (fetch_sub on apply-win).
-        const MAX_PENDING_OPS: i64 = 10_000;
         let pending_now = self.pending_op_count.load(Ordering::Relaxed);
         if pending_now >= MAX_PENDING_OPS {
             return Err(crate::error::YantrikDbError::Backpressure {

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -236,14 +236,31 @@ impl YantrikDB {
     /// SQL. That is the v0.7.1 counter-leak class, and it is why this returns
     /// the flag instead of acting on it.
     ///
-    /// `really_inserted` is `tx.changes() > 0` because the INSERT is
-    /// `OR IGNORE` on the `op_id` PK — a cluster-replay caller re-using an op_id
-    /// inserts nothing and must not be counted.
+    /// Uses a plain `INSERT`, NOT `INSERT OR IGNORE` — and that difference is
+    /// deliberate (sol, 4a.6a review finding 4).
     ///
-    /// The `MAX_PENDING_OPS` admission check is likewise NOT here: it is a
-    /// pre-mutation gate and belongs before the caller's first side effect,
-    /// beside the vector reservation. Inside the transaction it would fire after
-    /// the row already exists.
+    /// [`Self::log_op_pending`] uses `OR IGNORE` because it has cluster-replay
+    /// callers that re-use an existing `op_id`, where a silent no-op is the
+    /// correct outcome. This function mints a FRESH `op_id` and has no such
+    /// caller, so "ignored" could only mean an id collision or some other
+    /// constraint — and swallowing it would let the record transaction commit and
+    /// `record()` return `Ok` while the post-materialization enqueue silently did
+    /// not happen. That write's entity materialization would then be owed to
+    /// nobody, forever, which is the exact failure moving the enqueue into the
+    /// transaction was meant to prevent. A plain INSERT turns that into the error
+    /// it is, rolling the whole write back.
+    ///
+    /// (I originally copied `OR IGNORE` from `log_op_pending` without checking
+    /// whether its rationale applied here. It did not.)
+    ///
+    /// Returns the op_id. Deliberately does NOT touch `pending_op_count`: the
+    /// counter may only move AFTER the enclosing transaction commits — increment
+    /// it here and a rollback leaves the row gone but the counter raised, with
+    /// nothing to bring it back down ([`Self::mark_op_applied`] only decrements
+    /// rows it actually transitions, and there is no row). The drift is
+    /// monotonic, and at `MAX_PENDING_OPS` of net drift the admission check wedges
+    /// EVERY foreground write into `Backpressure` forever with zero pending ops in
+    /// SQL. That is the v0.7.1 counter-leak class.
     pub(crate) fn log_op_pending_in_tx(
         &self,
         tx: &rusqlite::Transaction<'_>,
@@ -252,12 +269,12 @@ impl YantrikDB {
         payload: &serde_json::Value,
         emb_hash: Option<&[u8]>,
         embedding: Option<&[u8]>,
-    ) -> Result<(bool, String)> {
+    ) -> Result<String> {
         let op_id = crate::id::new_id();
         let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
         let payload_str = serde_json::to_string(payload)?;
         tx.execute(
-            "INSERT OR IGNORE INTO oplog \
+            "INSERT INTO oplog \
              (op_id, op_type, timestamp, target_rid, payload, actor_id, hlc, \
               embedding_hash, origin_actor, applied, embedding) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0, ?10)",
@@ -274,16 +291,27 @@ impl YantrikDB {
                 embedding,
             ],
         )?;
-        Ok((tx.changes() > 0, op_id))
+        Ok(op_id)
     }
 
-    /// The `MAX_PENDING_OPS` admission check, split out of
-    /// [`Self::log_op_pending`] so a reserve-then-commit write path can run it
-    /// BEFORE its first side effect (v0.10 Item 4a.6a).
+    /// The `MAX_PENDING_OPS` admission check (v0.10 Item 4a.6a).
     ///
-    /// Backpressure must surface before anything visible has happened, so the
-    /// caller can bail having touched nothing.
-    pub(crate) fn check_pending_backpressure(&self) -> Result<()> {
+    /// **Must be called while holding the conn lock** to be authoritative. It was
+    /// originally an unlocked pre-lock read, which sol's 4a.6a review finding 1
+    /// showed is a TOCTOU: at 9,999 pending, N writers all read "under the limit",
+    /// then serialize under `conn` and each commit an enqueue, pushing the queue
+    /// past the ceiling. Under the lock the read and the commit that acts on it
+    /// are serialized, so the bound actually holds.
+    ///
+    /// [`Self::check_pending_backpressure_fast`] is the unlocked variant, useful
+    /// only as an early reject before doing expensive work.
+    pub(crate) fn check_pending_backpressure_locked(&self) -> Result<()> {
+        self.check_pending_backpressure_fast()
+    }
+
+    /// Unlocked, advisory admission check — an early reject only. NOT
+    /// authoritative: see [`Self::check_pending_backpressure_locked`].
+    pub(crate) fn check_pending_backpressure_fast(&self) -> Result<()> {
         use std::sync::atomic::Ordering;
         let pending = self.pending_op_count.load(Ordering::Relaxed);
         if pending >= MAX_PENDING_OPS {

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -13857,12 +13857,17 @@ fn boundary_audit_pattern_detects_synthetic_violation() {
 
 #[cfg(feature = "bundled-embedder")]
 #[test]
-fn record_backpressure_writes_nothing_at_all() {
+fn record_backpressure_writes_no_row_op_or_session_state() {
     // **v0.10 Item 4a.6a.** The v0.7.19 sibling below asserts the OLD contract:
     // the row was written, then a compensating DELETE reclaimed it. record() no
     // longer needs compensating — it RESERVES delta capacity before touching SQL,
-    // so Backpressure surfaces having written nothing. This asserts the stronger
-    // properties the compensating design could not give:
+    // so Backpressure surfaces without a row, an op, or session state.
+    //
+    // NAMED PRECISELY, because "writes nothing at all" would be a LIE (sol 4a.6a
+    // finding 2): `calibrate_importance` already autocommitted an update to
+    // `namespace_importance_stats` before routing, so a rejected write HAS moved
+    // this namespace's calibration. That defect predates 4a.6a and is fixed in
+    // 4a.6b (winner-only transactional calibration). What this test does assert:
     //
     //   1. no memories row              (the old design also achieved this, by
     //                                    writing one and deleting it)

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -13855,6 +13855,287 @@ fn boundary_audit_pattern_detects_synthetic_violation() {
 // DELETE + replication_apply_log audit table.
 // ─────────────────────────────────────────────────────────────────
 
+#[cfg(feature = "bundled-embedder")]
+#[test]
+fn record_backpressure_writes_nothing_at_all() {
+    // **v0.10 Item 4a.6a.** The v0.7.19 sibling below asserts the OLD contract:
+    // the row was written, then a compensating DELETE reclaimed it. record() no
+    // longer needs compensating — it RESERVES delta capacity before touching SQL,
+    // so Backpressure surfaces having written nothing. This asserts the stronger
+    // properties the compensating design could not give:
+    //
+    //   1. no memories row              (the old design also achieved this, by
+    //                                    writing one and deleting it)
+    //   2. no oplog op of ANY kind      (row + ops are now one transaction)
+    //   3. session memory_count UNCHANGED — the sharp one. The old path bumped
+    //      the count and needed a SECOND patch (v0.7.23) to reverse it. The bump
+    //      now never happens, so there is nothing to reverse.
+    //   4. pending_op_count UNCHANGED — the materialize enqueue is in the same
+    //      transaction, and the counter only moves after commit.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let dim = db.embedding_dim();
+
+    let session_id = db.session_start("default", "bp-client", &empty_meta()).ok();
+    let count_for = |sid: &str| -> i64 {
+        db.conn()
+            .query_row(
+                "SELECT memory_count FROM sessions WHERE session_id = ?1",
+                rusqlite::params![sid],
+                |r| r.get(0),
+            )
+            .unwrap_or(-1)
+    };
+
+    // Pump until the delta tier saturates (no compactor is running, so it never
+    // drains). Record the state at the moment Backpressure first appears.
+    let mut hit: Option<(i64, i64, i64, String)> = None;
+    for i in 0..400 {
+        let embedding: Vec<f32> = (0..dim).map(|j| ((i + j) as f32) * 0.001).collect();
+        let rows_before: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+            .unwrap();
+        let ops_before: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM oplog", [], |r| r.get(0))
+            .unwrap();
+        let sess_before = session_id.as_deref().map(count_for).unwrap_or(-1);
+        let pend_before = db.count_pending_ops().unwrap();
+
+        let text = format!("bp-probe-{i}");
+        match db.record(
+            &text,
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &embedding,
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        ) {
+            Ok(_) => continue,
+            Err(crate::error::YantrikDbError::Backpressure { .. }) => {
+                let rows_after: i64 = db
+                    .conn()
+                    .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+                    .unwrap();
+                let ops_after: i64 = db
+                    .conn()
+                    .query_row("SELECT COUNT(*) FROM oplog", [], |r| r.get(0))
+                    .unwrap();
+                let sess_after = session_id.as_deref().map(count_for).unwrap_or(-1);
+                let pend_after = db.count_pending_ops().unwrap();
+
+                assert_eq!(rows_after, rows_before, "Backpressure wrote a memories row");
+                assert_eq!(ops_after, ops_before, "Backpressure wrote an oplog op");
+                assert_eq!(
+                    sess_after, sess_before,
+                    "Backpressure bumped sessions.memory_count (the v0.7.23 residual)"
+                );
+                assert_eq!(
+                    pend_after, pend_before,
+                    "Backpressure moved pending_op_count"
+                );
+                // The rejected text must not be findable at all.
+                let found: i64 = db
+                    .conn()
+                    .query_row(
+                        "SELECT COUNT(*) FROM memories WHERE text = ?1",
+                        rusqlite::params![text],
+                        |r| r.get(0),
+                    )
+                    .unwrap();
+                assert_eq!(found, 0, "rejected record's text is present in memories");
+                hit = Some((rows_after, ops_after, sess_after, text));
+                break;
+            }
+            Err(e) => panic!("unexpected error while pumping the delta: {e:?}"),
+        }
+    }
+    assert!(
+        hit.is_some(),
+        "delta never saturated — test did not exercise Backpressure"
+    );
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
+fn consolidate_entity_overlap_guard_depends_on_materializer_progress() {
+    // Pins a genuine, load-bearing behaviour of consolidate(): its result depends
+    // on whether the materializer has populated `memory_entities` yet.
+    //
+    // The entity-overlap guard (require_entity_overlap, default true since v0.6.0)
+    // refuses to merge two memories whose entity sets are non-empty and DISJOINT —
+    // it exists to stop cosine-only false merges across distinct named subjects
+    // ("Alice is CEO" vs "Sarah is CTO"). Entities are extracted ASYNCHRONOUSLY by
+    // the materializer, so the SAME pair of memories clusters before extraction
+    // and refuses to cluster after it.
+    //
+    // This was found the hard way: v0.10 Item 4a.6a shifted record()'s commit
+    // timing and two python consolidation tests began flaking ~50%. They recorded
+    // "A1"/"A2" — distinct entities — and had only ever passed by outrunning the
+    // materializer. The engine was right both times; the tests encoded pre-guard
+    // behaviour. They now use entity-free text so they test consolidation
+    // mechanics rather than a race.
+    //
+    // Keep this test: it is the executable statement of that asymmetry, and it
+    // fails loudly if the guard's semantics ever drift.
+    let mk = |db: &YantrikDB, text: &str, seed: f32| {
+        db.record(
+            text,
+            "episodic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(seed, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap()
+    };
+
+    // --- WITHOUT draining: entities not yet extracted ---
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let r1 = mk(&db, "A1", 1.0);
+    let r2 = mk(&db, "A2", 1.02);
+    let ents_before: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memory_entities", [], |r| r.get(0))
+        .unwrap();
+    let clusters_nodrain =
+        crate::cognition::consolidate::find_consolidation_candidates(&db, 0.9, 30.0, 2, 100, true)
+            .unwrap()
+            .len();
+
+    // --- WITH draining: materializer has populated memory_entities ---
+    let db2 = YantrikDB::new(":memory:", 8).unwrap();
+    let _r3 = mk(&db2, "A1", 1.0);
+    let _r4 = mk(&db2, "A2", 1.02);
+    db2.apply_pending_ops_once(100).unwrap();
+    let ents_after: i64 = db2
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memory_entities", [], |r| r.get(0))
+        .unwrap();
+    let clusters_drained =
+        crate::cognition::consolidate::find_consolidation_candidates(&db2, 0.9, 30.0, 2, 100, true)
+            .unwrap()
+            .len();
+
+    // Report the mechanism plainly; the assertion is on the DIFFERENCE.
+    println!(
+        "no-drain: memory_entities={ents_before} clusters={clusters_nodrain}  |  \
+         drained: memory_entities={ents_after} clusters={clusters_drained}  (rids {r1} {r2})"
+    );
+
+    assert_ne!(
+        clusters_nodrain, clusters_drained,
+        "if these match, the entity-overlap guard is NOT the mechanism — hypothesis refuted"
+    );
+    assert_eq!(
+        clusters_drained, 0,
+        "once entities exist, the disjoint-entity guard must block the merge"
+    );
+}
+
+#[cfg(feature = "bundled-embedder")]
+#[test]
+fn record_commits_row_and_both_oplog_ops_atomically() {
+    // **v0.10 Item 4a.6a.** The row, the user-facing "record" op, and the
+    // materialize_record_post enqueue were three independent autocommit windows;
+    // a crash between them left a row with no provenance (the 23k-row leak) or a
+    // record whose entity materialization was owed to nobody. They now commit in
+    // ONE transaction, so all three exist together or not at all.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let pend_before = db.count_pending_ops().unwrap();
+
+    let rid = db
+        .record(
+            "atomic commit probe",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    let conn = db.conn();
+    let row: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE rid = ?1",
+            rusqlite::params![rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let rec_op: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE op_type = 'record' AND target_rid = ?1 AND applied = 1",
+            rusqlite::params![rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let post_op: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE op_type = ?1 AND target_rid = ?2 AND applied = 0",
+            rusqlite::params![crate::engine::op_types::OP_MATERIALIZE_RECORD_POST, rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    drop(conn);
+
+    assert_eq!(row, 1, "memories row missing");
+    assert_eq!(rec_op, 1, "the record op did not commit with the row");
+    assert_eq!(
+        post_op, 1,
+        "the materialize enqueue did not commit with the row"
+    );
+
+    // The counter moves only after commit, and exactly once.
+    assert_eq!(
+        db.count_pending_ops().unwrap(),
+        pend_before + 1,
+        "pending_op_count did not track the committed enqueue"
+    );
+
+    // Published, therefore visible to search.
+    let hits = db
+        .recall(
+            &vec_seed(1.0, 8),
+            5,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+    assert!(
+        hits.iter().any(|h| h.rid == rid),
+        "committed record was not published to the index"
+    );
+}
+
 #[test]
 fn record_with_rid_backpressure_does_not_leak_orphan_memories_row() {
     // **v0.7.19 fix verification.** Reproduces the trader's

--- a/crates/yantrikdb-core/tests/kill_record_boundary.rs
+++ b/crates/yantrikdb-core/tests/kill_record_boundary.rs
@@ -1,0 +1,187 @@
+//! v0.10 Item 4a.6a — the record-boundary kill proof.
+//!
+//! This is the test that actually discriminates. Every other assertion about
+//! 4a.6a passes on the OLD code too, because the old design reached the same
+//! FINAL state by different means: it wrote the memories row, and if the vector
+//! append then failed it reclaimed the row with a compensating DELETE. Observing
+//! the end state cannot tell "never written" from "written then deleted".
+//!
+//! The difference is only visible when the process dies BETWEEN the row and its
+//! oplog provenance — which is exactly the failure the old comment in record.rs
+//! recorded as "over 39 days on trader's `default` DB, this leaked 23k rows".
+//! The compensating DELETE never covered that case: a crash beats it.
+//!
+//! Before 4a.6a: the memories INSERT autocommitted on its own, so a kill here
+//! left a durable row with NO oplog op — an orphan, invisible to replication and
+//! to any oplog inspector, and no compensation could run because the process was
+//! gone.
+//!
+//! After 4a.6a: the row, the session updates, the `record` op and the
+//! `materialize_record_post` enqueue share one transaction, so a kill at this
+//! boundary rolls back all of it. Neither half survives.
+//!
+//! Mechanics mirror `kill_link_boundary.rs` (v0.10 Phase 0): re-invoke this test
+//! binary to run the ignored child helper with the failpoint armed, wait for the
+//! handshake line with a bounded timeout (no sleep roulette), kill the child,
+//! reopen, and assert.
+#![cfg(feature = "testing")]
+
+use std::io::BufRead;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use yantrikdb::YantrikDB;
+
+fn test_vec(seed: f32, dim: usize) -> Vec<f32> {
+    let raw: Vec<f32> = (0..dim).map(|i| ((seed + i as f32) * 0.7).sin()).collect();
+    let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-9);
+    raw.iter().map(|x| x / norm).collect()
+}
+
+/// CHILD half — ignored in normal runs; the parent invokes it explicitly.
+#[test]
+#[ignore]
+fn child_parks_at_record_boundary() {
+    let db_path = std::env::var("YANTRIKDB_KILL_DB").expect("child needs YANTRIKDB_KILL_DB");
+    let db = YantrikDB::new(&db_path, 8).unwrap();
+
+    // Handshake BEFORE any write. The failpoint is armed process-wide via
+    // YANTRIKDB_FAILPOINTS and it lives inside record(), so a "baseline" record
+    // here would park at the failpoint before the parent ever saw us — unlike
+    // kill_link_boundary, whose failpoint is in link() and whose setup records
+    // freely. The engine is open at this point, which is all the parent needs.
+    println!("CHILD_READY:opened");
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    // Parks inside the transaction, after the memories INSERT, before the oplog
+    // op. The parent kills us here.
+    let _ = db.record(
+        "the record that must not survive",
+        "semantic",
+        0.5,
+        0.0,
+        604800.0,
+        &serde_json::json!({}),
+        &test_vec(2.0, 8),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    );
+    unreachable!("parent must kill us at the failpoint");
+}
+
+/// PARENT half — the actual proof.
+#[test]
+fn kill_between_record_row_and_oplog_leaves_neither() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("kill_record.db");
+    let db_path_str = db_path.to_str().unwrap().to_string();
+
+    let exe = std::env::current_exe().unwrap();
+    let mut child = Command::new(exe)
+        .args([
+            "child_parks_at_record_boundary",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("YANTRIKDB_KILL_DB", &db_path_str)
+        .env("YANTRIKDB_FAILPOINTS", "record.between_row_and_oplog")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn child");
+
+    let stdout = child.stdout.take().unwrap();
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stdout)
+            .lines()
+            .map_while(|l| l.ok())
+        {
+            let _ = tx.send(line);
+        }
+    });
+
+    let deadline = Duration::from_secs(60);
+    let mut saw_ready = false;
+    let mut saw_failpoint = false;
+    let start = std::time::Instant::now();
+    while start.elapsed() < deadline {
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(line) if line.starts_with("CHILD_READY:") => saw_ready = true,
+            Ok(line) if line == "FAILPOINT:record.between_row_and_oplog" => {
+                saw_failpoint = true;
+                break;
+            }
+            Ok(_) => {}
+            Err(_) => {
+                if let Ok(Some(_)) = child.try_wait() {
+                    break;
+                }
+            }
+        }
+    }
+    assert!(saw_ready, "child never opened the engine");
+    assert!(saw_failpoint, "child never hit the armed failpoint");
+
+    // Kill mid-transaction — the deterministic version of a crash.
+    child.kill().expect("kill child");
+    let _ = child.wait();
+
+    let db = YantrikDB::new(&db_path_str, 8).unwrap();
+    let conn = db.conn();
+
+    let qc: String = conn
+        .query_row("PRAGMA quick_check", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(qc, "ok", "quick_check after kill");
+
+    // THE assertion. On the pre-4a.6a code this row exists (its INSERT
+    // autocommitted) with no oplog op to account for it — a 23k-leak orphan.
+    let orphan: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE text = ?1",
+            rusqlite::params!["the record that must not survive"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        orphan, 0,
+        "a memories row survived the kill with no oplog provenance — the orphan leak"
+    );
+
+    // The killed write was the only write, so the database must be empty. On the
+    // pre-4a.6a code this is 1 — the autocommitted orphan.
+    let memories: i64 = conn
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(memories, 0, "the killed record's row survived");
+
+    let record_ops: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE op_type = 'record'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(record_ops, 0, "the killed write logged an op");
+
+    // Every surviving row has provenance: no row without an op, no op without a
+    // row. That is the invariant the old three-autocommit shape could not hold.
+    let rows_without_ops: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories m WHERE NOT EXISTS \
+             (SELECT 1 FROM oplog o WHERE o.op_type = 'record' AND o.target_rid = m.rid)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        rows_without_ops, 0,
+        "a memories row exists with no record op"
+    );
+}

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -183,8 +183,19 @@ class TestConsolidate:
         assert len(edges) > 0
 
     def test_importance_boosted(self, db):
-        db.record("Important fact A", importance=0.8, embedding=_vec(1.0))
-        db.record("Related fact B", importance=0.6, embedding=_vec(1.02))
+        # Entity-free text ON PURPOSE. consolidate()'s entity-overlap guard
+        # (require_entity_overlap, default True since v0.6.0) refuses to merge two
+        # memories whose entity sets are non-empty and DISJOINT. Capitalized text
+        # like "Important fact A" / "Related fact B" extracts distinct entities, so
+        # this test used to pass only when it outran the materializer that
+        # populates memory_entities — a race, proven by
+        # `diagnostic_consolidate_entity_overlap_guard_is_materializer_race`
+        # (no-drain: 0 entities -> 1 cluster; drained: 2 entities -> 0 clusters).
+        # Similarity here comes from the EXPLICIT embeddings below, so the text
+        # affects nothing except entity extraction: lowercasing it makes the test
+        # deterministic without weakening what it checks.
+        db.record("the fact that was written", importance=0.8, embedding=_vec(1.0))
+        db.record("the related fact nearby", importance=0.6, embedding=_vec(1.02))
 
         results = consolidate(db, sim_threshold=0.9)
         consolidated = db.get(results[0]["consolidated_rid"])
@@ -205,9 +216,12 @@ class TestConsolidate:
         assert mem2["importance"] < 0.2
 
     def test_stats_after_consolidation(self, db):
-        db.record("A1", importance=0.7, embedding=_vec(1.0))
-        db.record("A2", importance=0.6, embedding=_vec(1.02))
-        db.record("B1", importance=0.5, embedding=_vec(10.0))
+        # Entity-free text — see test_importance_boosted. "A1"/"A2" extracted as
+        # DISTINCT entities, so the entity-overlap guard blocked the merge
+        # whenever the materializer won the race, flaking this test ~50%.
+        db.record("the first note", importance=0.7, embedding=_vec(1.0))
+        db.record("the second note", importance=0.6, embedding=_vec(1.02))
+        db.record("an unrelated note", importance=0.5, embedding=_vec(10.0))
 
         assert db.stats()["active_memories"] == 3
         assert db.stats()["consolidated_memories"] == 0


### PR DESCRIPTION
`record()`'s sync path was **four independent autocommit windows**: the memories row, the session updates, `log_op("record")`, and the materialize enqueue — with a plain `vec_index.append` in the middle. A crash between any of them left a committed row with **no oplog provenance**. That's the leak record.rs recorded in its own comment:

> *"Over 39 days on trader's `default` DB, this leaked 23k rows."*

The mitigation was a best-effort compensating DELETE (plus a second patch, v0.7.23, to reverse the session `memory_count` the DELETE left behind). **A crash beats a compensation.**

## The change

Adopts the reserve → commit → publish protocol `correct()` has used since Item 3:

1. **Reserve** vector capacity before any durable mutation — Backpressure and dim errors surface having touched nothing.
2. **Commit** row + session updates + *both* oplog ops in **one transaction**.
3. **Publish** (infallible).

The compensating DELETE and the `memory_count` reversal are **deleted, not relocated** — the orphan class is structurally impossible now, not cleaned up after.

`append_reserved` already existed (delta_index.rs:255). This adopts a protocol the codebase had; it doesn't invent one.

Sol's design review chose this over both options I proposed, and killed the tombstone idea with a fact I'd missed: replication's export doesn't filter on `applied` (replication.rs:78), so a merely-*pending* op is already exportable — a compensating tombstone races the very crash it's meant to cover.

## The proof

**Every other assertion I wrote passed on the old code too.** The old design reached the same *final* state by writing the row and deleting it, and end-state assertions cannot distinguish "never written" from "written then deleted". Only a crash **between** the windows separates them — exactly the case the compensating DELETE never covered.

`kill_record_boundary.rs` reproduces the 23k leak deterministically. Killed at `record.between_row_and_oplog`:

```
OLD: assertion failed: a memories row survived the kill with no oplog provenance — the orphan leak
       left:  1
      right:  0
NEW: passes — neither half survives
```

Modelled on `kill_link_boundary.rs`, Phase 0's proof for `link_core`.

## New primitives

Generalized from `insert_correct_op_in_tx` (which `correct()` has used since Item 3 — now a thin wrapper, so there's **one** implementation):

- **`log_op_in_tx`** — `applied=1` oplog row in the caller's tx.
- **`log_op_pending_in_tx`** — `applied=0`, returns `(really_inserted, op_id)` and deliberately does **not** touch `pending_op_count`. Incrementing inside the tx would leak the counter upward on rollback with no row for `mark_op_applied` to decrement; that drift is monotonic, and at `MAX_PENDING_OPS` it wedges every foreground write into Backpressure **forever** with an empty queue in SQL. The caller increments only after commit.
- **`check_pending_backpressure`** — the admission gate, split out so it runs before the first side effect rather than after the row exists.
- **`MAX_PENDING_OPS`** hoisted to one module-level const (it was declared three times).

Lock order follows CONCURRENCY.md **Rule 1** (`conn → … → vec_index`): conn is held across reserve, tx and publish, exactly as `correct()` does — it's the only thing serializing append order with commit order (`SyncWriteGuard` is a counter, not a mutex). Rule 4's "drop conn before the second lock" targets non-O(1) work; a delta reserve/publish is an O(1) `Vec` push / flag flip.

## Two racy Python tests fixed — with proof they were always racy

4a.6a's timing shift made `test_consolidate` flake **~50%** (old code 6/6 clean; new 3/6 failing; reproduced 3/3 with `test_eval + test_consolidate`).

Cause: `consolidate()`'s entity-overlap guard refuses to merge memories with non-empty **disjoint** entity sets — by design, to stop cosine-only false merges across distinct named subjects. Entities are extracted **asynchronously**, so the tests only ever passed by outrunning the materializer. Proven by a new permanent test:

```
no-drain: memory_entities=0  clusters=1
drained : memory_entities=2  clusters=0
```

"A1"/"A2" extract as *distinct* entities. The tests supply embeddings explicitly, so their text affects nothing but entity extraction — entity-free text makes them deterministic without weakening what they check. **The engine was right both times; the tests encoded pre-guard behaviour.**

## Verification

Rust lib **1707**; all three kill proofs (record, link, correct); **FULL** Python suite **234 × 3** (was 3/6 failing before the test fix); fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)