### PR TITLE
fix(oplog+conflict): fresh-id producers swallowed failed inserts; the sweep found an FK abort, a whole-DB deadlock, and seed-member deletion

### DIFF
--- a/crates/yantrikdb-core/src/engine/conflict.rs
+++ b/crates/yantrikdb-core/src/engine/conflict.rs
@@ -916,14 +916,21 @@ impl YantrikDB {
                 let recurrence = self.count_reclassify_pair_occurrences(ta, tb);
                 if recurrence >= 1 {
                     let prov_name = format!("learned_{}_{}", ta, tb);
-                    let cat_id = crate::id::new_id();
-                    self.conn().execute(
-                        "INSERT OR IGNORE INTO substitution_categories
-                         (id, name, conflict_mode, status, created_at, updated_at, hlc, origin_actor)
-                         VALUES (?1, ?2, 'exclusive', 'provisional', ?3, ?3, ?4, ?5)",
-                        params![cat_id, prov_name, ts, hlc_bytes, actor],
+                    // `learned_{a}_{b}` can already exist while NEITHER token is
+                    // a known member: find_member_category (which fed known_a /
+                    // known_b above) matches only `m.status = 'active'`, so a
+                    // category ingested via learn_category_members with
+                    // source="llm_suggested" — whose members are 'pending' — is
+                    // invisible here and lands us in this branch on a name that
+                    // is already taken.
+                    let (cat_id, created) = self.ensure_substitution_category(
+                        &prov_name,
+                        "provisional",
+                        ts,
+                        &hlc_bytes,
+                        &actor,
                     )?;
-                    self.add_member_to_category(
+                    let ta_added = self.add_member_to_category(
                         &cat_id,
                         ta,
                         ta,
@@ -933,7 +940,7 @@ impl YantrikDB {
                         &hlc_bytes,
                         &actor,
                     )?;
-                    self.add_member_to_category(
+                    let tb_added = self.add_member_to_category(
                         &cat_id,
                         tb,
                         tb,
@@ -943,16 +950,25 @@ impl YantrikDB {
                         &hlc_bytes,
                         &actor,
                     )?;
-                    category_created = Some(prov_name.clone());
+                    // Report what actually happened, not what this branch
+                    // intended: on a pre-existing name we created no category,
+                    // and add_member_to_category returns whether the member was
+                    // really added (its UNIQUE(category_id, token_normalized)
+                    // ignore is a legitimate semantic no-op). Hardcoding
+                    // `Some(name)` / `is_new: true` published that fiction to the
+                    // oplog and to the Python caller.
+                    if created {
+                        category_created = Some(prov_name.clone());
+                    }
                     learned_members.push(LearnedMember {
                         token: ta.to_string(),
                         category_name: prov_name.clone(),
-                        is_new: true,
+                        is_new: ta_added,
                     });
                     learned_members.push(LearnedMember {
                         token: tb.to_string(),
                         category_name: prov_name,
-                        is_new: true,
+                        is_new: tb_added,
                     });
                 }
             }
@@ -1062,35 +1078,25 @@ impl YantrikDB {
         let hlc_bytes = hlc_ts.to_bytes().to_vec();
         let actor = self.actor_id.clone();
 
-        // Find or create category
-        let cat_id = match self.conn().query_row(
-            "SELECT id FROM substitution_categories WHERE name = ?1",
-            params![category_name],
-            |row| row.get::<_, String>(0),
-        ) {
-            Ok(id) => id,
-            Err(rusqlite::Error::QueryReturnedNoRows) => {
-                let id = crate::id::new_id();
-                self.conn().execute(
-                    "INSERT INTO substitution_categories
-                     (id, name, conflict_mode, status, created_at, updated_at, hlc, origin_actor)
-                     VALUES (?1, ?2, 'exclusive', 'active', ?3, ?3, ?4, ?5)",
-                    params![id, category_name, ts, hlc_bytes, actor],
-                )?;
-                self.log_op(
-                    "category_create",
-                    None,
-                    &serde_json::json!({
-                        "category_id": id,
-                        "name": category_name,
-                        "source": source,
-                    }),
-                    None,
-                )?;
-                id
-            }
-            Err(e) => return Err(e.into()),
-        };
+        // Find or create category. This site was already correct in shape — it
+        // re-read by name instead of trusting a fresh id — but SELECT-then-INSERT
+        // is a TOCTOU: two concurrent ingests both see "absent" and one takes a
+        // UNIQUE(name) violation. The shared helper closes that by letting the
+        // INSERT arbitrate and reading back the winner.
+        let (cat_id, created) =
+            self.ensure_substitution_category(category_name, "active", ts, &hlc_bytes, &actor)?;
+        if created {
+            self.log_op(
+                "category_create",
+                None,
+                &serde_json::json!({
+                    "category_id": cat_id,
+                    "name": category_name,
+                    "source": source,
+                }),
+                None,
+            )?;
+        }
 
         let status = if source == "llm_suggested" {
             "pending"
@@ -1180,6 +1186,51 @@ impl YantrikDB {
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
             )
             .ok()
+    }
+
+    /// Find-or-create a substitution category by its UNIQUE `name`. Returns the
+    /// id the table actually holds, and whether THIS call created it.
+    ///
+    /// **Why the id must be re-read, never assumed (sol #83 finding 2).**
+    /// `substitution_categories.name` is UNIQUE while `id` is a freshly-minted
+    /// surrogate. A fresh-id + `INSERT OR IGNORE` therefore skips the row on a
+    /// name collision and leaves the fresh id naming NOTHING — and every caller
+    /// here goes on to attach members with it, hitting the
+    /// `substitution_members.category_id` REFERENCES FK (enforced:
+    /// `PRAGMA foreign_keys=ON`). The surviving row's id is the only usable one,
+    /// so the winner is re-read rather than presumed to be ours.
+    ///
+    /// **Why `ON CONFLICT DO NOTHING` + re-read and not `SELECT`-then-`INSERT`.**
+    /// The latter is a TOCTOU: two callers both read "absent", both insert, and
+    /// one takes a UNIQUE violation. Letting the INSERT arbitrate and then
+    /// reading whoever won serializes against a concurrent creator — the
+    /// `graph_ops::ensure_proposition` shape, whose rationale (recover the
+    /// winner from the conflict rather than assume it) applies here for the same
+    /// reason: the name, not the id, is the real key.
+    fn ensure_substitution_category(
+        &self,
+        name: &str,
+        status: &str,
+        ts: f64,
+        hlc_bytes: &[u8],
+        actor: &str,
+    ) -> Result<(String, bool)> {
+        let fresh_id = crate::id::new_id();
+        let inserted = self.conn().execute(
+            "INSERT INTO substitution_categories
+             (id, name, conflict_mode, status, created_at, updated_at, hlc, origin_actor)
+             VALUES (?1, ?2, 'exclusive', ?3, ?4, ?4, ?5, ?6)
+             ON CONFLICT(name) DO NOTHING",
+            params![fresh_id, name, status, ts, hlc_bytes, actor],
+        )?;
+        // The INSERT may have been a no-op — re-read to get whichever id won,
+        // ours or an existing/racing creator's.
+        let id: String = self.conn().query_row(
+            "SELECT id FROM substitution_categories WHERE name = ?1",
+            params![name],
+            |row| row.get(0),
+        )?;
+        Ok((id, inserted > 0))
     }
 
     fn add_member_to_category(

--- a/crates/yantrikdb-core/src/engine/conflict.rs
+++ b/crates/yantrikdb-core/src/engine/conflict.rs
@@ -842,7 +842,11 @@ impl YantrikDB {
             // Only learn if there's exactly one meaningful unknown — ambiguity = skip
             if unknown_b.len() == 1 {
                 let token_b = unknown_b[0];
-                self.add_member_to_category(
+                // is_new is what add_member_to_category REPORTS, not what this
+                // branch hopes: the member may already exist (then it is promoted,
+                // not created). Hardcoding `true` published a fiction to the oplog
+                // and to the Python caller (sol #83 r2).
+                let added = self.add_member_to_category(
                     cat_id_a,
                     token_b,
                     token_b,
@@ -856,7 +860,7 @@ impl YantrikDB {
                 learned_members.push(LearnedMember {
                     token: token_b.to_string(),
                     category_name: cat_name_a.to_string(),
-                    is_new: true,
+                    is_new: added,
                 });
             }
         }
@@ -877,7 +881,9 @@ impl YantrikDB {
                 .collect();
             if unknown_a.len() == 1 {
                 let token_a = unknown_a[0];
-                self.add_member_to_category(
+                // Report what add_member_to_category actually did — see the twin
+                // site above.
+                let added = self.add_member_to_category(
                     cat_id_b,
                     token_a,
                     token_a,
@@ -891,7 +897,7 @@ impl YantrikDB {
                 learned_members.push(LearnedMember {
                     token: token_a.to_string(),
                     category_name: cat_name_b.to_string(),
-                    is_new: true,
+                    is_new: added,
                 });
             }
         }
@@ -1207,6 +1213,13 @@ impl YantrikDB {
     /// `graph_ops::ensure_proposition` shape, whose rationale (recover the
     /// winner from the conflict rather than assume it) applies here for the same
     /// reason: the name, not the id, is the real key.
+    ///
+    /// **One guard across both statements** (sol #83 r2): `conn()` is public, so
+    /// re-acquiring between the INSERT and the read-back would let a raw caller
+    /// delete the row in between (→ spurious `NoRows`) or delete-and-recreate it
+    /// (→ `inserted > 0` true while the id we return belongs to someone else's
+    /// row). Holding the lock across the pair makes "who won" a question with one
+    /// answer. Callers must therefore NOT hold the conn lock when calling this.
     fn ensure_substitution_category(
         &self,
         name: &str,
@@ -1216,7 +1229,8 @@ impl YantrikDB {
         actor: &str,
     ) -> Result<(String, bool)> {
         let fresh_id = crate::id::new_id();
-        let inserted = self.conn().execute(
+        let conn = self.conn();
+        let inserted = conn.execute(
             "INSERT INTO substitution_categories
              (id, name, conflict_mode, status, created_at, updated_at, hlc, origin_actor)
              VALUES (?1, ?2, 'exclusive', ?3, ?4, ?4, ?5, ?6)
@@ -1224,8 +1238,8 @@ impl YantrikDB {
             params![fresh_id, name, status, ts, hlc_bytes, actor],
         )?;
         // The INSERT may have been a no-op — re-read to get whichever id won,
-        // ours or an existing/racing creator's.
-        let id: String = self.conn().query_row(
+        // ours or an existing/racing creator's. NEVER assume fresh_id landed.
+        let id: String = conn.query_row(
             "SELECT id FROM substitution_categories WHERE name = ?1",
             params![name],
             |row| row.get(0),
@@ -1233,6 +1247,39 @@ impl YantrikDB {
         Ok((id, inserted > 0))
     }
 
+    /// Evidence strength of a member `source`. Higher wins.
+    ///
+    /// `llm_suggested` is the only source that lands a member as `'pending'`
+    /// (i.e. invisible to `find_member_category`, which reads `'active'` only),
+    /// so it is the weakest. `seed` is ships-with-the-schema ground truth and is
+    /// never overwritten by a runtime observation.
+    fn member_source_rank(source: &str) -> u8 {
+        match source {
+            "seed" => 3,
+            "user_confirmed" => 2,
+            "llm_suggested" => 1,
+            _ => 2, // unknown runtime sources are treated as confirmed-strength
+        }
+    }
+
+    /// Add a member to a category, PROMOTING an existing row when the incoming
+    /// evidence is stronger. Returns whether a NEW member row was created (so
+    /// callers can report `is_new` honestly).
+    ///
+    /// **Why this is not a plain `OR IGNORE` no-op (sol #83 r2).** The ignore
+    /// fires on `UNIQUE(category_id, token_normalized)`, and I originally argued
+    /// that made it a legitimate semantic no-op. It doesn't: skipping is only
+    /// harmless if the surviving row is EQUIVALENT to what we'd have written.
+    /// A member already present as `llm_suggested`/`'pending'` is *not*
+    /// equivalent to the `user_confirmed`/`'active'` row a reclassify wants — so
+    /// the ignore silently threw the user's confirmation away and left the pair
+    /// `'pending'`, which `find_member_category` cannot see. The substitution was
+    /// never learned and nothing reported a failure.
+    ///
+    /// **Promote, never demote.** `DO UPDATE ... WHERE` fires only when the
+    /// incoming source outranks the stored one, so a later `llm_suggested` gossip
+    /// cannot knock a `user_confirmed` member back to `'pending'` (the same data
+    /// loss in the other direction), and `seed` rows are immovable.
     fn add_member_to_category(
         &self,
         cat_id: &str,
@@ -1250,17 +1297,47 @@ impl YantrikDB {
         } else {
             "active"
         };
-        let rows = self.conn().execute(
-            "INSERT OR IGNORE INTO substitution_members
+        let rank = Self::member_source_rank(source);
+        let conn = self.conn();
+        let rows = conn.execute(
+            "INSERT INTO substitution_members
              (id, category_id, token_normalized, token_display, confidence,
               source, status, context_hint, created_at, updated_at, hlc, origin_actor)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?8, ?9, ?10)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?8, ?9, ?10)
+             ON CONFLICT(category_id, token_normalized) DO UPDATE SET
+               token_display = excluded.token_display,
+               confidence    = excluded.confidence,
+               source        = excluded.source,
+               status        = excluded.status,
+               updated_at    = excluded.updated_at,
+               hlc           = excluded.hlc,
+               origin_actor  = excluded.origin_actor
+             WHERE ?11 > CASE substitution_members.source
+                           WHEN 'seed' THEN 3
+                           WHEN 'user_confirmed' THEN 2
+                           WHEN 'llm_suggested' THEN 1
+                           ELSE 2
+                         END",
             params![
                 member_id, cat_id, normalized, display, confidence, source, status, ts, hlc_bytes,
-                actor
+                actor, rank
             ],
         )?;
-        Ok(rows > 0)
+        // `rows` counts the UPDATE too, so it cannot distinguish "created" from
+        // "promoted". Callers report is_new, so ask the row itself: our freshly
+        // minted id is present only if THIS call inserted.
+        if rows == 0 {
+            return Ok(false);
+        }
+        let created: bool = conn
+            .query_row(
+                "SELECT id = ?1 FROM substitution_members \
+                 WHERE category_id = ?2 AND token_normalized = ?3",
+                params![member_id, cat_id, normalized],
+                |r| r.get(0),
+            )
+            .unwrap_or(false);
+        Ok(created)
     }
 
     fn count_reclassify_pair_occurrences(&self, token_a: &str, token_b: &str) -> usize {

--- a/crates/yantrikdb-core/src/engine/conflict.rs
+++ b/crates/yantrikdb-core/src/engine/conflict.rs
@@ -22,6 +22,25 @@ pub struct ConflictBurndownReport {
     pub errors: Vec<String>,
 }
 
+/// The member evidence ladder, as SQL over an existing `substitution_members`
+/// row. Higher wins. THE single definition of "may this write beat what's
+/// stored?" for SQL callers — mirrors [`YantrikDB::member_source_rank`], and
+/// `member_source_rank_agrees_with_sql` pins the two together.
+///
+/// This exists as one shared constant because the alternative already failed:
+/// #83 gave `add_member_to_category` a rank guard, and Strategy 1 — which
+/// UPDATEs members directly, bypassing that helper — kept its own unguarded
+/// policy and went on rewriting `source='seed'` rows to `'user_confirmed'`.
+/// That silently made seed members deletable by `reset_category_to_seed` (which
+/// deletes `source != 'seed'`) and made untouched seed categories look
+/// user-expanded to the gossip trigger. One policy, one place, or the sites
+/// drift apart again (sol #83 r3).
+pub(crate) const MEMBER_SOURCE_RANK_SQL: &str = "CASE substitution_members.source \
+     WHEN 'seed' THEN 3 \
+     WHEN 'user_confirmed' THEN 2 \
+     WHEN 'llm_suggested' THEN 1 \
+     ELSE 2 END";
+
 /// Common English stopwords that should never be added to substitution categories.
 const RECLASSIFY_STOPWORDS: &[&str] = &[
     "a",
@@ -794,11 +813,33 @@ impl YantrikDB {
         for &(token_a, cat_id_a, cat_name_a) in &known_a {
             for &(token_b, cat_id_b, _cat_name_b) in &known_b {
                 if cat_id_a == cat_id_b {
-                    // Same category — reinforce confidence
+                    // Same category — reinforce confidence.
+                    //
+                    // `source` only moves UP the ladder (sol #83 r3). This UPDATE
+                    // bypasses add_member_to_category, so it must apply the SAME
+                    // policy rather than its own: it used to rewrite `source` to
+                    // 'user_confirmed' unconditionally, which quietly rebranded
+                    // SEED members as runtime ones. reset_category_to_seed deletes
+                    // `source != 'seed'`, so a reclassify of two seeded tokens
+                    // (e.g. postgresql/mysql, both seeded into "databases") made
+                    // them deletable by a later reset; the gossip trigger, which
+                    // keys on `source != 'seed'`, also then read an untouched seed
+                    // category as user-expanded.
+                    //
+                    // Confidence reinforcement is not provenance and applies to
+                    // every row: the user did confirm these two substitute.
+                    let rank_user_confirmed = Self::member_source_rank("user_confirmed");
                     self.conn().execute(
-                        "UPDATE substitution_members SET confidence = 1.0, source = 'user_confirmed', updated_at = ?1
-                         WHERE category_id = ?2 AND (token_normalized = ?3 OR token_normalized = ?4)",
-                        params![ts, cat_id_a, token_a, token_b],
+                        &format!(
+                            "UPDATE substitution_members SET \
+                               confidence = 1.0, \
+                               source = CASE WHEN ?1 > {MEMBER_SOURCE_RANK_SQL} \
+                                             THEN 'user_confirmed' ELSE source END, \
+                               updated_at = ?2 \
+                             WHERE category_id = ?3 \
+                               AND (token_normalized = ?4 OR token_normalized = ?5)"
+                        ),
+                        params![rank_user_confirmed, ts, cat_id_a, token_a, token_b],
                     )?;
                     if processed.insert(token_a.to_string()) {
                         learned_members.push(LearnedMember {
@@ -1104,11 +1145,10 @@ impl YantrikDB {
             )?;
         }
 
-        let status = if source == "llm_suggested" {
-            "pending"
-        } else {
-            "active"
-        };
+        // (No local `status` here: add_member_to_category derives it from
+        // `source` itself. A dead duplicate of that policy sat here for
+        // releases — the kind of thing someone eventually "fixes" by wiring it
+        // up and forking the rule. sol #83 r3.)
         let mut added = 0;
 
         for (token, confidence) in members {
@@ -1253,7 +1293,10 @@ impl YantrikDB {
     /// (i.e. invisible to `find_member_category`, which reads `'active'` only),
     /// so it is the weakest. `seed` is ships-with-the-schema ground truth and is
     /// never overwritten by a runtime observation.
-    fn member_source_rank(source: &str) -> u8 {
+    ///
+    /// Must agree with [`MEMBER_SOURCE_RANK_SQL`] — pinned by
+    /// `member_source_rank_agrees_with_sql`.
+    pub(crate) fn member_source_rank(source: &str) -> u8 {
         match source {
             "seed" => 3,
             "user_confirmed" => 2,
@@ -1300,24 +1343,21 @@ impl YantrikDB {
         let rank = Self::member_source_rank(source);
         let conn = self.conn();
         let rows = conn.execute(
-            "INSERT INTO substitution_members
-             (id, category_id, token_normalized, token_display, confidence,
-              source, status, context_hint, created_at, updated_at, hlc, origin_actor)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?8, ?9, ?10)
-             ON CONFLICT(category_id, token_normalized) DO UPDATE SET
-               token_display = excluded.token_display,
-               confidence    = excluded.confidence,
-               source        = excluded.source,
-               status        = excluded.status,
-               updated_at    = excluded.updated_at,
-               hlc           = excluded.hlc,
-               origin_actor  = excluded.origin_actor
-             WHERE ?11 > CASE substitution_members.source
-                           WHEN 'seed' THEN 3
-                           WHEN 'user_confirmed' THEN 2
-                           WHEN 'llm_suggested' THEN 1
-                           ELSE 2
-                         END",
+            &format!(
+                "INSERT INTO substitution_members
+                 (id, category_id, token_normalized, token_display, confidence,
+                  source, status, context_hint, created_at, updated_at, hlc, origin_actor)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?8, ?9, ?10)
+                 ON CONFLICT(category_id, token_normalized) DO UPDATE SET
+                   token_display = excluded.token_display,
+                   confidence    = excluded.confidence,
+                   source        = excluded.source,
+                   status        = excluded.status,
+                   updated_at    = excluded.updated_at,
+                   hlc           = excluded.hlc,
+                   origin_actor  = excluded.origin_actor
+                 WHERE ?11 > {MEMBER_SOURCE_RANK_SQL}"
+            ),
             params![
                 member_id, cat_id, normalized, display, confidence, source, status, ts, hlc_bytes,
                 actor, rank

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1375,8 +1375,14 @@ impl YantrikDB {
 
         let conn = self.conn.lock();
         self.check_pending_backpressure_locked()?;
+        // Plain INSERT, not OR IGNORE. This is the QUEUED write's only durable
+        // record — record_queued() writes no memories row (by design), so this op
+        // IS the write. `OR IGNORE` here meant any swallowed constraint violation
+        // made record_queued() return a rid and Ok while persisting NOTHING: the
+        // caller's write vanished silently. The op_id is minted fresh two lines
+        // up, so no caller could ever have needed the ignore.
         conn.execute(
-            "INSERT OR IGNORE INTO oplog \
+            "INSERT INTO oplog \
              (op_id, op_type, timestamp, target_rid, payload, \
               actor_id, hlc, embedding_hash, origin_actor, applied, \
               embedding, embedding_model, applied_generation) \
@@ -1394,9 +1400,8 @@ impl YantrikDB {
                 embedding_model,
             ],
         )?;
-        if conn.changes() > 0 {
-            self.pending_op_count.fetch_add(1, Ordering::Relaxed);
-        }
+        // Unconditional: a plain INSERT that returned Ok wrote exactly one row.
+        self.pending_op_count.fetch_add(1, Ordering::Relaxed);
         Ok(op_id)
     }
 }

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1400,7 +1400,11 @@ impl YantrikDB {
                 embedding_model,
             ],
         )?;
-        // Unconditional: a plain INSERT that returned Ok wrote exactly one row.
+        // Unconditional: a plain INSERT that returned Ok inserted exactly one
+        // row. That is a claim about this statement, not about durability — a
+        // caller wrapping its own rolled-back SAVEPOINT around this (via the
+        // public `conn()`) still leaves the counter high. See the fuller note in
+        // `log_op_pending` (sol #83 finding 3).
         self.pending_op_count.fetch_add(1, Ordering::Relaxed);
         Ok(op_id)
     }

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -239,19 +239,22 @@ impl YantrikDB {
     /// Uses a plain `INSERT`, NOT `INSERT OR IGNORE` — and that difference is
     /// deliberate (sol, 4a.6a review finding 4).
     ///
-    /// [`Self::log_op_pending`] uses `OR IGNORE` because it has cluster-replay
-    /// callers that re-use an existing `op_id`, where a silent no-op is the
-    /// correct outcome. This function mints a FRESH `op_id` and has no such
-    /// caller, so "ignored" could only mean an id collision or some other
-    /// constraint — and swallowing it would let the record transaction commit and
-    /// `record()` return `Ok` while the post-materialization enqueue silently did
-    /// not happen. That write's entity materialization would then be owed to
-    /// nobody, forever, which is the exact failure moving the enqueue into the
-    /// transaction was meant to prevent. A plain INSERT turns that into the error
-    /// it is, rolling the whole write back.
+    /// This function mints a FRESH `op_id`, so "ignored" could only ever mean an
+    /// id collision or some other constraint — and swallowing it would let the
+    /// record transaction commit and `record()` return `Ok` while the
+    /// post-materialization enqueue silently did not happen. That write's entity
+    /// materialization would then be owed to nobody, forever, which is the exact
+    /// failure moving the enqueue into the transaction was meant to prevent. A
+    /// plain INSERT turns that into the error it is, rolling the whole write back.
     ///
-    /// (I originally copied `OR IGNORE` from `log_op_pending` without checking
-    /// whether its rationale applied here. It did not.)
+    /// (I originally copied `OR IGNORE` from [`Self::log_op_pending`] without
+    /// checking whether its rationale applied here. It did not — and this doc
+    /// then spent a release asserting that `log_op_pending` needed `OR IGNORE`
+    /// "because it has cluster-replay callers that re-use an existing `op_id`".
+    /// That was false: it mints its own id and no caller can supply one, so the
+    /// ignore there could never fire for the stated reason and only ever hid real
+    /// violations. #83 made it a plain INSERT too. The rationale I copied was
+    /// never real anywhere — sol #83 r2 caught this paragraph still teaching it.)
     ///
     /// Returns the op_id. Deliberately does NOT touch `pending_op_count`: the
     /// counter may only move AFTER the enclosing transaction commits — increment

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -469,11 +469,20 @@ impl YantrikDB {
             ],
         )?;
         // **v0.7.1**: maintain the cached counter.
-        // Unconditional: with a plain INSERT, reaching here means exactly one row
-        // landed — anything else returned Err above. The old `changes() > 0` guard
+        // Unconditional: a plain INSERT that returned Ok inserted exactly one
+        // row — anything else is an Err above. The old `changes() > 0` guard
         // existed to cope with `OR IGNORE` no-ops that could not happen for the
         // documented reason (no caller can supply an op_id), and it turned a
         // swallowed constraint violation into a silently-correct-looking count.
+        //
+        // Scope of that claim (sol #83 finding 3): it is about THIS statement,
+        // not about durability. `conn()` is public, so a caller that opens its
+        // own SAVEPOINT around this and rolls back leaves the row gone and this
+        // counter high — pre-existing, and not something `changes()` ever
+        // caught either. The counter is a cache over `applied = 0` and re-seeds
+        // on restart; the in-transaction sibling (`log_op_pending_in_tx`)
+        // deliberately leaves it alone precisely because only its committer
+        // knows the outcome.
         self.pending_op_count.fetch_add(1, Ordering::Relaxed);
         Ok(op_id)
     }
@@ -1373,8 +1382,12 @@ mod pending_ops_tests {
         assert_eq!(db.count_pending_ops().unwrap(), 0, "no pending after mark");
     }
 
+    /// NOT a typo: this asserts the OPPOSITE of idempotency, which is the real
+    /// contract. It was named `pending_op_idempotent_on_double_append` — a lie
+    /// that agreed with the rustdoc `log_op_pending` used to carry, and which
+    /// justified the `INSERT OR IGNORE` this test's own body disproves.
     #[test]
-    fn pending_op_idempotent_on_double_append() {
+    fn pending_op_double_append_writes_two_distinct_rows() {
         let db = open_test_db();
         let payload = serde_json::json!({"rid": "rid_idem"});
         let emb_bytes = fake_embedding(2.0, 64);

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -405,8 +405,17 @@ impl YantrikDB {
     /// Phase 1 (this version), the API is exposed for tests and for Phase 3
     /// worker scaffolding.
     ///
-    /// Idempotent on op_id: if the same op_id is appended twice (e.g., via
-    /// crash-restart replay), the second INSERT is silently skipped.
+    /// **NOT idempotent on op_id, and cannot be.** This rustdoc used to claim
+    /// "if the same op_id is appended twice (e.g. via crash-restart replay), the
+    /// second INSERT is silently skipped" — describing a capability the signature
+    /// does not offer: there is no `op_id` parameter, so a caller CANNOT supply
+    /// one. Every call mints a fresh id (below), so the `OR IGNORE` that claim
+    /// justified could never fire for the reason given, and instead silently
+    /// swallowed real constraint violations — returning `Ok(op_id)` for a row
+    /// that was never written. This now uses a plain INSERT so a failure to
+    /// enqueue is an error, not a fiction. (The genuine replay case is
+    /// replication apply, which really does receive a remote op_id and inserts it
+    /// itself.)
     pub fn log_op_pending(
         &self,
         op_type: &str,
@@ -442,7 +451,7 @@ impl YantrikDB {
         // instance, not the class.
         self.check_pending_backpressure_locked()?;
         conn.execute(
-            "INSERT OR IGNORE INTO oplog \
+            "INSERT INTO oplog \
              (op_id, op_type, timestamp, target_rid, payload, \
               actor_id, hlc, embedding_hash, origin_actor, applied, embedding) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0, ?10)",
@@ -460,12 +469,12 @@ impl YantrikDB {
             ],
         )?;
         // **v0.7.1**: maintain the cached counter. INSERT OR IGNORE on
-        // op_id PK means the row may not actually have been added (caller
-        // re-using an op_id is the cluster-replay shape). Check the
-        // changes count to only increment on a real insert.
-        if conn.changes() > 0 {
-            self.pending_op_count.fetch_add(1, Ordering::Relaxed);
-        }
+        // Unconditional: with a plain INSERT, reaching here means exactly one row
+        // landed — anything else returned Err above. The old `changes() > 0` guard
+        // existed to cope with `OR IGNORE` no-ops that could not happen for the
+        // documented reason (no caller can supply an op_id), and it turned a
+        // swallowed constraint violation into a silently-correct-looking count.
+        self.pending_op_count.fetch_add(1, Ordering::Relaxed);
         Ok(op_id)
     }
 

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -468,7 +468,7 @@ impl YantrikDB {
                 embedding,
             ],
         )?;
-        // **v0.7.1**: maintain the cached counter. INSERT OR IGNORE on
+        // **v0.7.1**: maintain the cached counter.
         // Unconditional: with a plain INSERT, reaching here means exactly one row
         // landed — anything else returned Err above. The old `changes() > 0` guard
         // existed to cope with `OR IGNORE` no-ops that could not happen for the

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -6524,6 +6524,49 @@ fn reclassify_reuses_existing_category_when_name_already_taken() {
         "no members stranded under a non-existent category"
     );
 
+    // The user_confirmed reclassify must PROMOTE the pre-existing pending/
+    // llm_suggested rows, not silently skip them (sol #83 r2). Before this, the
+    // UNIQUE(category_id, token_normalized) ignore left both members 'pending' —
+    // and find_member_category reads only 'active', so the pair stayed invisible
+    // to every later classification. The user's confirmation was thrown away with
+    // no error: the same silent-loss class as the rest of this item.
+    let promoted: Vec<(String, String, String)> = db
+        .conn()
+        .prepare(
+            "SELECT token_normalized, source, status FROM substitution_members \
+             WHERE category_id = ?1 ORDER BY token_normalized",
+        )
+        .unwrap()
+        .query_map(rusqlite::params![pre_id], |r| {
+            Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+        })
+        .unwrap()
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap();
+    for (tok, source, status) in &promoted {
+        assert_eq!(
+            (source.as_str(), status.as_str()),
+            ("user_confirmed", "active"),
+            "{tok} must be promoted to user_confirmed/active, got {source}/{status}"
+        );
+    }
+
+    // The POINT of promoting: the learned pair is now visible to later
+    // classification, which is what reclassify claimed to have achieved.
+    let visible: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM substitution_members \
+             WHERE token_normalized IN ('zorblat', 'quibnix') AND status = 'active'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        visible, 2,
+        "both learned tokens are findable as active members"
+    );
+
     // ...and both tokens still hang off the SURVIVING category.
     let members: Vec<String> = db
         .conn()
@@ -6593,6 +6636,64 @@ fn learn_category_members_creates_new_category_without_deadlocking() {
              self.conn() re-locked inside a match arm whose scrutinee still holds the guard"
         ),
     }
+}
+
+/// The other half of "promote, never demote" (sol #83 r2). Promoting is the
+/// obvious direction; the silent loss runs both ways. A later `llm_suggested`
+/// gossip must NOT knock a `user_confirmed` member back to `'pending'`, which
+/// would make an already-learned substitution vanish from
+/// `find_member_category` — the same invisibility, arrived at from the other
+/// side. `seed` outranks everything and is never overwritten.
+#[test]
+fn learn_category_members_promotes_but_never_demotes() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+
+    // Weak evidence first: lands 'pending'.
+    db.learn_category_members("promo_cat", &[("tok".to_string(), 0.4)], "llm_suggested")
+        .unwrap();
+    let row = |db: &YantrikDB| -> (String, String, f64) {
+        db.conn()
+            .query_row(
+                "SELECT source, status, confidence FROM substitution_members \
+                 WHERE token_normalized = 'tok'",
+                [],
+                |r| Ok((r.get(0).unwrap(), r.get(1).unwrap(), r.get(2).unwrap())),
+            )
+            .unwrap()
+    };
+    assert_eq!(
+        (row(&db).0.as_str(), row(&db).1.as_str()),
+        ("llm_suggested", "pending"),
+        "llm_suggested starts pending"
+    );
+
+    // Stronger evidence: PROMOTES.
+    db.learn_category_members("promo_cat", &[("tok".to_string(), 0.9)], "user_confirmed")
+        .unwrap();
+    let (source, status, conf) = row(&db);
+    assert_eq!(
+        (source.as_str(), status.as_str()),
+        ("user_confirmed", "active"),
+        "user_confirmed promotes the pending row"
+    );
+    assert!(
+        (conf - 0.9).abs() < 1e-9,
+        "confidence promoted too, got {conf}"
+    );
+
+    // Weak evidence again: must NOT demote.
+    db.learn_category_members("promo_cat", &[("tok".to_string(), 0.1)], "llm_suggested")
+        .unwrap();
+    let (source, status, conf) = row(&db);
+    assert_eq!(
+        (source.as_str(), status.as_str()),
+        ("user_confirmed", "active"),
+        "a later llm_suggested must not demote a user_confirmed member"
+    );
+    assert!(
+        (conf - 0.9).abs() < 1e-9,
+        "confidence must not be clobbered by weaker evidence, got {conf}"
+    );
 }
 
 // ── Relationship-Based Entity Type Tests ──

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -6599,8 +6599,13 @@ fn reclassify_reuses_existing_category_when_name_already_taken() {
 ///
 /// Reachable from the public Python binding (`learn_category_members(...,
 /// source="llm_suggested")`). The fix (`ensure_substitution_category`) removes the
-/// nesting: the INSERT and the read-back are separate statements, each releasing
-/// the guard.
+/// RE-LOCK: it acquires `conn` ONCE and runs both the INSERT and the read-back on
+/// that single guard, so there is no second `self.conn()` to deadlock against.
+///
+/// Note it deliberately does NOT drop the guard between the two statements —
+/// holding it across the pair is what makes "who won the name" a question with one
+/// answer (see the helper's own doc). Splitting them into separate acquisitions
+/// would fix the deadlock too, and quietly reopen that gap.
 ///
 /// Runs on a worker with a deadline so the deadlock FAILS this test instead of
 /// hanging the whole suite.

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -6384,6 +6384,217 @@ fn test_conflict_entity_substitution_tech() {
     assert!(conflicts.len() >= 0);
 }
 
+/// sol #83 finding 2: reclassify's provisional-category branch minted a FRESH
+/// `cat_id`, `INSERT OR IGNORE`d it, then attached members with that id — so on a
+/// `UNIQUE(name)` collision the id named NO row and the members hit the
+/// `substitution_members.category_id` FK (`IGNORE` resolves as `ABORT` for FK
+/// errors), failing a legitimate reclassify.
+///
+/// The collision is reachable because `find_member_category` — which decides
+/// "unknown token", routing us into this branch — matches only
+/// `m.status = 'active'`, while `learn_category_members(source="llm_suggested")`
+/// (public, via the Python binding) creates members as `'pending'`. So the
+/// category name is taken while both its tokens still look unknown.
+///
+/// Fails on the unfixed code with a FOREIGN KEY constraint error.
+#[test]
+fn reclassify_reuses_existing_category_when_name_already_taken() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+
+    // A category whose name is exactly what strategy 3 will mint, with 'pending'
+    // members so both tokens still read as unknown to find_member_category.
+    //
+    // Set up via raw SQL rather than learn_category_members ON PURPOSE: that API
+    // deadlocks while creating a new category (see
+    // learn_category_members_creates_new_category_without_deadlocking), and
+    // routing this test through it would make it hang before it ever reached the
+    // behavior under test. One test, one claim.
+    // Invented tokens ON PURPOSE: the schema seeds real categories (redis, for
+    // instance, ships as an active member of "databases"), and any seeded token
+    // makes find_member_category return Some → known_a non-empty → strategy 2
+    // handles it and strategy 3 never runs. An earlier draft of this test used
+    // redis/memcached and passed against the UNFIXED code for exactly that
+    // reason — it never reached the branch it was written to cover.
+    let pre_id = "cat_pre_existing";
+    {
+        let conn = db.conn();
+        conn.execute(
+            "INSERT INTO substitution_categories \
+             (id, name, conflict_mode, status, created_at, updated_at, hlc, origin_actor) \
+             VALUES (?1, 'learned_zorblat_quibnix', 'exclusive', 'active', 1.0, 1.0, X'00', 'test')",
+            rusqlite::params![pre_id],
+        )
+        .unwrap();
+        for (i, tok) in ["zorblat", "quibnix"].iter().enumerate() {
+            conn.execute(
+                "INSERT INTO substitution_members \
+                 (id, category_id, token_normalized, token_display, confidence, source, \
+                  status, created_at, updated_at, hlc, origin_actor) \
+                 VALUES (?1, ?2, ?3, ?3, 1.0, 'llm_suggested', 'pending', 1.0, 1.0, X'00', 'test')",
+                rusqlite::params![format!("m{i}"), pre_id, tok],
+            )
+            .unwrap();
+        }
+    }
+
+    // Two memories differing by exactly one meaningful token per side.
+    let mk = |text: &str, emb: &[f32]| {
+        db.record(
+            text,
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            emb,
+            "default",
+            0.8,
+            "work",
+            "user",
+            None,
+        )
+        .unwrap()
+    };
+    let a = mk("the config sets zorblat for caching", &vec_seed(1.0, 8));
+    let b = mk("the config sets quibnix for caching", &vec_seed(1.1, 8));
+
+    let mk_conflict = |id: &str| {
+        db.conn()
+            .execute(
+                "INSERT INTO conflicts \
+                 (conflict_id, conflict_type, priority, status, memory_a, memory_b, \
+                  detected_at, detected_by, detection_reason, hlc, origin_actor) \
+                 VALUES (?1, 'redundancy', 'medium', 'open', ?2, ?3, 2000.0, 'test', \
+                         'same attribute, different value', X'00', 'test')",
+                rusqlite::params![id, a, b],
+            )
+            .unwrap();
+    };
+    mk_conflict("cf1");
+    mk_conflict("cf2");
+
+    // First pass seeds the recurrence (strategy 3 requires a PRIOR
+    // conflict_reclassify carrying this token pair).
+    db.reclassify_conflict("cf1", "semantic").unwrap();
+
+    // Second pass: recurrence >= 1, both tokens unknown → strategy 3 mints
+    // "learned_zorblat_quibnix", which already exists. This is the call that
+    // failed before the fix (FOREIGN KEY constraint).
+    let res = db
+        .reclassify_conflict("cf2", "semantic")
+        .expect("reclassify must reuse the existing category, not die on its FK");
+
+    // Guard against a vacuous pass: prove strategy 3 ACTUALLY RAN. Without this,
+    // the assertions below hold trivially on any code path that never reaches
+    // the branch under test — which is exactly how the first draft of this test
+    // passed against the unfixed code.
+    assert!(
+        res.learned_members
+            .iter()
+            .any(|m| m.category_name == "learned_zorblat_quibnix"),
+        "strategy 3 must have run and targeted the colliding name, got {:?}",
+        res.learned_members
+    );
+
+    // The name still resolves to ONE category — the pre-existing one.
+    let n: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM substitution_categories WHERE name = 'learned_zorblat_quibnix'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(n, 1, "no duplicate category row");
+
+    // No member may reference a category id that doesn't exist. This is the
+    // invariant the fresh-id + OR IGNORE shape broke; asserting it directly
+    // catches the bug whether or not the FK happens to be enforced.
+    let orphans: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM substitution_members m \
+             WHERE NOT EXISTS (SELECT 1 FROM substitution_categories c WHERE c.id = m.category_id)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        orphans, 0,
+        "no members stranded under a non-existent category"
+    );
+
+    // ...and both tokens still hang off the SURVIVING category.
+    let members: Vec<String> = db
+        .conn()
+        .prepare(
+            "SELECT token_normalized FROM substitution_members \
+             WHERE category_id = ?1 ORDER BY token_normalized",
+        )
+        .unwrap()
+        .query_map(rusqlite::params![pre_id], |r| r.get(0))
+        .unwrap()
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap();
+    assert!(
+        members.contains(&"zorblat".to_string()) && members.contains(&"quibnix".to_string()),
+        "members belong to the surviving category, got {members:?}"
+    );
+}
+
+/// `learn_category_members` deadlocked outright on the branch that CREATES a
+/// category — i.e. the half its own doc comment advertises ("Creates the category
+/// if it doesn't exist"). Found while proving the #83 finding-2 regression test:
+/// that test hung here during setup instead of reaching the bug it targeted.
+///
+/// Cause: the `MutexGuard` from `self.conn()` sat in a `match` SCRUTINEE. Rust
+/// keeps scrutinee temporaries alive until the end of the whole `match`, so the
+/// guard was still held inside the `QueryReturnedNoRows` arm when that arm called
+/// `self.conn()` again — a re-lock of a non-reentrant `parking_lot::Mutex` on the
+/// same thread. It wedges the entire DB, not just the caller: every other writer
+/// then blocks on `conn` forever.
+///
+/// Reachable from the public Python binding (`learn_category_members(...,
+/// source="llm_suggested")`). The fix (`ensure_substitution_category`) removes the
+/// nesting: the INSERT and the read-back are separate statements, each releasing
+/// the guard.
+///
+/// Runs on a worker with a deadline so the deadlock FAILS this test instead of
+/// hanging the whole suite.
+#[test]
+fn learn_category_members_creates_new_category_without_deadlocking() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        let r = db.learn_category_members(
+            "brand_new_category",
+            &[("alpha".to_string(), 1.0), ("beta".to_string(), 1.0)],
+            "user_confirmed",
+        );
+        let n: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM substitution_categories WHERE name = 'brand_new_category'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(-1);
+        let _ = tx.send((r.map_err(|e| e.to_string()), n));
+    });
+
+    match rx.recv_timeout(std::time::Duration::from_secs(30)) {
+        Ok((res, n)) => {
+            let added = res.expect("learn_category_members must create the category");
+            assert_eq!(added, 2, "both members ingested");
+            assert_eq!(n, 1, "the new category row exists");
+        }
+        Err(_) => panic!(
+            "learn_category_members deadlocked creating a new category: \
+             self.conn() re-locked inside a match arm whose scrutinee still holds the guard"
+        ),
+    }
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -6696,6 +6696,158 @@ fn learn_category_members_promotes_but_never_demotes() {
     );
 }
 
+/// Strategy 1 UPDATEs members directly instead of going through
+/// `add_member_to_category`, so #83's rank guard did not cover it and it kept
+/// rewriting `source` to 'user_confirmed' unconditionally — including
+/// `source='seed'` rows (sol #83 r3).
+///
+/// That is not cosmetic. `reset_category_to_seed` deletes `source != 'seed'`, so
+/// a reclassify of two SEEDED tokens made them deletable by a later reset; and
+/// the gossip trigger keys on `source != 'seed'`, so an untouched seed category
+/// started reading as user-expanded.
+///
+/// `postgresql` and `mysql` both ship seeded into "databases", so this is the
+/// real, default-configuration path — no fixture needed.
+#[test]
+fn reclassify_reinforcement_does_not_rebrand_seed_members() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+
+    let seed_sources = |db: &YantrikDB| -> Vec<(String, String)> {
+        db.conn()
+            .prepare(
+                "SELECT token_normalized, source FROM substitution_members \
+                 WHERE token_normalized IN ('postgresql', 'mysql') ORDER BY token_normalized",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert_eq!(
+        seed_sources(&db),
+        vec![
+            ("mysql".to_string(), "seed".to_string()),
+            ("postgresql".to_string(), "seed".to_string()),
+        ],
+        "precondition: both ship as seed members"
+    );
+
+    let mk = |text: &str, emb: &[f32]| {
+        db.record(
+            text,
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            emb,
+            "default",
+            0.8,
+            "work",
+            "user",
+            None,
+        )
+        .unwrap()
+    };
+    let a = mk("the service stores rows in postgresql", &vec_seed(1.0, 8));
+    let b = mk("the service stores rows in mysql", &vec_seed(1.1, 8));
+    db.conn()
+        .execute(
+            "INSERT INTO conflicts \
+             (conflict_id, conflict_type, priority, status, memory_a, memory_b, \
+              detected_at, detected_by, detection_reason, hlc, origin_actor) \
+             VALUES ('cf_seed', 'redundancy', 'medium', 'open', ?1, ?2, 2000.0, 'test', \
+                     'same attribute, different value', X'00', 'test')",
+            rusqlite::params![a, b],
+        )
+        .unwrap();
+
+    // Both tokens are known active members of the SAME category → strategy 1.
+    db.reclassify_conflict("cf_seed", "semantic").unwrap();
+
+    assert_eq!(
+        seed_sources(&db),
+        vec![
+            ("mysql".to_string(), "seed".to_string()),
+            ("postgresql".to_string(), "seed".to_string()),
+        ],
+        "seed provenance must survive a user_confirmed reinforcement"
+    );
+
+    // The consequence that made it data loss: a later reset must not delete them.
+    let removed = db.reset_category_to_seed("databases").unwrap();
+    let survivors: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM substitution_members \
+             WHERE token_normalized IN ('postgresql', 'mysql')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        survivors, 2,
+        "reset_category_to_seed deleted seed members that reclassify had rebranded \
+         (removed {removed})"
+    );
+}
+
+/// The Rust ladder (`member_source_rank`, which computes the INCOMING rank) and
+/// the SQL ladder (`MEMBER_SOURCE_RANK_SQL`, which computes the STORED rank) are
+/// two spellings of one policy that must agree — every rank guard compares one
+/// against the other, so a silent disagreement re-opens exactly the demotion bug
+/// this pins shut.
+///
+/// This evaluates the REAL constant, not a copy of it. (The first draft inlined
+/// its own third copy of the CASE, which would have pinned the Rust fn against
+/// the test's private duplicate and gone on passing while the two real
+/// definitions drifted — the same mistake this whole PR is about, committed
+/// inside the test written to prevent it.)
+#[test]
+fn member_source_rank_agrees_with_sql() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let conn = db.conn();
+    conn.execute(
+        "INSERT INTO substitution_categories \
+         (id, name, conflict_mode, status, created_at, updated_at, hlc, origin_actor) \
+         VALUES ('rc', 'rank_probe_cat', 'exclusive', 'active', 1.0, 1.0, X'00', 't')",
+        [],
+    )
+    .unwrap();
+
+    for (i, source) in ["seed", "user_confirmed", "llm_suggested", "something_else"]
+        .iter()
+        .enumerate()
+    {
+        let tok = format!("tok{i}");
+        conn.execute(
+            "INSERT INTO substitution_members \
+             (id, category_id, token_normalized, token_display, confidence, source, \
+              status, context_hint, created_at, updated_at, hlc, origin_actor) \
+             VALUES (?1, 'rc', ?2, ?2, 1.0, ?3, 'active', NULL, 1.0, 1.0, X'00', 't')",
+            rusqlite::params![format!("rp{i}"), tok, source],
+        )
+        .unwrap();
+
+        let sql_rank: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT {} FROM substitution_members WHERE token_normalized = ?1",
+                    crate::engine::conflict::MEMBER_SOURCE_RANK_SQL
+                ),
+                rusqlite::params![tok],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let rust_rank = YantrikDB::member_source_rank(source);
+        assert_eq!(
+            sql_rank, rust_rank as i64,
+            "rank ladders disagree for source '{source}'"
+        );
+    }
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]


### PR DESCRIPTION
`log_op_pending` (stats.rs) and `log_op_pending_for_reembed_queue` (record.rs) both mint a **fresh** `op_id` and then used `INSERT OR IGNORE`.

Neither has — or *can* have — a caller that supplies an `op_id`: there's no such parameter in either signature. So the ignore could never fire for the reason its rustdoc gave:

> *"Idempotent on op_id: if the same op_id is appended twice (e.g., via crash-restart replay), the second INSERT is silently skipped."*

That describes a capability the API doesn't offer. What `OR IGNORE` actually did was **swallow real constraint violations** and return `Ok(op_id)` for a row that was never written.

## The queued path is the bad one

`record_queued()` deliberately writes **no memories row** — the pending oplog op *is* the write. An ignored insert therefore returned a rid and `Ok` while persisting **nothing at all**. The caller's write vanished, silently, with no error anywhere.

Same class as #79 (batch never replicated), #80 (mention_count inflation), #81 (batch router bypass): nothing throws, the data is just gone.

## The fix

Plain `INSERT` in both, so a failure to enqueue is an error rather than a fiction. The `conn.changes() > 0` guard on the counter becomes unconditional — it only existed to account for ignores that couldn't legitimately happen, and it made a swallowed violation look like a correct count.

## The rule, restated after review

The first version of this PR claimed the rule was **"fresh id → plain INSERT; received id → `OR IGNORE`"** and that the category was swept because exactly one `INSERT OR IGNORE INTO oplog` remained. sol rejected that, correctly, and both halves needed fixing.

Then round 2 **rejected my replacement rule too**, which is the more useful lesson. I'd written: *"`OR IGNORE` is legitimate when the ignore fires on a constraint whose violation is a semantically expected no-op"*, and concluded `add_member_to_category` was therefore fine as-is. It wasn't — see below. The exemption was too broad.

The rule, third time, now with the clause that actually does the work:

> `OR IGNORE` is legitimate **iff** the ignore fires on a constraint whose violation means the surviving row is **semantically equivalent** to what we'd have written (so skipping loses nothing), **and** the code either doesn't need the surviving row's id or re-reads it.
>
> It is a bug when the only reachable trigger is a freshly-minted surrogate id (it cannot fire for its stated reason, so it can only hide real violations), or when the code uses that fresh id as though the row existed, **or when the surviving row is weaker than the one we meant to write**.

Twice I under-generalized at the level of the *rule* rather than the code — while writing the rule into a PR body as evidence I had generalized.

## `add_member_to_category` silently discarded the user's confirmation (sol #83 r2)

Its ignore fires on `UNIQUE(category_id, token_normalized)` and I argued that made it a real no-op. It doesn't. A member already present as `llm_suggested`/`'pending'` is **not equivalent** to the `user_confirmed`/`'active'` row a reclassify wants. The ignore threw the confirmation away and left the pair `'pending'` — and `find_member_category` reads `'active'` only, so the "learned" substitution stayed invisible to every later classification. Nothing errored. Verified before fixing:

```
members after a user_confirmed reclassify:
  [("quibnix", "llm_suggested", "pending"), ("zorblat", "llm_suggested", "pending")]
zorblat visible as active member = 0
```

Fixed with `ON CONFLICT(category_id, token_normalized) DO UPDATE`, gated on an explicit source-rank ladder (`seed` 3 > `user_confirmed` 2 > `llm_suggested` 1): **promote, never demote**. A later `llm_suggested` gossip can't knock a `user_confirmed` member back to `'pending'` — the same loss from the other side — and `seed` rows are immovable. It now returns whether a row was really *created* (re-reading its own minted id, since rows-changed counts the UPDATE too), so callers report `is_new` honestly.

## The category, actually swept (sol #83 finding 2)

The `oplog` table was not the boundary of this bug — I'd stopped at the instance again.

**`reclassify_conflict`'s provisional-category branch (conflict.rs)** had the same shape and a worse ending: it minted a fresh `cat_id`, `INSERT OR IGNORE`d into `substitution_categories` (where `name` is UNIQUE), then attached members with that id. On a name collision the ignore skipped the row, so `cat_id` named **nothing**, and `add_member_to_category` hit the `substitution_members.category_id` FK — `IGNORE` resolves as `ABORT` for FK errors, so a legitimate reclassify just failed.

Reachable through the public Python API: `find_member_category` (which decides "unknown token", routing into that branch) matches only `m.status = 'active'`, while `learn_category_members(source="llm_suggested")` creates members as `'pending'`. So `learned_<a>_<b>` can already exist while both its tokens still read as unknown.

Fixed by factoring `ensure_substitution_category` — `ON CONFLICT(name) DO NOTHING` then **re-read the winner**, the existing `graph_ops::ensure_proposition` shape — and using it at *both* call sites. That also closes a TOCTOU in `learn_category_members`, whose `SELECT`-then-`INSERT` raced two concurrent ingests into a UNIQUE violation.

## And a deadlock, found by writing that test

The regression test above **hung** instead of failing. `learn_category_members` deadlocks on the branch that *creates* a category — the half its own doc comment advertises ("Creates the category if it doesn't exist"):

```rust
let cat_id = match self.conn().query_row(...) {   // guard: a match SCRUTINEE
    Ok(id) => id,
    Err(QueryReturnedNoRows) => {
        self.conn().execute(...)                  // re-lock, guard STILL held
```

Rust keeps scrutinee temporaries alive until the end of the whole `match`, so the `MutexGuard` was still held when the arm called `self.conn()` again — a re-lock of a non-reentrant `parking_lot::Mutex` on the same thread. It wedges the **entire database**, not just the caller: `conn` is the single write lock, so every other writer then blocks forever.

That path has never worked, which is why it had no tests. Reachable from the public Python binding. The helper fixes it by construction — the INSERT and the read-back are separate statements, each releasing the guard.

## The tests, proven against the unfixed code first

- `reclassify_reuses_existing_category_when_name_already_taken` — unfixed: `SqliteFailure(787)`, FOREIGN KEY constraint failed.
- `learn_category_members_creates_new_category_without_deadlocking` — unfixed: hangs. Runs on a worker with a 30s deadline so a deadlock **fails the test** instead of wedging CI.
- `learn_category_members_promotes_but_never_demotes` — covers the never-demote half, the easy one to silently break while getting promote right. Proven to fail pre-fix.
- the reclassify test now also asserts promotion + visibility. Pre-fix it fails with *"quibnix must be promoted to user_confirmed/active, got llm_suggested/pending"* — the assertion I was missing in round 1, which is why that draft sailed past a live silent-loss bug.

The first draft of the reclassify test **passed against the unfixed code** — it used `redis`/`memcached`, and the schema *seeds* `redis` as an active member of `"databases"`, so `known_a` was never empty and strategy 3 never ran. It asserted things that were true no matter what. Retargeted at invented tokens, plus an assertion that strategy 3 *actually fired* and an orphan-member check, so it can't pass vacuously again. (A regression test that only ever passes is decoration — this is the second time in this item that a first-draft test proved nothing.)

While there, two adjacent fictions in the same branch: `category_created` and `is_new: true` were hardcoded and written to the oplog and returned to Python, so a reclassify that created nothing still reported that it had. Both now report what actually happened (`add_member_to_category` already returned the truth; the caller was ignoring it).

## Strategy 1 was rebranding seed members — and a reset then deleted them (sol r3)

Round 2 gave `add_member_to_category` the rank guard and declared "seed rows are immovable." Strategy 1 UPDATEs `substitution_members` **directly**, bypassing that helper, and kept its own unguarded policy:

```sql
UPDATE substitution_members SET confidence = 1.0, source = 'user_confirmed'
```

So I fixed the helper and left its sibling — the same instance-not-class move, in the commit whose message was about not making it.

Not cosmetic, and reachable on a **default** database: `postgresql` and `mysql` both ship seeded into `"databases"`. Reclassify that pair → both rebranded `user_confirmed` → `reset_category_to_seed` deletes `source != 'seed'` → **the seed members are gone**. The gossip trigger keys on `source != 'seed'` too, so an untouched seed category reads as user-expanded.

**The root cause is duplicated policy, so the fix is de-duplication, not another patched instance.** `MEMBER_SOURCE_RANK_SQL` is now the single SQL definition of the ladder, used by *both* `add_member_to_category`'s `ON CONFLICT` guard and Strategy 1's `UPDATE`. Rust's `member_source_rank` (incoming rank) mirrors it (stored rank), and `member_source_rank_agrees_with_sql` pins them together for every source — **evaluating the real constant**. That test's first draft inlined its own *third* copy of the CASE: it would have pinned the Rust fn against the test's private duplicate and passed forever while the two real definitions drifted. The same mistake, inside the test written to prevent it.

Confidence reinforcement still applies to every row; only `source` is gated, and only ever moves up.

`reclassify_reinforcement_does_not_rebrand_seed_members` fails pre-fix with *"seed provenance must survive a user_confirmed reinforcement"*, and asserts the consequence — that a later `reset_category_to_seed` doesn't delete them — so it fails for the reason that actually hurts.

**Deliberate gap:** equal-rank writes don't refresh confidence, so a second `user_confirmed` with higher confidence is a no-op. Defensible while rank is the only write authority; pinning it needs its own rule + test if product semantics change.

## Also from review

- **r2** — the `log_op_pending_in_tx` rustdoc still taught the dead rationale: *"`log_op_pending` uses `OR IGNORE` because it has cluster-replay callers that re-use an existing `op_id`."* False twice over — it no longer uses `OR IGNORE`, and it never had such callers. Exactly the comment class this PR exists to delete, surviving inside the PR deleting it.
- **r2** — `is_new: true` was still hardcoded in strategies 1/2; both now carry `add_member_to_category`'s actual return.
- **r2** — `ensure_substitution_category` now holds **one** `conn` guard across its insert and read-back. Because `conn()` is public, re-acquiring between them let a raw caller delete the row (spurious `NoRows`) or delete-and-recreate it (`inserted > 0` true while the returned id belongs to another row).
- **finding 3** — the new "plain INSERT Ok ⇒ durably landed" comments overstated: `conn()` is public, so a caller can wrap this in its own SAVEPOINT and roll back, leaving the counter high. Pre-existing and not something `changes()` ever caught either, but the comments now scope the claim to the statement rather than to durability.
- **finding 1** — `apply_ops` materializes a received op's side effects *before* claiming it, so two concurrent appliers can double-apply non-idempotent arms (`relate` bumps `mention_count`, `consolidate` re-multiplies importance) and the `OR IGNORE` at replication.rs:303 hides the second. Pre-existing and out of this diff, same class as #80. Filed as **#84** rather than widening this PR.

## Stale comment

The counter comment's first line had survived an earlier edit and read `INSERT OR IGNORE on` trailing off — directly above a plain INSERT. Removed. Three of the four silent bugs in this item were hiding behind comments asserting the opposite of the code, so leaving one in *this* PR would have been funny in the worst way.

Test `pending_op_idempotent_on_double_append` renamed to `pending_op_double_append_writes_two_distinct_rows`: its body always asserted the **opposite** of idempotency (two distinct op_ids, two rows), so the name was a lie that corroborated the very rustdoc this PR deletes.

## Filed, not smuggled in

- **#84** — `apply_ops` materializes a received op's side effects *before* claiming it; two concurrent appliers double-apply non-idempotent arms and the `OR IGNORE` at replication.rs:303 hides the second. Pre-existing, out of diff, same class as #80.
- **#85** — seed population is the one writer of `substitution_members.source` outside the ladder, while `MEMBER_SOURCE_RANK_SQL` claims `seed` tops it. Narrow, and self-heals on reopen — genuinely unlike everything above, which is why it's an issue.

sol confirmed the ladder is otherwise single-sourced for both runtime decision sites, that `format!`-ing the constant has no injection surface and correct `?N` numbering, and that the seed fix didn't break reinforcement.

## How it was found

Sol, in the 4a.6a round-3 review, after I explicitly told it to assume I'd under-generalized — then sol again here, for four rounds, **finding a real bug in every one**. Twice it disproved a claim I had just written into this PR body as evidence I'd generalized (the `OR IGNORE` rule; "seed rows are immovable"). The rule took three revisions.

The scoreboard for the review discipline, since it is the actual product of this PR:

- **My first-draft tests were decoration twice.** One passed on unfixed code because the schema seeds `redis` into `"databases"`, so `known_a` was never empty and the branch under test never ran. One inlined a private third copy of the ladder it existed to pin. Both now assert the branch *actually fired* against the *real* definition.
- **Patching the named site never held.** Four rounds, four instances, every one tracing to two sites owning one rule. Duplication of policy is the bug generator; the question is *"who else owns a copy of this rule,"* not *"where else is this bug."*
- The worst bug here — the deadlock — was found by **writing a test for something else**, in a function that had no tests because the path had never worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
