### PR TITLE
fix(4a.6a-2): one owner for reserve→commit→publish; both correction paths were unwind-holed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,17 @@ jobs:
       - name: Run Rust Tests
         run: cargo test --workspace --exclude yantrikdb-python --verbose
 
+      # The `testing` feature gates the failpoint seam, and every kill proof
+      # is `#![cfg(feature = "testing")]`. Without this step they compile out
+      # of every CI run and report "ok. 0 passed" — so the three kill proofs
+      # cited as proof of the v0.10 write boundaries had never actually run on
+      # a PR. A test that never runs is worse than no test: it reports green.
+      # Also covers the correction-path unwind failpoints (4a.6a finding 2),
+      # which assert the RAII discharge that a killed process would hide —
+      # restart repairs a crash, so only a caught, continuing unwind exposes it.
+      - name: Run Rust Tests (testing feature — failpoints + kill proofs)
+        run: cargo test --workspace --exclude yantrikdb-python --features testing --verbose
+
       - name: Install Python package
         run: pip install -e ".[all,dev]"
 

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -4,6 +4,7 @@ use crate::error::{Result, YantrikDbError};
 use crate::scoring;
 use crate::types::*;
 
+use super::reservation::ReservationGuard;
 use super::{embedding_hash, now, YantrikDB};
 
 /// **v0.10 Item 3 — correction seqlock guard (sol r4).** Bumps the DB-wide
@@ -1362,6 +1363,20 @@ impl YantrikDB {
                 return Err(e);
             }
 
+            // From here the reservation is owed back on EVERY exit — including an
+            // unwinding panic. The hand-rolled `remove_appended` this replaces
+            // could not cover that: a panic inside the commit closure unwound
+            // straight past it and leaked the reservation permanently (compaction
+            // retains unpublished entries by design, so nobody ever reclaims it,
+            // and enough leaks wedge every writer into Backpressure).
+            //
+            // publish_only, NOT with_pending_op: this transaction's `correct` op
+            // commits via log_op_in_tx with applied=1, so it creates no pending
+            // op. Incrementing pending_op_count here would inflate the cache
+            // against zero pending rows — the v0.7.1 counter-leak class, in the
+            // other direction.
+            let mut reservation = ReservationGuard::publish_only(&state_for_commit, rid, seq_new);
+
             // SQL transaction. Prior state is re-read HERE (under the
             // serialized conn lock) so it reflects any correction that
             // committed just before us.
@@ -1535,12 +1550,13 @@ impl YantrikDB {
                 Err(e) => {
                     // Commit failed (rare IO error) OR the row was forgotten
                     // mid-correction (NotFound from the active-status guard).
-                    // Remove the RESERVED append so the delta returns to its
+                    // The guard is still in Reserved phase, so dropping it here
+                    // removes the reservation — the delta returns to its
                     // pre-correction visibility (old vector shows / rid stays
-                    // forgotten), matching the unchanged SQL. Compaction
-                    // could not have sealed it — reserved entries are skipped
-                    // by the seal — so this removal always succeeds.
-                    state_for_commit.vec_index.remove_appended(rid, seq_new);
+                    // forgotten), matching the unchanged SQL. Compaction could
+                    // not have sealed it (reserved entries are skipped by the
+                    // seal), so the removal always succeeds.
+                    drop(reservation);
                     drop(_epoch);
                     drop(conn);
                     drop(sync_guard);
@@ -1548,11 +1564,20 @@ impl YantrikDB {
                 }
             };
 
+            // The correction is durable: the obligation INVERTS here from
+            // "remove the reservation" to "publish it". Nothing fallible may sit
+            // between the commit and this call.
+            reservation.mark_committed();
+
             // **Publish** the reserved append now that the correction is
             // durable: it becomes the visible, compaction-eligible live
             // vector, atomically superseding the old one. Still under the
             // conn lock, so the publish order matches the commit order.
-            state_for_commit.vec_index.publish(rid, seq_new);
+            //
+            // Via the guard, so an unwind between the commit and here still
+            // publishes rather than stranding a durable row behind an invisible
+            // vector (only an index rebuild would have recovered it).
+            reservation.complete();
 
             // Kill boundary. A crash HERE (after the durable commit) leaves
             // SQL wholly-new — new text + embedding + revision + correct op
@@ -1792,6 +1817,15 @@ impl YantrikDB {
                 None
             };
 
+            // Same obligation as the leader path, via the same guard: owed back on
+            // every exit including an unwind, which the hand-rolled cleanup below
+            // could not cover. `None` when this correction carries no vector —
+            // there is nothing reserved, so nothing is owed.
+            //
+            // publish_only: this tx commits an already-applied replicated
+            // correction and enqueues no pending op.
+            let mut reservation = seq_new.map(|s| ReservationGuard::publish_only(&state, rid, s));
+
             let commit: Result<()> = (|| {
                 let tx = conn.unchecked_transaction()?;
                 tx.execute(
@@ -1870,13 +1904,14 @@ impl YantrikDB {
                 Ok(())
             })();
             if let Err(e) = commit {
-                if let Some(s) = seq_new {
-                    state.vec_index.remove_appended(rid, s);
-                }
+                // Still Reserved: dropping removes the reservation.
+                drop(reservation);
                 return Err(e);
             }
-            if let Some(s) = seq_new {
-                state.vec_index.publish(rid, s);
+            if let Some(r) = reservation.as_mut() {
+                // Durable — the obligation inverts to publish.
+                r.mark_committed();
+                r.complete();
             }
             {
                 let mut cache = self.scoring_cache.write();

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -50,6 +50,7 @@ mod record;
 pub mod reembed;
 pub mod repair;
 mod replay_engine;
+mod reservation;
 mod sanitize;
 mod schema_induction_engine;
 mod session;

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -6,91 +6,9 @@ use crate::serde_helpers::serialize_f32;
 use crate::types::*;
 
 use super::reembed::SearchState;
+use super::reservation::ReservationGuard;
 use super::write_router::SyncWriteGuard;
 use super::{embedding_hash, now, sanitize, YantrikDB};
-
-/// Which obligation the write currently owes (v0.10 Item 4a.6a).
-enum ResPhase {
-    /// Reserved, nothing durable. Owe: remove the reservation.
-    Reserved,
-    /// Durable. Owe: publish the vector AND count the pending op.
-    Committed,
-    /// All obligations discharged.
-    Done,
-}
-
-/// PHASE-AWARE RAII for the reserve → commit → publish protocol (sol 4a.6a
-/// findings 3 and r2-2).
-///
-/// The obligation this guard carries INVERTS at commit, and both halves must
-/// survive an unwinding panic:
-///
-/// - **Before commit** — nothing durable exists, so the reservation must be
-///   REMOVED. `append_reserved` consumes delta capacity with an entry search
-///   skips and compaction deliberately RETAINS rather than seals (the property
-///   that makes rollback safe). So a leaked reservation is permanent: nobody
-///   else will ever remove it, it holds capacity until restart, and enough of
-///   them wedge every writer into Backpressure.
-/// - **After commit** — the row is durable, so the reservation must be
-///   PUBLISHED and the pending op COUNTED. A panic here previously left a
-///   durable row whose vector was invisible until an index rebuild, plus a
-///   pending row missing from `pending_op_count`. The first version defused the
-///   guard AT commit, before both — and the `debug_assert!` added to be careful
-///   was itself a panic point in that window.
-///
-/// Restart repairs both (the index rebuilds from `memories`; the counter
-/// re-seeds), but the engine deliberately uses non-poisoning locks so a
-/// `catch_unwind` process CONTINUES — and that process is the exposure.
-struct ReservationGuard<'a> {
-    state: &'a SearchState,
-    pending_op_count: &'a std::sync::atomic::AtomicI64,
-    rid: &'a str,
-    seq: u64,
-    phase: ResPhase,
-}
-
-impl ReservationGuard<'_> {
-    /// The transaction committed: from here the obligation is publish+count.
-    fn mark_committed(&mut self) {
-        self.phase = ResPhase::Committed;
-    }
-
-    /// Discharge the post-commit obligations exactly once. Returns whether
-    /// `publish` found the reservation.
-    fn complete(&mut self) -> bool {
-        let published = self.discharge_committed();
-        self.phase = ResPhase::Done;
-        published
-    }
-
-    /// publish + count. Idempotent-by-phase: only ever run once, either from
-    /// `complete()` or from `Drop` on a post-commit unwind.
-    fn discharge_committed(&self) -> bool {
-        let published = self.state.vec_index.publish(self.rid, self.seq);
-        self.pending_op_count
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        published
-    }
-}
-
-impl Drop for ReservationGuard<'_> {
-    fn drop(&mut self) {
-        match self.phase {
-            // Always succeeds: reserved entries are never sealed. A removal, NOT
-            // a tombstone — a tombstone would suppress the rid and hide a
-            // still-valid older vector.
-            ResPhase::Reserved => {
-                self.state.vec_index.remove_appended(self.rid, self.seq);
-            }
-            // Unwound after commit. The write IS durable, so finish the job
-            // rather than strand it.
-            ResPhase::Committed => {
-                self.discharge_committed();
-            }
-            ResPhase::Done => {}
-        }
-    }
-}
 
 /// Coerce a blank namespace to the canonical default (v0.7.23).
 ///
@@ -398,13 +316,11 @@ impl YantrikDB {
         // From here until commit, ANY exit — including an unwinding panic —
         // must drop the reservation, or its capacity is held forever
         // (compaction retains unpublished entries by design).
-        let mut reservation = ReservationGuard {
-            state: &state,
-            pending_op_count: &self.pending_op_count,
-            rid: &rid,
-            seq,
-            phase: ResPhase::Reserved,
-        };
+        // with_pending_op, not publish_only: this transaction enqueues a PENDING
+        // op (log_op_pending_in_tx, applied=0) that `pending_op_count` caches, so
+        // post-commit this writer owes the increment as well as the publish.
+        let mut reservation =
+            ReservationGuard::with_pending_op(&state, &self.pending_op_count, &rid, seq);
 
         // ONE transaction: row + session links + the record op + the
         // post-materialization enqueue. Either all of it is durable or none is.

--- a/crates/yantrikdb-core/src/engine/reservation.rs
+++ b/crates/yantrikdb-core/src/engine/reservation.rs
@@ -1,0 +1,300 @@
+//! The reserve → commit → publish protocol's RAII guard (v0.10 Item 4a.6a
+//! finding 2).
+//!
+//! Every writer that puts a vector into the delta index BEFORE its SQL is
+//! durable owes one of two obligations, and which one it owes INVERTS at the
+//! commit point. Both halves must survive an unwinding panic. This module is the
+//! single owner of that rule.
+//!
+//! ## Why it must be RAII, and why a kill proof cannot cover it
+//!
+//! - **Before commit** — nothing durable exists, so the reservation must be
+//!   REMOVED. `append_reserved` consumes delta capacity with an entry search
+//!   skips and compaction deliberately RETAINS rather than seals (the property
+//!   that makes rollback safe). A leaked reservation is therefore PERMANENT:
+//!   nobody else will ever remove it, it holds capacity until restart, and
+//!   enough of them wedge every writer into `Backpressure`.
+//! - **After commit** — the row is durable, so the reservation must be PUBLISHED
+//!   (and any pending op counted). A panic here leaves a durable row whose vector
+//!   is invisible until an index rebuild.
+//!
+//! Restart repairs both — the index rebuilds from `memories`, the counter
+//! re-seeds — which is exactly why the kill proofs do NOT cover this. The engine
+//! deliberately uses non-poisoning locks, so a `catch_unwind` process CONTINUES
+//! carrying the leak. That continuing process is the whole exposure.
+//!
+//! ## Why the pending-op count is a parameter and not part of the rule
+//!
+//! `record()` owes `publish + count` because its transaction enqueues a PENDING
+//! op (`applied = 0`, via `log_op_pending_in_tx`) that `pending_op_count` caches.
+//! The correction paths owe `publish` ALONE: `log_op_in_tx` commits `applied = 1`,
+//! so they never create a pending op. Counting there would inflate the cache
+//! against zero pending rows — monotonic drift with nothing to bring it back down
+//! (`mark_op_applied` only decrements rows it actually transitions), and at
+//! `MAX_PENDING_OPS` of drift the admission check wedges EVERY foreground write
+//! into `Backpressure` forever. That is the v0.7.1 counter-leak class.
+//!
+//! So the obligation is shared; the counting is not. Copying `record()`'s guard
+//! wholesale onto a correction would have introduced precisely the bug the guard
+//! exists to prevent, in the other direction.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use super::reembed::SearchState;
+
+/// Which obligation the write currently owes.
+enum ResPhase {
+    /// Reserved, nothing durable. Owe: remove the reservation.
+    Reserved,
+    /// Durable. Owe: publish the vector (and count the pending op, if any).
+    Committed,
+    /// All obligations discharged.
+    Done,
+}
+
+/// PHASE-AWARE RAII for `reserve → commit → publish`.
+///
+/// Construct immediately after `append_reserved`. Call [`Self::mark_committed`]
+/// the instant the transaction commits — that is the point the obligation
+/// inverts, and nothing fallible may sit between the commit and that call.
+/// [`Self::complete`] discharges the post-commit work on the happy path; `Drop`
+/// discharges whichever obligation is still owed on any unwind.
+pub(crate) struct ReservationGuard<'a> {
+    state: &'a SearchState,
+    /// `Some` only for writers whose committed transaction enqueued a pending
+    /// op. See the module doc: this is per-site because the RATIONALE is
+    /// per-site, not because the rule is.
+    pending_op_count: Option<&'a AtomicI64>,
+    rid: &'a str,
+    seq: u64,
+    phase: ResPhase,
+}
+
+impl<'a> ReservationGuard<'a> {
+    /// A writer whose transaction enqueues a pending op: post-commit it owes
+    /// `publish` AND the `pending_op_count` increment. (`record()`.)
+    pub(crate) fn with_pending_op(
+        state: &'a SearchState,
+        pending_op_count: &'a AtomicI64,
+        rid: &'a str,
+        seq: u64,
+    ) -> Self {
+        Self {
+            state,
+            pending_op_count: Some(pending_op_count),
+            rid,
+            seq,
+            phase: ResPhase::Reserved,
+        }
+    }
+
+    /// A writer whose transaction commits an ALREADY-APPLIED op: post-commit it
+    /// owes `publish` only. Counting here would inflate `pending_op_count`
+    /// against zero pending rows. (The correction paths.)
+    pub(crate) fn publish_only(state: &'a SearchState, rid: &'a str, seq: u64) -> Self {
+        Self {
+            state,
+            pending_op_count: None,
+            rid,
+            seq,
+            phase: ResPhase::Reserved,
+        }
+    }
+
+    /// The transaction committed: from here the obligation is publish (+count).
+    pub(crate) fn mark_committed(&mut self) {
+        self.phase = ResPhase::Committed;
+    }
+
+    /// Discharge the post-commit obligations exactly once. Returns whether
+    /// `publish` found the reservation.
+    pub(crate) fn complete(&mut self) -> bool {
+        let published = self.discharge_committed();
+        self.phase = ResPhase::Done;
+        published
+    }
+
+    /// publish + count. Idempotent-by-phase: only ever runs once, either from
+    /// `complete()` or from `Drop` on a post-commit unwind.
+    fn discharge_committed(&self) -> bool {
+        let published = self.state.vec_index.publish(self.rid, self.seq);
+        if let Some(counter) = self.pending_op_count {
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+        published
+    }
+}
+
+impl Drop for ReservationGuard<'_> {
+    fn drop(&mut self) {
+        match self.phase {
+            // Always succeeds: reserved entries are never sealed. A removal, NOT
+            // a tombstone — a tombstone would suppress the rid and hide a
+            // still-valid older vector.
+            ResPhase::Reserved => {
+                self.state.vec_index.remove_appended(self.rid, self.seq);
+            }
+            // Unwound after commit. The write IS durable, so finish the job
+            // rather than strand it.
+            ResPhase::Committed => {
+                self.discharge_committed();
+            }
+            ResPhase::Done => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::YantrikDB;
+
+    /// These pin the RULE the guard owns, in the DEFAULT test suite — no
+    /// `testing` feature, so CI runs them on every PR regardless of the
+    /// failpoint seam.
+    ///
+    /// They exercise the property a kill proof structurally cannot: the engine
+    /// uses non-poisoning locks, so a caught panic leaves the PROCESS ALIVE
+    /// holding whatever the unwind skipped. A killed process is repaired by
+    /// restart; this one is not.
+    fn db() -> YantrikDB {
+        YantrikDB::new(":memory:", 8).unwrap()
+    }
+
+    #[test]
+    fn drop_before_commit_removes_the_reservation() {
+        let db = db();
+        let state = db.search_state.load_full();
+        state
+            .vec_index
+            .append_reserved("r1".into(), vec![0.1; 8], 7)
+            .unwrap();
+
+        {
+            let _g = ReservationGuard::publish_only(&state, "r1", 7);
+            // falls out of scope still Reserved
+        }
+
+        assert!(
+            !state.vec_index.remove_appended("r1", 7),
+            "guard's Drop must have removed the reservation (nothing left to remove)"
+        );
+    }
+
+    #[test]
+    fn unwind_before_commit_removes_the_reservation() {
+        let db = db();
+        let state = db.search_state.load_full();
+        state
+            .vec_index
+            .append_reserved("r2".into(), vec![0.1; 8], 8)
+            .unwrap();
+
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = ReservationGuard::publish_only(&state, "r2", 8);
+            panic!("simulated panic between reserve and commit");
+        }));
+        assert!(res.is_err(), "panic must propagate");
+
+        // THE bug this guard exists for: a leaked reservation is permanent —
+        // compaction retains unpublished entries, so nobody ever reclaims the
+        // capacity, and enough of them wedge every writer into Backpressure.
+        assert!(
+            !state.vec_index.remove_appended("r2", 8),
+            "unwind must not leak the reservation"
+        );
+    }
+
+    #[test]
+    fn unwind_after_commit_publishes_rather_than_stranding() {
+        let db = db();
+        let state = db.search_state.load_full();
+        state
+            .vec_index
+            .append_reserved("r3".into(), vec![0.1; 8], 9)
+            .unwrap();
+
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut g = ReservationGuard::publish_only(&state, "r3", 9);
+            g.mark_committed();
+            panic!("simulated panic between commit and publish");
+        }));
+        assert!(res.is_err(), "panic must propagate");
+
+        // The write IS durable at this point, so the obligation inverted: the
+        // vector must be published, not removed. Otherwise the row exists with an
+        // invisible vector until an index rebuild.
+        assert!(
+            !state.vec_index.publish("r3", 9),
+            "Drop must have published it already (a second publish finds nothing unpublished)"
+        );
+        assert!(
+            state.vec_index.remove_appended("r3", 9),
+            "the entry must still EXIST — post-commit it is published, never removed"
+        );
+    }
+
+    #[test]
+    fn complete_then_drop_discharges_exactly_once() {
+        let db = db();
+        let state = db.search_state.load_full();
+        state
+            .vec_index
+            .append_reserved("r4".into(), vec![0.1; 8], 10)
+            .unwrap();
+        let before = db.pending_op_count.load(Ordering::Relaxed);
+
+        {
+            let mut g = ReservationGuard::with_pending_op(&state, &db.pending_op_count, "r4", 10);
+            g.mark_committed();
+            assert!(g.complete(), "complete() publishes and reports it");
+            // Drop runs here in Done phase and must NOT count again.
+        }
+
+        assert_eq!(
+            db.pending_op_count.load(Ordering::Relaxed),
+            before + 1,
+            "exactly one increment — complete() then Drop must not double-count"
+        );
+    }
+
+    /// The counting is per-SITE because the rationale is per-site. The
+    /// correction paths commit `applied = 1` ops (log_op_in_tx) and enqueue
+    /// nothing pending, so counting there would inflate the cache against zero
+    /// pending rows — monotonic drift with nothing to bring it down, which at
+    /// MAX_PENDING_OPS wedges every foreground write into Backpressure forever.
+    /// That is the v0.7.1 counter-leak class, and it is exactly what copying
+    /// record()'s guard wholesale onto a correction would have introduced.
+    #[test]
+    fn publish_only_never_touches_the_pending_counter() {
+        let db = db();
+        let state = db.search_state.load_full();
+        let before = db.pending_op_count.load(Ordering::Relaxed);
+
+        // committed-and-completed
+        state
+            .vec_index
+            .append_reserved("r5".into(), vec![0.1; 8], 11)
+            .unwrap();
+        {
+            let mut g = ReservationGuard::publish_only(&state, "r5", 11);
+            g.mark_committed();
+            g.complete();
+        }
+        // committed-and-unwound (Drop discharges)
+        state
+            .vec_index
+            .append_reserved("r6".into(), vec![0.1; 8], 12)
+            .unwrap();
+        {
+            let mut g = ReservationGuard::publish_only(&state, "r6", 12);
+            g.mark_committed();
+        }
+
+        assert_eq!(
+            db.pending_op_count.load(Ordering::Relaxed),
+            before,
+            "publish_only must never move pending_op_count, on either discharge path"
+        );
+    }
+}

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -6853,6 +6853,85 @@ fn member_source_rank_agrees_with_sql() {
     }
 }
 
+/// A text-changing correction reserves a vector, commits, publishes — the same
+/// protocol `record()` runs. But its `correct` op commits via `log_op_in_tx` with
+/// `applied = 1`, so it enqueues NO pending op and must never move
+/// `pending_op_count`.
+///
+/// This is the test that catches a correction site built with the WRONG guard
+/// constructor (`with_pending_op` instead of `publish_only`). The guard's own unit
+/// test cannot: `publish_only` holds `None`, so the type system already stops it
+/// there — only a real site can pick the wrong one.
+///
+/// Getting it wrong inflates the cache against zero pending rows. Nothing brings
+/// it back down (`mark_op_applied` only decrements rows it actually transitions,
+/// and there is no row), so the drift is monotonic and at `MAX_PENDING_OPS` the
+/// admission check wedges EVERY foreground write into `Backpressure` forever —
+/// the v0.7.1 counter-leak class, reached by "reusing" record()'s guard.
+#[test]
+fn text_correction_publishes_its_vector_without_counting_a_pending_op() {
+    struct Fake;
+    impl crate::types::Embedder for Fake {
+        fn embed(
+            &self,
+            t: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+            // Deterministic, text-dependent: the corrected text must produce a
+            // DIFFERENT vector, or there is nothing to reserve and publish.
+            let mut v = vec![0.1; 8];
+            v[0] = (t.len() % 7) as f32 * 0.1;
+            Ok(v)
+        }
+        fn dim(&self) -> usize {
+            8
+        }
+    }
+
+    let mut db = YantrikDB::new(":memory:", 8).unwrap();
+    db.set_embedder(Box::new(Fake)).unwrap();
+
+    let rid = db
+        .record_text(
+            "the sky is green today",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "default",
+            0.8,
+            "work",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    let pending_before = db
+        .pending_op_count
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    db.correct(&rid, Some("the sky is blue"), None, None, None, "observed")
+        .expect("text correction must succeed");
+
+    assert_eq!(
+        db.pending_op_count
+            .load(std::sync::atomic::Ordering::Relaxed),
+        pending_before,
+        "a correction commits an applied op and enqueues nothing pending — \
+         counting here is the v0.7.1 counter-leak class"
+    );
+
+    // ...and it really did run the reserve→publish protocol: the corrected text
+    // is durable and retrievable, i.e. the vector was published, not stranded.
+    let text: String = db
+        .conn()
+        .query_row("SELECT text FROM memories WHERE rid = ?1", [&rid], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(text, "the sky is blue", "correction is durable");
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -6932,6 +6932,86 @@ fn text_correction_publishes_its_vector_without_counting_a_pending_op() {
     assert_eq!(text, "the sky is blue", "correction is durable");
 }
 
+/// The REPLICATED correction's twin of the test above (sol's item-2 review: the
+/// leader site was covered and this one was not — asymmetric coverage between two
+/// sites owning one rule is exactly how the whole 4a series kept getting bitten).
+///
+/// `apply_replicated_correct` reserves a vector and publishes it post-commit, but
+/// its oplog rows all commit `applied = 1`, so like the leader it must never move
+/// `pending_op_count`. Mutating its `publish_only` to `with_pending_op` must fail
+/// THIS test — the leader's test cannot see that site.
+#[test]
+fn replicated_correction_publishes_its_vector_without_counting_a_pending_op() {
+    struct Fake;
+    impl crate::types::Embedder for Fake {
+        fn embed(
+            &self,
+            t: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+            let mut v = vec![0.1; 8];
+            v[0] = (t.len() % 7) as f32 * 0.1;
+            Ok(v)
+        }
+        fn dim(&self) -> usize {
+            8
+        }
+    }
+
+    let mut db = YantrikDB::new(":memory:", 8).unwrap();
+    db.set_embedder(Box::new(Fake)).unwrap();
+
+    let rid = db
+        .record_text(
+            "the sky is green today",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "default",
+            0.8,
+            "work",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    let pending_before = db
+        .pending_op_count
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    // reembedded=true with no usable exact bytes → the follower re-embeds
+    // locally, which is the branch that reserves a vector.
+    db.apply_replicated_correct(
+        &serde_json::json!({
+            "rid": rid,
+            "revision_num": 1,
+            "new_text": "the sky is blue",
+            "reason": "peer correction",
+            "reembedded": true,
+        }),
+        None,
+        "peer-actor",
+    )
+    .expect("replicated correction must apply");
+
+    assert_eq!(
+        db.pending_op_count
+            .load(std::sync::atomic::Ordering::Relaxed),
+        pending_before,
+        "a replicated correction commits applied=1 ops and enqueues nothing pending — \
+         counting here is the v0.7.1 counter-leak class"
+    );
+
+    let text: String = db
+        .conn()
+        .query_row("SELECT text FROM memories WHERE rid = ?1", [&rid], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(text, "the sky is blue", "replicated correction is durable");
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]


### PR DESCRIPTION
sol's own **4a.6a finding 2** — the debt #82 was merged over, tracked in the item-4a handoff as "don't let it quietly become permanent."

## The holes

4a.6a gave `record()` a phase-aware RAII guard and left the two correction paths hand-rolling the same protocol. Both carried the holes the guard closes:

- a panic inside the commit closure unwinds straight past the manual `remove_appended`, **leaking the reservation permanently** — compaction retains unpublished entries by design, so nobody ever reclaims that capacity, and enough leaks wedge every writer into `Backpressure`;
- a panic between `tx.commit()` and the manual `publish` **strands a durable row behind an invisible vector** until an index rebuild.

## Factored, not patched

Per #83's lesson — four review rounds, every failure tracing to two sites owning one rule — the guard moves to `engine/reservation.rs` as the **single owner**. All three `append_reserved` sites now go through it: `record`, `correct_with_reembed`, `apply_replicated_correct`. Swept: 3 reserve sites, 3 guard constructions, zero hand-rolled `remove_appended`/`publish` left.

## The count is a parameter, because the rationale is per-site

I did **not** reuse `record()`'s guard wholesale, and shouldn't have:

- `record()` owes `publish + count` — its tx enqueues a PENDING op (`log_op_pending_in_tx`, `applied=0`) that `pending_op_count` caches.
- The corrections owe `publish` **alone** — `log_op_in_tx` commits `applied=1`, so they enqueue nothing pending.

Counting there would inflate the cache against zero pending rows: monotonic drift, nothing to bring it down (`mark_op_applied` only decrements rows it actually transitions), and at `MAX_PENDING_OPS` every foreground write wedges into `Backpressure` forever. **Reusing the guard naively would have introduced the exact bug it exists to prevent, in the other direction** — the v0.7.1 counter-leak class. Hence `with_pending_op()` vs `publish_only()`. sol traced both paths and confirmed the split.

## Why these are not kill proofs

A killed process is repaired by restart — the index rebuilds from `memories`, the counter re-seeds. The engine deliberately uses non-poisoning locks, so the real exposure is a **caught** panic in a process that **continues** carrying the leak. Only `catch_unwind` can see it. sol agreed this is the honest surface.

## CI was not running the kill proofs at all

Separate commit. No workflow enabled `--features testing`, so all three kill proofs compiled out of every run and reported `ok. 0 passed`. "3 kill proofs" was a true claim about the code and a false claim about CI — they had never executed on a PR. They pass when run; now they run.

## Tests, each mutation-verified rather than assumed

5 guard-contract tests in the **default** suite (no feature needed, so CI runs them on every PR):

| mutation | caught by |
|---|---|
| `Drop` no-op in `Reserved` (the leak) | 2 tests fail |
| `Drop` no-op after commit (the strand) | 1 test fails |
| `complete()` forgets `Done` (double discharge) | 1 test fails |

Plus **site-level** tests for both correction paths. The guard's unit tests cannot catch a site picking the wrong constructor (`publish_only` holds `None`, so the type system stops it there) — only a real site can. sol caught that I'd covered the leader and not its twin; mutating each site now fails its own test and only its own:

```
mutate leader     -> text_correction_...        FAILED (left 2, right 1)
mutate replicated -> replicated_correction_...  FAILED (left 2, right 1)
                     text_correction_...        ok      <- blind to it
```

**Process note:** the first leader mutation "passed" and I nearly recorded the test as decoration. The mutation had silently not applied — `str.replace` no-ops on a missed pattern and `cargo fmt` had reformatted the target line. The harness now exits non-zero if the pattern is absent. Verify the artifact, not the exit code.

Rust lib **1719** default / **1721** with `--features testing`; 3 kill proofs green; fmt clean.

Filed separately: **#86** (`engine/tests.rs` is 16,714 lines / 354 tests in one file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)