### PR TITLE
feat(v0.10-4a.6b): winner-only transactional calibration + provenance nudge; two bypasses closed

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"48c5baf6-0baa-4c37-93d2-a8f22722b261","pid":92712,"acquiredAt":1778091707761}
+{"sessionId":"48c5baf6-0baa-4c37-93d2-a8f22722b261","pid":79916,"acquiredAt":1779075447243}

--- a/crates/yantrikdb-core/src/base/provenance.rs
+++ b/crates/yantrikdb-core/src/base/provenance.rs
@@ -185,6 +185,19 @@ pub enum GateMode {
     Enforce,
 }
 
+/// What the gate concluded about an ALLOWED write (4a.6b). `Enforce`
+/// violations never produce a verdict — they are refused as `Err` before any
+/// side effect. `Flagged` means warn-mode saw a violation and let it through;
+/// the caller must report it via `note_flagged_write_committed` **after** the
+/// write commits, so the warn→enforce nudge metric counts only writes that
+/// actually landed. `#[must_use]`: dropping the verdict silently undercounts.
+#[must_use = "a Flagged verdict must be ticked post-commit via note_flagged_write_committed"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateVerdict {
+    Clean,
+    Flagged,
+}
+
 impl GateMode {
     /// Parse a persisted mode. **Fail-CLOSED (sol 4a.4):** only an exact `off`
     /// yields `Off`. A malformed value (e.g. the typo `enforc`) must NOT

--- a/crates/yantrikdb-core/src/base/provenance.rs
+++ b/crates/yantrikdb-core/src/base/provenance.rs
@@ -198,6 +198,31 @@ pub enum GateVerdict {
     Flagged,
 }
 
+/// Whether a `record_with_rid` call is an ORIGIN write or an already-admitted
+/// APPLY (4a.6b, sol r2 finding 2). `record_with_rid` is BOTH the public
+/// caller-supplied-rid origin API and the cluster commit-apply primitive, and
+/// those want opposite gate behavior:
+///
+/// - **`Origin`** — a fresh write entering here for the first time. Runs the
+///   anti-laundering gate exactly like `record()`; a declared contradiction is
+///   refused in Enforce and flagged in Warn.
+/// - **`Admitted`** — a consensus-committed / replicated op being applied. It
+///   was already gated at the leader's origin ingress, so it MUST NOT be
+///   re-gated: on the openraft apply path every follower re-applies the leader's
+///   committed entry locally, and re-gating would make followers reject the
+///   leader's write and wedge the cluster (yantrikdb-server's consensus-
+///   admission review). The materializer drain and replication apply pass this.
+///
+/// This is a REQUIRED argument, not a defaulted flag, precisely so a caller
+/// cannot silently inherit the wrong behavior: an apply caller that forgets to
+/// pass `Admitted` gets a gated write (safe-ish), and an origin caller that
+/// forgets `Origin` gets a compile error, not a silent bypass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteAdmission {
+    Origin,
+    Admitted,
+}
+
 impl GateMode {
     /// Parse a persisted mode. **Fail-CLOSED (sol 4a.4):** only an exact `off`
     /// yields `Off`. A malformed value (e.g. the typo `enforc`) must NOT

--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -1575,6 +1575,7 @@ mod tests {
             &[],
             "test-model",
             None,
+            crate::provenance::WriteAdmission::Admitted,
         )
         .unwrap();
 

--- a/crates/yantrikdb-core/src/engine/importance.rs
+++ b/crates/yantrikdb-core/src/engine/importance.rs
@@ -75,55 +75,99 @@ pub(crate) fn calibrate_importance_value(raw: f64, ewma: f64, count: u64) -> f64
     (HIGH_FLOOR + frac * (ceiling - HIGH_FLOOR)).clamp(0.0, 1.0)
 }
 
+/// Read-only calibration against `conn`'s current stats: snapshot the
+/// namespace's `(ewma, count)` and run the pure transform. **No write** — safe
+/// to call before the write is known to land, and safe under an already-held
+/// conn guard (takes the connection instead of locking; `record_batch` calls
+/// this with its SAVEPOINT guard held, where a `self.conn()` re-lock would be
+/// the `learn_category_members` deadlock, #83).
+pub(crate) fn calibrated_importance_on(
+    conn: &rusqlite::Connection,
+    namespace: &str,
+    raw: f64,
+) -> Result<f64> {
+    // Key the stats by the normalized namespace so the "" / "default"
+    // aliasing can't split a namespace's distribution across two rows.
+    let namespace = super::record::normalize_namespace(namespace);
+    let existing: Option<(f64, i64)> = conn
+        .query_row(
+            "SELECT ewma, count FROM namespace_importance_stats WHERE namespace = ?1",
+            params![namespace],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()?;
+    let (ewma, count) = existing.unwrap_or((raw, 0));
+    let calibrated = calibrate_importance_value(raw, ewma, count as u64);
+    if (calibrated - raw).abs() > f64::EPSILON {
+        tracing::debug!(
+            target: "yantrikdb::audit::importance",
+            namespace,
+            raw,
+            calibrated,
+            ewma,
+            count,
+            "deflated saturated importance",
+        );
+    }
+    Ok(calibrated)
+}
+
 impl YantrikDB {
-    /// Calibrate a raw importance against the writing namespace's running
-    /// distribution, updating that distribution with the raw value. See the
-    /// module docs for semantics. Called once per write at the ingest entry
-    /// points.
-    pub(crate) fn calibrate_importance(&self, namespace: &str, raw: f64) -> Result<f64> {
-        // Key the stats by the normalized namespace so the "" / "default"
-        // aliasing can't split a namespace's distribution across two rows.
+    /// Read-only: the calibrated importance for `raw` in `namespace`, computed
+    /// against the current stats. **Does not advance the distribution** — that
+    /// is [`Self::advance_importance_stats_in_tx`], which runs inside the
+    /// winner's transaction (4a.6b). Locks `conn`; do not call with the guard
+    /// already held (use [`calibrated_importance_on`] there).
+    pub(crate) fn calibrated_importance(&self, namespace: &str, raw: f64) -> Result<f64> {
+        calibrated_importance_on(&self.conn(), namespace, raw)
+    }
+
+    /// **v0.10 Item 4a.6b — winner-only calibration.** Advance the namespace's
+    /// distribution by one observation of `raw`, INSIDE the transaction (or
+    /// savepoint) that lands the write.
+    ///
+    /// **Why in-tx.** The predecessor (`calibrate_importance`) read the stats,
+    /// blended the EWMA in Rust, and wrote it back on a bare `conn()` — an
+    /// AUTOCOMMIT — at the ingest entry point, BEFORE routing. A write rejected
+    /// afterwards (backpressure, delta capacity, the provenance gate, a failed
+    /// transaction) had already advanced this namespace's calibration
+    /// permanently: losers moved state. Inside the winner's transaction, a
+    /// rollback takes the observation with it.
+    ///
+    /// **Why SQL computes the blend and Rust does not.** Read-in-Rust /
+    /// write-in-Rust is a TOCTOU on an order-dependent accumulator: two writers
+    /// both read `ewma = X`, both blend from X, and the second CLOBBERS the
+    /// first — one observation vanishes with no error. Blending against the
+    /// STORED value in the UPDATE makes the advance atomic, so writers compose.
+    /// `EWMA_ALPHA` is BOUND as a parameter rather than spelled into the SQL, so
+    /// the constant keeps exactly one definition (the #83 lesson: a rule with
+    /// two spellings drifts).
+    ///
+    /// The EWMA tracks the RAW value — what writers asked for (their intent),
+    /// never the deflated output, so saturation is measured honestly. Pass the
+    /// raw importance, not the calibrated one.
+    ///
+    /// Takes `&Connection` (a `Transaction` derefs to it; a SAVEPOINT has no
+    /// typed handle) — the `_in_tx` contract is by convention and enforced
+    /// behaviorally by `record_backpressure_writes_nothing_at_all`: calling it
+    /// outside the winner's transaction recreates the loser-writes bug.
+    pub(crate) fn advance_importance_stats_in_tx(
+        &self,
+        conn: &rusqlite::Connection,
+        namespace: &str,
+        raw: f64,
+    ) -> Result<()> {
         let namespace = super::record::normalize_namespace(namespace);
-
-        let conn = self.conn();
-        let existing: Option<(f64, i64)> = conn
-            .query_row(
-                "SELECT ewma, count FROM namespace_importance_stats WHERE namespace = ?1",
-                params![namespace],
-                |r| Ok((r.get(0)?, r.get(1)?)),
-            )
-            .optional()?;
-        let (ewma, count) = existing.unwrap_or((raw, 0));
-
-        let calibrated = calibrate_importance_value(raw, ewma, count as u64);
-
-        // Advance the EWMA toward the RAW value — we track what writers ask
-        // for (their intent), not our deflated output, so saturation is
-        // measured honestly.
-        let new_ewma = if count == 0 {
-            raw
-        } else {
-            (1.0 - EWMA_ALPHA) * ewma + EWMA_ALPHA * raw
-        };
         conn.execute(
             "INSERT INTO namespace_importance_stats (namespace, ewma, count, updated_at) \
              VALUES (?1, ?2, 1, ?3) \
-             ON CONFLICT(namespace) DO UPDATE SET ewma = ?2, count = count + 1, updated_at = ?3",
-            params![namespace, new_ewma, now()],
+             ON CONFLICT(namespace) DO UPDATE SET \
+               ewma = (1.0 - ?4) * namespace_importance_stats.ewma + ?4 * ?2, \
+               count = namespace_importance_stats.count + 1, \
+               updated_at = ?3",
+            params![namespace, raw, now(), EWMA_ALPHA],
         )?;
-
-        if (calibrated - raw).abs() > f64::EPSILON {
-            tracing::debug!(
-                target: "yantrikdb::audit::importance",
-                namespace,
-                raw,
-                calibrated,
-                ewma = new_ewma,
-                count = count + 1,
-                "deflated saturated importance",
-            );
-        }
-        Ok(calibrated)
+        Ok(())
     }
 }
 

--- a/crates/yantrikdb-core/src/engine/importance.rs
+++ b/crates/yantrikdb-core/src/engine/importance.rs
@@ -158,11 +158,19 @@ impl YantrikDB {
         raw: f64,
     ) -> Result<()> {
         let namespace = super::record::normalize_namespace(namespace);
+        // The CASE on stored count reproduces the predecessor's `count == 0 =>
+        // ewma = raw` seed EXACTLY (sol 4a.6b finding 3). A row with count = 0 is
+        // not produced by any engine path — every advance sets count >= 1 — but
+        // the schema permits it and `conn()` is public, so a maintenance/test
+        // insert of `(ewma=X, count=0)` must still seed to `raw`, not blend X in.
+        // EWMA_ALPHA is a bound parameter (?4), never spelled into the SQL, so the
+        // Rust const stays the one definition (#83).
         conn.execute(
             "INSERT INTO namespace_importance_stats (namespace, ewma, count, updated_at) \
              VALUES (?1, ?2, 1, ?3) \
              ON CONFLICT(namespace) DO UPDATE SET \
-               ewma = (1.0 - ?4) * namespace_importance_stats.ewma + ?4 * ?2, \
+               ewma = CASE WHEN namespace_importance_stats.count = 0 THEN ?2 \
+                           ELSE (1.0 - ?4) * namespace_importance_stats.ewma + ?4 * ?2 END, \
                count = namespace_importance_stats.count + 1, \
                updated_at = ?3",
             params![namespace, raw, now(), EWMA_ALPHA],

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -925,8 +925,9 @@ impl YantrikDB {
         // plaintext metadata (not the caller's patch) paired with the record's
         // existing `source` — `correct()` cannot change `source` itself. Runs
         // before the revision insert / UPDATE below, inside the tx, so a refusal
-        // rolls back leaving the row untouched.
-        self.gate_provenance(&original.source, &new_metadata_val)?;
+        // rolls back leaving the row untouched. Warn-mode flags are counted only
+        // after the commit below (4a.6b).
+        let gate_verdict = self.gate_provenance(&original.source, &new_metadata_val)?;
         let stored_new_text = self.encrypt_text(&new_text_val)?;
         let stored_new_metadata = self.encrypt_text(&serde_json::to_string(&new_metadata_val)?)?;
 
@@ -1003,6 +1004,9 @@ impl YantrikDB {
         )?;
 
         tx.commit()?;
+
+        // 4a.6b: the correction is durable — a warn-mode flag counts now.
+        self.note_flagged_write_committed(gate_verdict);
 
         // Refresh the scoring_cache BEFORE dropping conn (finding 4): two
         // serialized corrections must update the cache in commit order, not
@@ -1380,6 +1384,10 @@ impl YantrikDB {
             // SQL transaction. Prior state is re-read HERE (under the
             // serialized conn lock) so it reflects any correction that
             // committed just before us.
+            //
+            // 4a.6b: the gate verdict escapes the closure so a warn-mode flag
+            // can be counted post-commit. `None` only on a pre-gate error path.
+            let mut gate_verdict: Option<crate::provenance::GateVerdict> = None;
             let commit_result: Result<i64> =
                 (|| {
                     let tx = conn.unchecked_transaction()?;
@@ -1444,6 +1452,22 @@ impl YantrikDB {
                         }
                         None => prior_meta_val.clone(),
                     };
+                    // **Anti-laundering gate — the text-changing correction was
+                    // a BYPASS (found while wiring 4a.6b).** 4a.4b gated the
+                    // scalar-only path (correct_impl), but `text_changes`
+                    // dispatches HERE before that gate runs, and this path
+                    // merges `metadata_merge` all the same — so
+                    // `correct(new_text=<any one-char change>,
+                    // metadata_merge={"kind":"fact"})` on an inference-sourced
+                    // record laundered straight past Enforce. Verified
+                    // empirically before fixing: the scalar flip refused, the
+                    // text-change flip committed kind=fact. Gate on the FINAL
+                    // merged metadata, inside the tx (a refusal rolls back and
+                    // the outer match removes the reserved append), same design
+                    // as the scalar site. `original.source` is stable —
+                    // correct() cannot change source.
+                    let v = self.gate_provenance(&original.source, &new_metadata_val)?;
+                    gate_verdict = Some(v);
                     let stored_new_text = self.encrypt_text(new_text)?;
                     let stored_new_metadata =
                         self.encrypt_text(&serde_json::to_string(&new_metadata_val)?)?;
@@ -1578,6 +1602,12 @@ impl YantrikDB {
             // publishes rather than stranding a durable row behind an invisible
             // vector (only an index rebuild would have recovered it).
             reservation.complete();
+
+            // 4a.6b: durable — a warn-mode flag counts now. Set on every path
+            // that reaches the commit (the gate runs before any tx write).
+            if let Some(v) = gate_verdict {
+                self.note_flagged_write_committed(v);
+            }
 
             // Kill boundary. A crash HERE (after the durable commit) leaves
             // SQL wholly-new — new text + embedding + revision + correct op

--- a/crates/yantrikdb-core/src/engine/materializer.rs
+++ b/crates/yantrikdb-core/src/engine/materializer.rs
@@ -392,6 +392,7 @@ mod tests {
                 &[],
                 "test-embedder",
                 None,
+                crate::provenance::WriteAdmission::Admitted,
             )
             .expect("with the compactor running, 350 writes must not 503 at delta_max=256");
         }
@@ -475,6 +476,7 @@ mod tests {
                 &[],
                 "test-embedder",
                 None,
+                crate::provenance::WriteAdmission::Admitted,
             );
             if let Err(e) = res {
                 last_err = Some(e);

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -90,6 +90,7 @@ use crate::error::{Result, YantrikDbError};
 use crate::graph_index::GraphIndex;
 use crate::hlc::{HLCTimestamp, HLC};
 use crate::hnsw::HnswIndex;
+use crate::provenance::GateVerdict;
 use crate::schema::{
     MIGRATE_V10_TO_V11, MIGRATE_V11_TO_V12, MIGRATE_V12_TO_V13, MIGRATE_V13_TO_V14,
     MIGRATE_V14_TO_V15, MIGRATE_V15_TO_V16, MIGRATE_V16_TO_V17, MIGRATE_V17_TO_V18,
@@ -1279,13 +1280,17 @@ impl YantrikDB {
     /// unchanged). Runs BEFORE any side effect. In `Enforce` a violation is a
     /// typed `ProvenanceInconsistent` refusal; in `Warn` it is counted
     /// (`provenance_flagged_since_boot`) and allowed; `Off` skips entirely.
-    pub(crate) fn gate_provenance(&self, source: &str, metadata: &serde_json::Value) -> Result<()> {
+    pub(crate) fn gate_provenance(
+        &self,
+        source: &str,
+        metadata: &serde_json::Value,
+    ) -> Result<GateVerdict> {
         use crate::provenance::{
             check_provenance_consistency_opt, ClaimKind, ConfidenceBasis, GateMode, Source,
         };
         let mode = self.provenance_gate_mode();
         if mode == GateMode::Off {
-            return Ok(());
+            return Ok(GateVerdict::Clean);
         }
         let verdict = (|| -> Result<()> {
             // **`source` is a FREE-FORM public dimension — an unrecognized one
@@ -1328,19 +1333,36 @@ impl YantrikDB {
             check_provenance_consistency_opt(src, basis.as_ref(), &kind, override_kind)
         })();
         match verdict {
-            Ok(()) => Ok(()),
+            Ok(()) => Ok(GateVerdict::Clean),
             Err(e) => {
                 if mode == GateMode::Enforce {
                     Err(e)
                 } else {
-                    // Warn: count the nudge and allow the write (never break a
-                    // migrated caller).
-                    self.provenance_flagged_since_boot
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    // Warn: allow the write, and REPORT the flag instead of
+                    // counting it here (4a.6b). The gate runs before routing, so
+                    // ticking `provenance_flagged_since_boot` at this point
+                    // counted writes that were subsequently REJECTED —
+                    // inflating the very nudge metric an operator reads to
+                    // decide when warn can become enforce. The caller ticks via
+                    // [`Self::note_flagged_write_committed`] only after the
+                    // write is durable.
                     tracing::warn!(reason = %e, "provenance gate (warn): flagged an inconsistent write");
-                    Ok(())
+                    Ok(GateVerdict::Flagged)
                 }
             }
+        }
+    }
+
+    /// **4a.6b — the winner-only half of the warn-mode gate.** Call exactly once
+    /// AFTER the flagged write's transaction commits. In-memory since-boot
+    /// diagnostic: an unwind between commit and this call loses at most one
+    /// tick of a counter that re-seeds at boot — acceptable, unlike the
+    /// pre-routing overcount this replaces, which inflated the metric with
+    /// writes that never landed.
+    pub(crate) fn note_flagged_write_committed(&self, verdict: GateVerdict) {
+        if verdict == GateVerdict::Flagged {
+            self.provenance_flagged_since_boot
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
     }
 
@@ -1759,18 +1781,22 @@ impl YantrikDB {
         )?;
         // v0.10 Item 4a.4 anti-laundering gate — before the (slow) embed and
         // any side effect. `record_text` bypasses `record()`, so it gates here
-        // too (T06 coverage).
-        self.gate_provenance(source, metadata)?;
+        // too (T06 coverage). A warn-mode Flagged verdict is carried to the
+        // routed path and counted only after the write commits (4a.6b).
+        let gate_verdict = self.gate_provenance(source, metadata)?;
         // Task 29 (Ingest Integrity): strip any leaked tool-call
         // serialization tail BEFORE embedding, so both the computed vector
         // and the stored text reflect the real memory rather than the
         // artifact. Borrowed (no allocation) on the clean path.
         let sanitized = sanitize::sanitize_tool_call_artifacts(text);
         let text = sanitized.as_ref();
-        // Task 31 (Ingest Integrity): calibrate importance once, before the
-        // (retryable) embed loop, so a generation-swap retry never
-        // double-counts the namespace distribution.
-        let importance = self.calibrate_importance(namespace, importance)?;
+        // Task 31 (Ingest Integrity): compute the calibrated importance once,
+        // before the (retryable) embed loop — READ-ONLY as of 4a.6b, so the
+        // "retry must not double-count" property this comment used to defend is
+        // now structural: the distribution advances inside the winning path's
+        // transaction, and a retry loop commits at most once.
+        let raw_importance = importance;
+        let importance = self.calibrated_importance(namespace, importance)?;
         loop {
             // Step 1: snapshot SearchState for the embed — capture
             // generation + digest so we can revalidate after the embed.
@@ -1815,6 +1841,7 @@ impl YantrikDB {
                         text,
                         memory_type,
                         importance,
+                        raw_importance,
                         valence,
                         half_life,
                         metadata,
@@ -1824,6 +1851,7 @@ impl YantrikDB {
                         domain,
                         source,
                         emotional_state,
+                        gate_verdict,
                     );
                 }
             };
@@ -1861,6 +1889,7 @@ impl YantrikDB {
                 text,
                 memory_type,
                 importance,
+                raw_importance,
                 valence,
                 half_life,
                 metadata,
@@ -1870,6 +1899,7 @@ impl YantrikDB {
                 domain,
                 source,
                 emotional_state,
+                gate_verdict,
             );
         }
     }

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -894,6 +894,14 @@ impl YantrikDB {
         // would report Err for an already-committed batch, and a retrying caller
         // would then write DUPLICATE records under fresh rids — turning a missed
         // stat into data corruption. So it logs and continues.
+        //
+        // NB (sol r4 / #94): `log_record_ops_batch(...)?` below still `?`-returns
+        // after this winner point — a PRE-EXISTING Err-after-commit (#79-era)
+        // that is NOT best-effortable (the ops are what replicate the batch). Its
+        // correct fix is to move that append inside the savepoint above (needs a
+        // held-conn variant to avoid the #83 re-lock); tracked in #94, out of
+        // 4a.6b's scope. Calibration is best-effort ONLY because it is
+        // approximate — do not copy this pattern to the oplog append.
         {
             let conn = self.conn();
             let advanced = (|| -> Result<()> {

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -777,13 +777,11 @@ impl YantrikDB {
 
             conn.execute_batch("RELEASE batch_record")?;
         }
-        // 4a.6b: the RELEASE above committed the batch (the savepoint is the
-        // outermost transaction on this autocommit connection), so warn-mode
-        // flags count only now — an enforce-rejected or deferred batch ticks
-        // nothing.
-        for verdict in gate_verdicts {
-            self.note_flagged_write_committed(verdict);
-        }
+        // NOTE: warn-mode flag ticks are DEFERRED to after the vector-append
+        // loop below (4a.6b finding 1). The append is a post-RELEASE failure
+        // point whose compensation deletes the rows — so ticking here would
+        // count writes the caller then sees fail. See the tick loop past the
+        // append.
         // conn dropped; now update graph_index in-memory.
         {
             let mut gi = self.graph_index.write();
@@ -866,6 +864,24 @@ impl YantrikDB {
                 return Err(e);
             }
             self.bump_visible_seq(&input.namespace, seq);
+        }
+        // 4a.6b finding 1 (flag half): every append landed, so the batch is
+        // durable AND visible — count the warn-mode flags now. Ticking after
+        // RELEASE but before this point would have counted a batch whose append
+        // then failed and whose rows were compensated away.
+        //
+        // KNOWN RESIDUAL (sol 4a.6b finding 1, tracked as the 4a.6d batch
+        // restructure): the EWMA advances committed inside the savepoint are NOT
+        // reversed if an append fails here. Unlike a row DELETE or a counter
+        // decrement, a committed EWMA blend is IRREVERSIBLE by compensation — the
+        // prior value is gone — so the only correct fix is to RESERVE delta
+        // capacity before the savepoint (record()'s 4a.6a pattern) so append
+        // cannot fail post-commit. That is the batch's pre-existing
+        // incomplete-compensation gap (entities / graph_index have never been
+        // reversed here either), generalized; it is out of 4a.6b's scope and
+        // deliberately not half-patched.
+        for verdict in gate_verdicts {
+            self.note_flagged_write_committed(verdict);
         }
         // vec_index dropped, now scoring_cache
         {

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -886,13 +886,31 @@ impl YantrikDB {
         // Grouped in one transaction so the N advances are all-or-nothing. Each
         // is a plain upsert (SQL blend against the stored value; composes with
         // concurrent writers), fed the RAW importance.
+        //
+        // BEST-EFFORT, deliberately NOT `?` (sol 4a.6b r3 finding 1): the rows
+        // and vectors are already durable and visible — the batch WON. Calibration
+        // is an approximate ranking prior, so failing to advance it is a benign
+        // skipped observation. Propagating a SQLITE_FULL/IO error from this tx
+        // would report Err for an already-committed batch, and a retrying caller
+        // would then write DUPLICATE records under fresh rids — turning a missed
+        // stat into data corruption. So it logs and continues.
         {
             let conn = self.conn();
-            let tx = conn.unchecked_transaction()?;
-            for input in inputs.iter() {
-                self.advance_importance_stats_in_tx(&tx, &input.namespace, input.importance)?;
+            let advanced = (|| -> Result<()> {
+                let tx = conn.unchecked_transaction()?;
+                for input in inputs.iter() {
+                    self.advance_importance_stats_in_tx(&tx, &input.namespace, input.importance)?;
+                }
+                tx.commit()?;
+                Ok(())
+            })();
+            if let Err(e) = advanced {
+                tracing::warn!(
+                    error = %e,
+                    "record_batch: post-commit calibration advance failed; \
+                     batch is durable, calibration observation skipped"
+                );
             }
-            tx.commit()?;
         }
         for verdict in gate_verdicts {
             self.note_flagged_write_committed(verdict);
@@ -1268,9 +1286,14 @@ impl YantrikDB {
             )?;
         }
 
-        // 4a.6b: an ORIGIN write that was warn-flagged and reached here is
-        // durable — count it now. ADMITTED writes carry Clean and tick nothing.
-        self.note_flagged_write_committed(gate_verdict);
+        // 4a.6b: an ORIGIN write that was warn-flagged and actually WROTE A ROW is
+        // durable — count it now. Gated on `was_new_row` (sol r3 finding 2): this
+        // path is `INSERT OR IGNORE`, so a replay of an existing rid persists
+        // nothing, and ticking there would inflate the warn→enforce nudge metric
+        // with no-op replays. ADMITTED writes carry Clean and tick nothing.
+        if was_new_row {
+            self.note_flagged_write_committed(gate_verdict);
+        }
         Ok(())
     }
 

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -67,8 +67,10 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
     ) -> Result<String> {
-        // v0.9.3 contract gate: validate BEFORE any side effect (importance
-        // calibration below mutates the namespace's running distribution).
+        // v0.9.3 contract gate: validate before anything else. (Historically
+        // "before any side effect" because importance calibration used to
+        // autocommit here; as of 4a.6b nothing below this point mutates state
+        // until the winner's transaction commits.)
         crate::validate::validate_embedding("record", embedding, self.embedding_dim)?;
         crate::validate::validate_scalars(
             "record",
@@ -79,11 +81,13 @@ impl YantrikDB {
                 ("half_life", half_life),
             ],
         )?;
-        // v0.10 Item 4a.4 anti-laundering gate: refuse (enforce) / count (warn)
+        // v0.10 Item 4a.4 anti-laundering gate: refuse (enforce) / flag (warn)
         // a record whose declared provenance is internally inconsistent (e.g.
         // source=inference claiming metadata.kind=fact), BEFORE any side effect.
-        // For a fresh insert `metadata` IS the final merged metadata.
-        self.gate_provenance(source, metadata)?;
+        // For a fresh insert `metadata` IS the final merged metadata. A warn-mode
+        // Flagged verdict is counted only after the write COMMITS (4a.6b) — the
+        // routed paths below carry it to their post-commit tick.
+        let gate_verdict = self.gate_provenance(source, metadata)?;
         // Task 29 (Ingest Integrity): strip any leaked tool-call
         // serialization tail from the stored text. On this entry point the
         // caller supplies the embedding, so the vector may still reflect the
@@ -96,10 +100,14 @@ impl YantrikDB {
         // consumer persists an unscoped "" partition. Shadows the param so
         // both the sync and queued paths below see the normalized value.
         let namespace = normalize_namespace(namespace);
-        // Task 31 (Ingest Integrity): calibrate importance against this
-        // namespace's running distribution before it is stored OR replicated
-        // (the sync, queued, and oplog paths all flow from the value below).
-        let importance = self.calibrate_importance(namespace, importance)?;
+        // Task 31 (Ingest Integrity): compute the calibrated importance against
+        // this namespace's running distribution — READ-ONLY (4a.6b). The
+        // distribution itself advances inside the winning path's transaction
+        // (`advance_importance_stats_in_tx`), fed the RAW value, so a rejected
+        // write leaves the namespace's calibration untouched. The sync, queued,
+        // and oplog paths all store/replicate the calibrated value below.
+        let raw_importance = importance;
+        let importance = self.calibrated_importance(namespace, importance)?;
         // Issue #41 layer 3: route on write_router state. The guard
         // (if acquired) is held for the full sync path and drops via
         // RAII at function return, panic-safe.
@@ -112,6 +120,7 @@ impl YantrikDB {
                 text,
                 memory_type,
                 importance,
+                raw_importance,
                 valence,
                 half_life,
                 metadata,
@@ -121,6 +130,7 @@ impl YantrikDB {
                 domain,
                 source,
                 emotional_state,
+                gate_verdict,
             );
         }
         // guard is held; RAII Drop at function exit decrements inflight.
@@ -144,6 +154,7 @@ impl YantrikDB {
             text,
             memory_type,
             importance,
+            raw_importance,
             valence,
             half_life,
             metadata,
@@ -153,6 +164,7 @@ impl YantrikDB {
             domain,
             source,
             emotional_state,
+            gate_verdict,
         )
     }
 
@@ -180,6 +192,7 @@ impl YantrikDB {
         text: &str,
         memory_type: &str,
         importance: f64,
+        raw_importance: f64,
         valence: f64,
         half_life: f64,
         metadata: &serde_json::Value,
@@ -189,6 +202,7 @@ impl YantrikDB {
         domain: &str,
         source: &str,
         emotional_state: Option<&str>,
+        gate_verdict: crate::provenance::GateVerdict,
     ) -> Result<String> {
         let rid = crate::id::new_id();
         let ts = now();
@@ -244,16 +258,12 @@ impl YantrikDB {
         // binding check happens under the conn lock below. Doing it here too just
         // avoids the embed/serialize work on an obviously-full queue.
         //
-        // KNOWN GAP, deliberately not closed here (sol 4a.6a finding 2): this is
-        // not "before any side effect". `calibrate_importance` (record.rs:101)
-        // already ran and autocommitted an update to `namespace_importance_stats`
-        // (importance.rs:88) BEFORE routing, so a write rejected below — by
-        // backpressure, by delta capacity, or by a transaction failure — has
-        // already advanced this namespace's calibration distribution permanently.
-        // That is a real defect and it predates 4a.6a; sol's own increment plan
-        // puts the fix in 4a.6b ("winner-only, transactional calibration"), where
-        // the claim decides who is allowed to advance it. It is called out here so
-        // nobody reads this path as fully side-effect-free before then.
+        // This IS "before any side effect" as of 4a.6b: the calibration read
+        // upstream is read-only, the stats advance happens inside this write's
+        // transaction below, and the warn-gate's flag is counted post-commit —
+        // so a rejection here (or anywhere later) leaves no trace anywhere.
+        // `record_backpressure_writes_nothing_at_all` is the enforcing test,
+        // and its name is the contract.
         self.check_pending_backpressure_fast()?;
 
         let emb_hash = embedding_hash(embedding);
@@ -365,6 +375,14 @@ impl YantrikDB {
                 )?;
             }
 
+            // 4a.6b winner-only calibration: the namespace's distribution
+            // advances HERE, inside the winning write's transaction, fed the RAW
+            // importance (writer intent, not the deflated output). A rollback —
+            // or never reaching this transaction at all (backpressure, gate,
+            // delta capacity) — leaves the distribution untouched: losers no
+            // longer move state.
+            self.advance_importance_stats_in_tx(&tx, namespace, raw_importance)?;
+
             // Kill boundary. Before 4a.6a the row above was already committed by
             // its own autocommit at this point, while the oplog op below had not
             // been written — a process death here left exactly the orphan the
@@ -428,6 +446,10 @@ impl YantrikDB {
         // a caught panic cannot strand a durable write with an invisible vector
         // or an uncounted pending row.
         let published = reservation.complete();
+
+        // 4a.6b: a warn-mode Flagged verdict is counted only now — the write is
+        // durable, so the nudge metric counts writes that actually landed.
+        self.note_flagged_write_committed(gate_verdict);
 
         // The counter moved inside complete() above — only after the tx
         // committed. Incrementing inside the tx would leak it upward on rollback
@@ -496,6 +518,8 @@ impl YantrikDB {
         // v0.9.3 contract gate: prevalidate the ENTIRE batch before any side
         // effect (calibration / SQL / oplog / index), so a bad element late
         // in the batch can't leave earlier elements half-committed.
+        let mut gate_verdicts: Vec<crate::provenance::GateVerdict> =
+            Vec::with_capacity(inputs.len());
         for (i, input) in inputs.iter().enumerate() {
             crate::validate::validate_embedding(
                 "record_batch",
@@ -527,8 +551,10 @@ impl YantrikDB {
             // the batch PREVALIDATION loop, so an inconsistent element late in
             // the batch rejects the whole batch before any side effect rather
             // than half-committing the earlier ones — the same contract the
-            // embedding/scalar gates above rely on.
-            self.gate_provenance(&input.source, &input.metadata)
+            // embedding/scalar gates above rely on. Warn-mode Flagged verdicts
+            // are only COUNTED after the batch commits (4a.6b).
+            let verdict = self
+                .gate_provenance(&input.source, &input.metadata)
                 .map_err(|e| match e {
                     crate::error::YantrikDbError::ProvenanceInconsistent { path, reason } => {
                         crate::error::YantrikDbError::ProvenanceInconsistent {
@@ -538,6 +564,7 @@ impl YantrikDB {
                     }
                     other => other,
                 })?;
+            gate_verdicts.push(verdict);
         }
 
         // Task 29 (Ingest Integrity): strip any leaked tool-call
@@ -551,14 +578,17 @@ impl YantrikDB {
             .map(|i| sanitize::sanitize_tool_call_artifacts(&i.text))
             .collect();
 
-        // Task 31 (Ingest Integrity): calibrate each input's importance
-        // against its namespace distribution (positionally aligned with
-        // `inputs`). Calls run in order, so later items in the batch see the
-        // running-mean effect of earlier ones in the same namespace.
-        let calibrated_importances: Vec<f64> = inputs
-            .iter()
-            .map(|i| self.calibrate_importance(&i.namespace, i.importance))
-            .collect::<Result<Vec<_>>>()?;
+        // Task 31 (Ingest Integrity): each input's importance is calibrated
+        // against its namespace distribution INSIDE the savepoint below (4a.6b),
+        // positionally aligned with `inputs` via push order. Computing +
+        // advancing per item under the savepoint's transaction view preserves
+        // the documented property that later items in the batch see the
+        // running-mean effect of earlier ones in the same namespace — while a
+        // ROLLBACK TO takes every advance with it, so a rejected batch leaves
+        // every namespace's distribution untouched. (The old pre-routing
+        // autocommit advanced ALL of them even when the batch then deferred on
+        // the write-router or died mid-savepoint.)
+        let mut calibrated_importances: Vec<f64> = Vec::with_capacity(inputs.len());
 
         // **Issue #41 layer 3.** Enter the write-router BEFORE snapshotting
         // SearchState, exactly as `record()` does (record.rs:105/138).
@@ -635,6 +665,20 @@ impl YantrikDB {
                 let ts = now();
                 let emb_blob = serialize_f32(&input.embedding);
                 let meta_str = serde_json::to_string(&input.metadata)?;
+
+                // 4a.6b: calibrate + advance under the savepoint. The `_on`
+                // variant reads through the HELD guard — calling the locking
+                // wrapper here would re-lock `conn` on the same thread, the
+                // `learn_category_members` deadlock (#83). The snapshot sees the
+                // advances of EARLIER items in this batch (same tx view), which
+                // is what keeps the in-batch running-mean property.
+                let calibrated = super::importance::calibrated_importance_on(
+                    &conn,
+                    &input.namespace,
+                    input.importance,
+                )?;
+                self.advance_importance_stats_in_tx(&conn, &input.namespace, input.importance)?;
+                calibrated_importances.push(calibrated);
 
                 // Encrypt fields if encryption is enabled. Task 29: store the
                 // sanitized text (positionally aligned with `inputs`).
@@ -732,6 +776,13 @@ impl YantrikDB {
             }
 
             conn.execute_batch("RELEASE batch_record")?;
+        }
+        // 4a.6b: the RELEASE above committed the batch (the savepoint is the
+        // outermost transaction on this autocommit connection), so warn-mode
+        // flags count only now — an enforce-rejected or deferred batch ticks
+        // nothing.
+        for verdict in gate_verdicts {
+            self.note_flagged_write_committed(verdict);
         }
         // conn dropped; now update graph_index in-memory.
         {
@@ -1194,11 +1245,13 @@ impl YantrikDB {
     /// pre-encoded old-embedder vector in oplog would race against
     /// post-swap replay and produce dim mismatch when the new HNSW is
     /// at a different dim.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn record_queued(
         &self,
         text: &str,
         memory_type: &str,
         importance: f64,
+        raw_importance: f64,
         valence: f64,
         half_life: f64,
         metadata: &serde_json::Value,
@@ -1208,6 +1261,7 @@ impl YantrikDB {
         domain: &str,
         source: &str,
         emotional_state: Option<&str>,
+        gate_verdict: crate::provenance::GateVerdict,
     ) -> Result<String> {
         let rid = crate::id::new_id();
         let ts = now();
@@ -1257,7 +1311,14 @@ impl YantrikDB {
             Some(&rid),
             &payload,
             current_embedder_name.as_deref(),
+            // 4a.6b: the stats advance rides in the same transaction as the
+            // pending op — the queued write's only durable record. RAW value:
+            // the EWMA tracks writer intent, not the deflated output.
+            Some((namespace, raw_importance)),
         )?;
+
+        // 4a.6b: the pending op is durable, so a warn-mode flag counts now.
+        self.note_flagged_write_committed(gate_verdict);
 
         Ok(rid)
     }
@@ -1268,12 +1329,20 @@ impl YantrikDB {
     /// discriminate queued-during-reembed ops (which need re-encoding
     /// under the new embedder) from legacy pre-v27 ops (which have
     /// NULL `embedding_model` and trust their stored embedding bytes).
+    /// `stats_advance`: 4a.6b winner-only calibration for the queued path. The
+    /// pending op IS the queued write's only durable record, so the namespace's
+    /// importance distribution must advance atomically WITH it — `(namespace,
+    /// raw_importance)` here, in the same transaction as the INSERT. `None` for
+    /// op types that are not a record write (none today; the parameter exists so
+    /// a future non-record caller cannot silently inherit a stats advance that
+    /// does not belong to it).
     pub(crate) fn log_op_pending_for_reembed_queue(
         &self,
         op_type: &str,
         target_rid: Option<&str>,
         payload: &serde_json::Value,
         embedding_model: Option<&str>,
+        stats_advance: Option<(&str, f64)>,
     ) -> Result<String> {
         use rusqlite::params;
         use std::sync::atomic::Ordering;
@@ -1291,13 +1360,18 @@ impl YantrikDB {
 
         let conn = self.conn.lock();
         self.check_pending_backpressure_locked()?;
+        // ONE transaction: the pending op + the namespace stats advance. This
+        // used to be a bare autocommit INSERT; wrapping it costs nothing on the
+        // happy path and makes the stats advance winner-only — an INSERT failure
+        // rolls the observation back with it.
+        let tx = conn.unchecked_transaction()?;
         // Plain INSERT, not OR IGNORE. This is the QUEUED write's only durable
         // record — record_queued() writes no memories row (by design), so this op
         // IS the write. `OR IGNORE` here meant any swallowed constraint violation
         // made record_queued() return a rid and Ok while persisting NOTHING: the
-        // caller's write vanished silently. The op_id is minted fresh two lines
-        // up, so no caller could ever have needed the ignore.
-        conn.execute(
+        // caller's write vanished silently. The op_id is minted fresh above, so
+        // no caller could ever have needed the ignore.
+        tx.execute(
             "INSERT INTO oplog \
              (op_id, op_type, timestamp, target_rid, payload, \
               actor_id, hlc, embedding_hash, origin_actor, applied, \
@@ -1316,11 +1390,17 @@ impl YantrikDB {
                 embedding_model,
             ],
         )?;
-        // Unconditional: a plain INSERT that returned Ok inserted exactly one
-        // row. That is a claim about this statement, not about durability — a
-        // caller wrapping its own rolled-back SAVEPOINT around this (via the
-        // public `conn()`) still leaves the counter high. See the fuller note in
-        // `log_op_pending` (sol #83 finding 3).
+        if let Some((namespace, raw_importance)) = stats_advance {
+            self.advance_importance_stats_in_tx(&tx, namespace, raw_importance)?;
+        }
+        tx.commit()?;
+        // Only after commit: a plain INSERT inside a committed tx means exactly
+        // one pending row landed. (Moving the increment before the commit would
+        // leak it upward on rollback — the v0.7.1 counter-leak class.) Still a
+        // claim about this statement, not durability — a caller wrapping its own
+        // rolled-back SAVEPOINT around this (via the public `conn()`) leaves the
+        // counter high. See the fuller note in `log_op_pending` (sol #83
+        // finding 3).
         self.pending_op_count.fetch_add(1, Ordering::Relaxed);
         Ok(op_id)
     }

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -669,15 +669,26 @@ impl YantrikDB {
                 // 4a.6b: calibrate + advance under the savepoint. The `_on`
                 // variant reads through the HELD guard — calling the locking
                 // wrapper here would re-lock `conn` on the same thread, the
-                // `learn_category_members` deadlock (#83). The snapshot sees the
-                // advances of EARLIER items in this batch (same tx view), which
-                // is what keeps the in-batch running-mean property.
+                // `learn_category_members` deadlock (#83).
+                //
+                // 4a.6b (sol r2 finding 1): the stats ADVANCE is NOT done here.
+                // The vector append happens after the savepoint RELEASE and can
+                // still fail, and a committed EWMA blend is irreversible by the
+                // compensating DELETE — so advancing inside the savepoint left a
+                // rejected batch having permanently moved calibration. The
+                // advance is deferred to the post-append-loop block below, run
+                // only once the append wins. Consequence: every item calibrates
+                // against the SAME pre-batch snapshot (no within-batch running
+                // mean). That intra-batch progression was never pinned by a test
+                // and is a defensible semantics change — a batch is one
+                // simultaneous act — and it buys winner-only correctness. The
+                // cross-batch running mean is unchanged (the deferred advances
+                // move the table).
                 let calibrated = super::importance::calibrated_importance_on(
                     &conn,
                     &input.namespace,
                     input.importance,
                 )?;
-                self.advance_importance_stats_in_tx(&conn, &input.namespace, input.importance)?;
                 calibrated_importances.push(calibrated);
 
                 // Encrypt fields if encryption is enabled. Task 29: store the
@@ -865,21 +876,24 @@ impl YantrikDB {
             }
             self.bump_visible_seq(&input.namespace, seq);
         }
-        // 4a.6b finding 1 (flag half): every append landed, so the batch is
-        // durable AND visible — count the warn-mode flags now. Ticking after
-        // RELEASE but before this point would have counted a batch whose append
-        // then failed and whose rows were compensated away.
+        // 4a.6b (sol r2 finding 1): every append landed, so the batch is durable
+        // AND visible — the winner is decided. Advance the calibration stats and
+        // count the warn-mode flags NOW, both winner-only. Ticking or advancing
+        // before this point would have moved state for a batch whose append then
+        // failed and whose rows were compensated away — and a committed EWMA
+        // blend cannot be un-done by the compensating DELETE.
         //
-        // KNOWN RESIDUAL (sol 4a.6b finding 1, tracked as the 4a.6d batch
-        // restructure): the EWMA advances committed inside the savepoint are NOT
-        // reversed if an append fails here. Unlike a row DELETE or a counter
-        // decrement, a committed EWMA blend is IRREVERSIBLE by compensation — the
-        // prior value is gone — so the only correct fix is to RESERVE delta
-        // capacity before the savepoint (record()'s 4a.6a pattern) so append
-        // cannot fail post-commit. That is the batch's pre-existing
-        // incomplete-compensation gap (entities / graph_index have never been
-        // reversed here either), generalized; it is out of 4a.6b's scope and
-        // deliberately not half-patched.
+        // Grouped in one transaction so the N advances are all-or-nothing. Each
+        // is a plain upsert (SQL blend against the stored value; composes with
+        // concurrent writers), fed the RAW importance.
+        {
+            let conn = self.conn();
+            let tx = conn.unchecked_transaction()?;
+            for input in inputs.iter() {
+                self.advance_importance_stats_in_tx(&tx, &input.namespace, input.importance)?;
+            }
+            tx.commit()?;
+        }
         for verdict in gate_verdicts {
             self.note_flagged_write_committed(verdict);
         }
@@ -929,6 +943,18 @@ impl YantrikDB {
     /// timestamp + embedding_model. Engine does NOT call its own embedder
     /// or NER. Used by yantrikdb-server's cluster-mode applier so
     /// replicated writes are byte-deterministic across leader + followers.
+    ///
+    /// **`admission` (4a.6b, sol r2 finding 2) — REQUIRED, choose deliberately.**
+    /// This method is both a public origin API and the cluster apply primitive.
+    /// Pass `WriteAdmission::Admitted` from any consensus/replication APPLY path
+    /// (the leader already gated the op at origin ingress; re-gating on the apply
+    /// path makes followers reject the leader's committed write and wedge the
+    /// cluster). Pass `WriteAdmission::Origin` for a genuinely new write entering
+    /// here for the first time — it runs the anti-laundering gate exactly like
+    /// `record()`. It is a required argument, not a defaulted flag, so a caller
+    /// cannot silently inherit the apply bypass: `record_with_rid` was a public
+    /// Enforce bypass before this (a direct caller could persist
+    /// `source=inference` + `kind=fact`).
     ///
     /// # Contract
     ///
@@ -987,7 +1013,18 @@ impl YantrikDB {
         extracted_entities: &[&str],
         embedding_model: &str,
         seq: Option<u64>,
+        admission: crate::provenance::WriteAdmission,
     ) -> Result<()> {
+        // 4a.6b (sol r2 finding 2): the anti-laundering gate. ORIGIN callers are
+        // gated exactly like record(); ADMITTED callers (the materializer drain,
+        // replication apply) are NOT re-gated — the op was gated at the leader's
+        // origin ingress, and re-gating the apply path would make followers
+        // reject the leader's consensus-committed write and wedge the cluster
+        // (yantrikdb-server). A warn-mode Flagged verdict is counted post-commit.
+        let gate_verdict = match admission {
+            crate::provenance::WriteAdmission::Origin => self.gate_provenance(source, metadata)?,
+            crate::provenance::WriteAdmission::Admitted => crate::provenance::GateVerdict::Clean,
+        };
         // v0.7.23: coerce a blank namespace to the canonical default. This is
         // the path the server's commit applier uses (record_with_rid on every
         // node), so it closes the gateway `unwrap_or("")` footgun at the
@@ -1231,6 +1268,9 @@ impl YantrikDB {
             )?;
         }
 
+        // 4a.6b: an ORIGIN write that was warn-flagged and reached here is
+        // durable — count it now. ADMITTED writes carry Clean and tick nothing.
+        self.note_flagged_write_committed(gate_verdict);
         Ok(())
     }
 

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7249,6 +7249,170 @@ fn deferred_batch_leaves_importance_stats_untouched() {
     db.write_router.switch_to_normal();
 }
 
+/// 4a.6b sol r2 finding 2: `record_with_rid` is both the public origin API and
+/// the cluster apply primitive. As ORIGIN it must gate provenance (it was a
+/// public Enforce bypass — a Rust caller could persist source=inference/
+/// kind=fact directly). As ADMITTED it must NOT gate — re-gating a
+/// consensus-committed op on the apply path makes followers reject the leader
+/// and wedge the cluster. The required `WriteAdmission` arg forces the choice.
+#[test]
+fn record_with_rid_gates_origin_but_not_admitted() {
+    let mk = |db: &YantrikDB, rid: &str, adm: crate::provenance::WriteAdmission| {
+        db.record_with_rid(
+            rid,
+            "the sky is green",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &serde_json::json!({"kind": "fact"}), // laundering: inference + fact
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "work",
+            "inference",
+            None,
+            1_000_000,
+            &[],
+            "test-embedder",
+            None,
+            adm,
+        )
+    };
+
+    // ORIGIN, Enforce (fresh DB): the contradiction is refused.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    assert_eq!(db.stats(None).unwrap().provenance_gate_mode, "enforce");
+    let err = mk(&db, "rid_origin", crate::provenance::WriteAdmission::Origin)
+        .expect_err("origin record_with_rid must gate a declared contradiction");
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::ProvenanceInconsistent { .. }
+        ),
+        "expected ProvenanceInconsistent, got {err:?}"
+    );
+    let n: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE rid = 'rid_origin'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(n, 0, "refused origin write persisted nothing");
+
+    // ADMITTED, Enforce: the SAME op applies (it was gated at its origin; the
+    // apply path must not re-gate, or the cluster wedges).
+    mk(
+        &db,
+        "rid_admitted",
+        crate::provenance::WriteAdmission::Admitted,
+    )
+    .expect("admitted apply must NOT be re-gated");
+    let n: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE rid = 'rid_admitted'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(n, 1, "admitted apply committed");
+}
+
+/// 4a.6b sol r2 finding 1: a batch whose VECTOR APPEND fails (after the SQL
+/// savepoint has committed) must leave `namespace_importance_stats` untouched.
+/// The stats advance is deferred to after the append loop wins; before this fix
+/// it ran inside the savepoint, and a committed EWMA blend cannot be reversed by
+/// the compensating row DELETE — so a rejected batch permanently moved the
+/// namespace's calibration.
+#[test]
+fn batch_append_failure_leaves_importance_stats_untouched() {
+    // Saturate the delta so the NEXT append fails, using single-record writes in
+    // a DIFFERENT namespace so the target namespace's stats stay pristine.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let dim = db.embedding_dim();
+    let mut saturated = false;
+    for i in 0..400 {
+        let emb: Vec<f32> = (0..dim).map(|j| ((i + j) as f32) * 0.001).collect();
+        match db.record(
+            &format!("filler-{i}"),
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &emb,
+            "filler_ns",
+            0.8,
+            "general",
+            "user",
+            None,
+        ) {
+            Ok(_) => {}
+            Err(crate::error::YantrikDbError::Backpressure { .. }) => {
+                saturated = true;
+                break;
+            }
+            Err(e) => panic!("unexpected: {e:?}"),
+        }
+    }
+    assert!(saturated, "delta never saturated");
+
+    // The target namespace has no stats row yet.
+    let stats = |db: &YantrikDB| -> Option<(f64, i64)> {
+        db.conn()
+            .query_row(
+                "SELECT ewma, count FROM namespace_importance_stats WHERE namespace = 'batch_ns'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .ok()
+    };
+    assert_eq!(stats(&db), None, "precondition: no stats for batch_ns");
+
+    // A batch into batch_ns: SQL savepoint commits, then the vector append hits
+    // the saturated delta and fails, triggering the compensating DELETE.
+    let err = db
+        .record_batch(&[RecordInput {
+            text: "batch after saturation".into(),
+            memory_type: "semantic".into(),
+            importance: 0.9,
+            valence: 0.0,
+            half_life: 604800.0,
+            metadata: serde_json::json!({}),
+            embedding: vec_seed(2.0, 8),
+            namespace: "batch_ns".into(),
+            certainty: 0.8,
+            domain: "work".into(),
+            source: "user".into(),
+            emotional_state: None,
+        }])
+        .expect_err("append must fail into the saturated delta");
+    assert!(
+        matches!(err, crate::error::YantrikDbError::Backpressure { .. }),
+        "expected Backpressure from the append, got {err:?}"
+    );
+
+    // Rows compensated AND stats untouched (the winner-only guarantee).
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'batch_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(rows, 0, "compensating DELETE removed the batch rows");
+    assert_eq!(
+        stats(&db),
+        None,
+        "a batch whose append failed advanced namespace_importance_stats — \
+         a loser moved calibration state"
+    );
+}
+
 /// 4a.6b finding 3: the in-tx SQL EWMA advance must reproduce the predecessor's
 /// `count == 0 => ewma = raw` seed exactly. A `(ewma=X, count=0)` row is not
 /// produced by any engine path, but the schema permits it and `conn()` is
@@ -9328,6 +9492,7 @@ fn record_with_rid_basic_succeeds() {
         &[],
         "test-model.v1",
         None,
+        crate::provenance::WriteAdmission::Admitted,
     )
     .expect("record_with_rid succeeds");
 
@@ -9359,6 +9524,7 @@ fn record_with_rid_persists_v25_columns() {
         &[],
         "bge-base-en-v1.5",
         None,
+        crate::provenance::WriteAdmission::Admitted,
     )
     .unwrap();
 
@@ -9402,6 +9568,7 @@ fn record_with_rid_is_idempotent_on_replay() {
             &entity_refs,
             "test-model.v1",
             None,
+            crate::provenance::WriteAdmission::Admitted,
         )
         .expect("idempotent re-apply");
     }
@@ -9477,6 +9644,7 @@ fn record_with_rid_rejects_dimension_mismatch() {
             &[],
             "test-model.v1",
             None,
+            crate::provenance::WriteAdmission::Admitted,
         )
         .expect_err("must reject");
     match err {
@@ -9513,6 +9681,7 @@ fn record_with_rid_uses_caller_supplied_timestamp() {
         &[],
         "test-model.v1",
         None,
+        crate::provenance::WriteAdmission::Admitted,
     )
     .unwrap();
     // Verify created_at REAL and created_at_unix_micros INTEGER both
@@ -9557,6 +9726,7 @@ fn record_with_rid_makes_recall_find_it() {
         &[],
         "test-model.v1",
         None,
+        crate::provenance::WriteAdmission::Admitted,
     )
     .unwrap();
 
@@ -10066,6 +10236,7 @@ fn record_with_rid_uses_caller_supplied_seq_and_bumps_visible() {
         &[],
         "test-model.v1",
         Some(1_000_000),
+        crate::provenance::WriteAdmission::Admitted,
     )
     .unwrap();
     assert_eq!(
@@ -10094,6 +10265,7 @@ fn record_with_rid_uses_caller_supplied_seq_and_bumps_visible() {
         &[],
         "test-model.v1",
         None,
+        crate::provenance::WriteAdmission::Admitted,
     )
     .unwrap();
     assert!(
@@ -15163,6 +15335,7 @@ fn record_with_rid_backpressure_does_not_leak_orphan_memories_row() {
             &[],
             "test-embedder",
             None,
+            crate::provenance::WriteAdmission::Admitted,
         );
         if let Err(crate::error::YantrikDbError::Backpressure { .. }) = res {
             last_backpressure_rid = Some(attempted_rid);
@@ -15241,6 +15414,7 @@ fn record_with_rid_backpressure_does_not_overcount_session_memory_count() {
             &[],
             "test-embedder",
             None,
+            crate::provenance::WriteAdmission::Admitted,
         );
         if let Err(crate::error::YantrikDbError::Backpressure { .. }) = res {
             saw_backpressure = true;
@@ -15363,6 +15537,7 @@ fn record_with_rid_coerces_blank_namespace_to_default() {
         &[],
         "test-embedder",
         None,
+        crate::provenance::WriteAdmission::Admitted,
     )
     .unwrap();
     assert_eq!(

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7249,6 +7249,54 @@ fn deferred_batch_leaves_importance_stats_untouched() {
     db.write_router.switch_to_normal();
 }
 
+/// 4a.6b finding 3: the in-tx SQL EWMA advance must reproduce the predecessor's
+/// `count == 0 => ewma = raw` seed exactly. A `(ewma=X, count=0)` row is not
+/// produced by any engine path, but the schema permits it and `conn()` is
+/// public, so a stray zero-count row must SEED to the incoming raw, not blend
+/// the stale X in. Without the CASE, this stores 0.32 instead of 1.0.
+#[test]
+fn stats_advance_seeds_from_raw_when_stored_count_is_zero() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    db.conn()
+        .execute(
+            "INSERT INTO namespace_importance_stats (namespace, ewma, count, updated_at) \
+             VALUES ('zc', 0.2, 0, 1.0)",
+            [],
+        )
+        .unwrap();
+
+    // Drive one real write through the sync path into namespace 'zc'.
+    db.record(
+        "seed from raw",
+        "semantic",
+        1.0,
+        0.0,
+        604800.0,
+        &empty_meta(),
+        &vec_seed(1.0, 8),
+        "zc",
+        0.8,
+        "work",
+        "user",
+        None,
+    )
+    .unwrap();
+
+    let (ewma, count): (f64, i64) = db
+        .conn()
+        .query_row(
+            "SELECT ewma, count FROM namespace_importance_stats WHERE namespace = 'zc'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert!(
+        (ewma - 1.0).abs() < 1e-9,
+        "count=0 must seed ewma to raw (1.0), not blend the stale 0.2 in; got {ewma}"
+    );
+    assert_eq!(count, 1, "count advances to 1");
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7321,6 +7321,58 @@ fn record_with_rid_gates_origin_but_not_admitted() {
     assert_eq!(n, 1, "admitted apply committed");
 }
 
+/// 4a.6b sol r3 finding 2: `record_with_rid` is `INSERT OR IGNORE`, so replaying
+/// an existing rid persists nothing. A warn-mode ORIGIN replay of a flagged op
+/// must NOT tick `provenance_flagged_since_boot` — that counter gates the
+/// warn→enforce decision, and counting no-op replays inflates it with writes
+/// that never landed.
+#[test]
+fn record_with_rid_origin_replay_does_not_overcount_flags() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    db.set_provenance_gate_mode(crate::provenance::GateMode::Warn)
+        .unwrap();
+    let flagged = |db: &YantrikDB| db.stats(None).unwrap().provenance_flagged_since_boot;
+
+    let write = |db: &YantrikDB| {
+        db.record_with_rid(
+            "dup_rid",
+            "flagged origin write",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &serde_json::json!({"kind": "fact"}),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "work",
+            "inference",
+            None,
+            1_000_000,
+            &[],
+            "test-embedder",
+            None,
+            crate::provenance::WriteAdmission::Origin,
+        )
+    };
+
+    let n0 = flagged(&db);
+    write(&db).expect("first origin write lands");
+    assert_eq!(
+        flagged(&db),
+        n0 + 1,
+        "first flagged origin write ticks once"
+    );
+
+    // Replay the SAME rid: INSERT OR IGNORE persists nothing, so no tick.
+    write(&db).expect("replay is a no-op Ok");
+    assert_eq!(
+        flagged(&db),
+        n0 + 1,
+        "idempotent replay of an existing rid must not tick the nudge counter"
+    );
+}
+
 /// 4a.6b sol r2 finding 1: a batch whose VECTOR APPEND fails (after the SQL
 /// savepoint has committed) must leave `namespace_importance_stats` untouched.
 /// The stats advance is deferred to after the append loop wins; before this fix

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7012,6 +7012,243 @@ fn replicated_correction_publishes_its_vector_without_counting_a_pending_op() {
     assert_eq!(text, "the sky is blue", "replicated correction is durable");
 }
 
+/// The anti-laundering gate had a one-character bypass (found wiring 4a.6b,
+/// verified empirically before fixing): 4a.4b gated the scalar-only correction
+/// path, but a TEXT-CHANGING correction dispatches to `correct_with_reembed`
+/// BEFORE that gate runs — and merges `metadata_merge` all the same. So in
+/// Enforce mode, `correct(new_text=<any change>, metadata_merge={"kind":"fact"})`
+/// on an inference-sourced record committed the exact laundering the gate
+/// exists to refuse. Pre-fix: the scalar flip refused, the text flip stored
+/// kind="fact".
+#[test]
+fn text_changing_correction_cannot_launder_kind() {
+    let db = YantrikDB::new(":memory:", 8).unwrap(); // fresh ⇒ Enforce
+    assert_eq!(db.stats(None).unwrap().provenance_gate_mode, "enforce");
+    let rid = db
+        .record(
+            "the sky might be green",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "work",
+            "inference",
+            None,
+        )
+        .unwrap();
+    let gen = db.search_state.load().generation;
+
+    // The laundering attempt, via the path that used to bypass the gate.
+    let err = db
+        .correct_with_embedding(
+            &rid,
+            Some("the sky might be green!"),
+            &vec_seed(1.1, 8),
+            gen,
+            Some(&serde_json::json!({"kind": "fact"})),
+            None,
+            None,
+            "launder via text change",
+        )
+        .expect_err("text-changing kind flip must be refused in Enforce");
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::ProvenanceInconsistent { .. }
+        ),
+        "expected ProvenanceInconsistent, got {err:?}"
+    );
+
+    // Refused BEFORE any side effect: text, kind, and revision chain untouched.
+    let (text, kind): (String, Option<String>) = db
+        .conn()
+        .query_row(
+            "SELECT text, json_extract(metadata, '$.kind') FROM memories WHERE rid = ?1",
+            rusqlite::params![rid],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(text, "the sky might be green", "text must be unchanged");
+    assert_eq!(kind, None, "kind must not have been laundered in");
+    assert_eq!(db.history(&rid).unwrap().len(), 0, "no revision recorded");
+
+    // The documented escape is raising the basis — that must still work
+    // through the SAME text-changing path (the gate refuses contradictions,
+    // not corrections).
+    db.correct_with_embedding(
+        &rid,
+        Some("the sky is verified green"),
+        &vec_seed(1.2, 8),
+        gen,
+        Some(&serde_json::json!({"kind": "fact", "confidence_basis": "verification"})),
+        None,
+        None,
+        "verified independently",
+    )
+    .expect("basis-raising text correction must pass the gate");
+}
+
+/// 4a.6b winner-only, warn-mode half: a FLAGGED write that COMMITS ticks
+/// `provenance_flagged_since_boot` exactly once, on every gated path. (The
+/// anchor backpressure test proves the rejected side; this proves the
+/// accepted side didn't get lost in the verdict refactor.)
+#[test]
+fn flagged_committed_writes_tick_the_nudge_counter_exactly_once() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    db.set_provenance_gate_mode(crate::provenance::GateMode::Warn)
+        .unwrap();
+    let flagged = |db: &YantrikDB| db.stats(None).unwrap().provenance_flagged_since_boot;
+    let launder_meta = serde_json::json!({"kind": "fact"});
+
+    // record(): sync path.
+    let n0 = flagged(&db);
+    let rid = db
+        .record(
+            "flagged one",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &launder_meta,
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "work",
+            "inference",
+            None,
+        )
+        .unwrap();
+    assert_eq!(flagged(&db), n0 + 1, "committed flagged record ticks once");
+
+    // record(): queued path (router in Queueing).
+    db.write_router.switch_to_queueing();
+    db.record(
+        "flagged two",
+        "semantic",
+        0.7,
+        0.0,
+        604800.0,
+        &launder_meta,
+        &vec_seed(1.05, 8),
+        "default",
+        0.8,
+        "work",
+        "inference",
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        flagged(&db),
+        n0 + 2,
+        "committed flagged queued write ticks once"
+    );
+    db.write_router.switch_to_normal();
+
+    // record_batch(): two flagged inputs, one clean.
+    let mk = |text: &str, meta: serde_json::Value, source: &str| RecordInput {
+        text: text.into(),
+        memory_type: "semantic".into(),
+        importance: 0.7,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: meta,
+        embedding: vec_seed(1.1, 8),
+        namespace: "default".into(),
+        certainty: 0.8,
+        domain: "work".into(),
+        source: source.into(),
+        emotional_state: None,
+    };
+    db.record_batch(&[
+        mk("flagged three", launder_meta.clone(), "inference"),
+        mk("clean one", serde_json::json!({}), "user"),
+        mk("flagged four", launder_meta.clone(), "inference"),
+    ])
+    .unwrap();
+    assert_eq!(flagged(&db), n0 + 4, "batch ticks once per flagged input");
+
+    // correct(): scalar path (metadata-only flip on the inference record —
+    // warn allows it, counts it).
+    db.correct(&rid, None, Some(&launder_meta), None, None, "warn flip")
+        .unwrap();
+    assert_eq!(
+        flagged(&db),
+        n0 + 5,
+        "committed flagged correction ticks once"
+    );
+
+    // correct(): text-changing path (the ex-bypass — now gated AND counted).
+    let gen = db.search_state.load().generation;
+    db.correct_with_embedding(
+        &rid,
+        Some("flagged one, changed"),
+        &vec_seed(1.15, 8),
+        gen,
+        Some(&launder_meta),
+        None,
+        None,
+        "warn flip with text",
+    )
+    .unwrap();
+    assert_eq!(
+        flagged(&db),
+        n0 + 6,
+        "committed flagged text-correction ticks once"
+    );
+}
+
+/// 4a.6b, batch loser path: a batch deferred by the write-router (reembed
+/// cutover in flight) must leave every namespace's importance distribution
+/// untouched. Pre-fix, `record_batch` calibrated ALL inputs — autocommitting
+/// every namespace's EWMA advance — BEFORE it ever consulted the router.
+#[test]
+fn deferred_batch_leaves_importance_stats_untouched() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    db.write_router.switch_to_queueing();
+
+    let err = db
+        .record_batch(&[RecordInput {
+            text: "deferred".into(),
+            memory_type: "semantic".into(),
+            importance: 0.9,
+            valence: 0.0,
+            half_life: 604800.0,
+            metadata: serde_json::json!({}),
+            embedding: vec_seed(1.0, 8),
+            namespace: "bp_ns".into(),
+            certainty: 0.8,
+            domain: "work".into(),
+            source: "user".into(),
+            emotional_state: None,
+        }])
+        .expect_err("router is Queueing; the batch must defer");
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::BatchDeferredDuringReembed { .. }
+        ),
+        "expected BatchDeferredDuringReembed, got {err:?}"
+    );
+
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM namespace_importance_stats WHERE namespace = 'bp_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        rows, 0,
+        "a deferred batch advanced namespace_importance_stats — a loser moved state"
+    );
+    db.write_router.switch_to_normal();
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]
@@ -14485,17 +14722,19 @@ fn boundary_audit_pattern_detects_synthetic_violation() {
 
 #[cfg(feature = "bundled-embedder")]
 #[test]
-fn record_backpressure_writes_no_row_op_or_session_state() {
-    // **v0.10 Item 4a.6a.** The v0.7.19 sibling below asserts the OLD contract:
-    // the row was written, then a compensating DELETE reclaimed it. record() no
-    // longer needs compensating — it RESERVES delta capacity before touching SQL,
-    // so Backpressure surfaces without a row, an op, or session state.
+fn record_backpressure_writes_nothing_at_all() {
+    // **v0.10 Item 4a.6a + 4a.6b.** The v0.7.19 sibling below asserts the OLD
+    // contract: the row was written, then a compensating DELETE reclaimed it.
+    // record() no longer needs compensating — it RESERVES delta capacity before
+    // touching SQL, so Backpressure surfaces without a row, an op, or session
+    // state.
     //
-    // NAMED PRECISELY, because "writes nothing at all" would be a LIE (sol 4a.6a
-    // finding 2): `calibrate_importance` already autocommitted an update to
-    // `namespace_importance_stats` before routing, so a rejected write HAS moved
-    // this namespace's calibration. That defect predates 4a.6a and is fixed in
-    // 4a.6b (winner-only transactional calibration). What this test does assert:
+    // This test spent 4a.6a named `..._writes_no_row_op_or_session_state`,
+    // because "writes nothing at all" was then a LIE (sol 4a.6a finding 2):
+    // `calibrate_importance` autocommitted a `namespace_importance_stats` update
+    // before routing, and the warn-mode gate ticked its nudge counter before
+    // routing — so a rejected write HAD moved state. 4a.6b made both
+    // winner-only, and the name is finally the contract. Asserted:
     //
     //   1. no memories row              (the old design also achieved this, by
     //                                    writing one and deleting it)
@@ -14592,6 +14831,70 @@ fn record_backpressure_writes_no_row_op_or_session_state() {
     assert!(
         hit.is_some(),
         "delta never saturated — test did not exercise Backpressure"
+    );
+
+    // ── 4a.6b: the LOSER-side effects. The delta is saturated, so this probe is
+    // guaranteed to be rejected — and a rejected write must leave NO trace:
+    //
+    //   5. namespace_importance_stats UNCHANGED — calibrate_importance used to
+    //      autocommit the EWMA advance BEFORE routing, so every rejected write
+    //      still permanently moved this namespace's calibration distribution.
+    //   6. provenance_flagged_since_boot UNCHANGED — the warn-mode gate used to
+    //      tick its nudge counter BEFORE routing, so flagged-but-rejected writes
+    //      inflated the very metric that decides when warn can become enforce.
+    //
+    // The probe is deliberately BOTH flagged and rejected: source="inference" +
+    // kind="fact" + no confidence_basis is the anti-laundering violation, and in
+    // Warn mode that is counted-and-allowed — so only the Backpressure rejection
+    // downstream separates "accepted flagged write" (must count) from "rejected
+    // flagged write" (must not).
+    db.set_provenance_gate_mode(crate::provenance::GateMode::Warn)
+        .unwrap();
+    let stats_row = |db: &YantrikDB| -> Option<(f64, i64)> {
+        db.conn()
+            .query_row(
+                "SELECT ewma, count FROM namespace_importance_stats WHERE namespace = 'default'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .ok()
+    };
+    let stats_before = stats_row(&db);
+    let flagged_before = db.stats(None).unwrap().provenance_flagged_since_boot;
+
+    let embedding: Vec<f32> = (0..dim).map(|j| ((999 + j) as f32) * 0.001).collect();
+    let err = db
+        .record(
+            "bp-probe-flagged-and-rejected",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({"kind": "fact"}),
+            &embedding,
+            "default",
+            0.8,
+            "general",
+            "inference",
+            None,
+        )
+        .expect_err("delta is saturated; the probe must be rejected");
+    assert!(
+        matches!(err, crate::error::YantrikDbError::Backpressure { .. }),
+        "probe must fail with Backpressure, got {err:?}"
+    );
+
+    assert_eq!(
+        stats_row(&db),
+        stats_before,
+        "rejected write advanced namespace_importance_stats — a loser moved the \
+         namespace's calibration distribution permanently"
+    );
+    assert_eq!(
+        db.stats(None).unwrap().provenance_flagged_since_boot,
+        flagged_before,
+        "flagged-but-REJECTED write ticked provenance_flagged_since_boot — \
+         inflating the warn→enforce nudge metric with writes that never landed"
     );
 }
 

--- a/yantrikdb-for-novelists.html
+++ b/yantrikdb-for-novelists.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>YantrikDB — Capabilities Overview</title>
+<style>
+  :root {
+    --bg: #0e1116;
+    --panel: #161b22;
+    --ink: #e6edf3;
+    --muted: #9aa7b4;
+    --accent: #7c9cff;
+    --accent-2: #58d39b;
+    --line: #2a323d;
+    --code-bg: #0b0e13;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--ink);
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 900px; margin: 0 auto; padding: 0 24px; }
+
+  header {
+    border-bottom: 1px solid var(--line);
+    padding: 48px 0 32px;
+  }
+  h1 { font-size: 30px; margin: 0 0 8px; letter-spacing: -0.01em; }
+  .tagline { color: var(--muted); font-size: 17px; margin: 0 0 18px; max-width: 680px; }
+  .meta-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .chip {
+    font-size: 12.5px; color: var(--ink);
+    background: var(--panel); border: 1px solid var(--line);
+    padding: 5px 11px; border-radius: 7px;
+  }
+  .chip b { color: var(--accent-2); }
+
+  section { padding: 38px 0; border-bottom: 1px solid var(--line); }
+  h2 { font-size: 21px; margin: 0 0 6px; letter-spacing: -0.01em; }
+  .sub { color: var(--muted); margin: 0 0 22px; font-size: 15px; }
+  h3 { font-size: 15.5px; margin: 24px 0 8px; color: var(--accent); }
+  p { margin: 0 0 12px; }
+
+  /* what it is */
+  .what { color: var(--muted); font-size: 15.5px; }
+  .what b { color: var(--ink); }
+
+  /* capability list */
+  .caps { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  @media (max-width: 720px) { .caps { grid-template-columns: 1fr; } h1 { font-size: 25px; } }
+  .cap {
+    background: var(--panel); border: 1px solid var(--line);
+    border-radius: 10px; padding: 15px 17px;
+  }
+  .cap h4 { margin: 0 0 5px; font-size: 15px; }
+  .cap p { margin: 0; color: var(--muted); font-size: 14px; }
+  .cap code { color: var(--accent-2); font-size: 12.5px; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 14.5px; margin-top: 6px; }
+  th, td { text-align: left; padding: 10px 13px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+  td b { color: var(--ink); }
+  td.tool code { color: var(--accent-2); background: var(--code-bg); padding: 2px 6px; border-radius: 5px; font-size: 12.5px; }
+  .bench td b { color: var(--accent-2); }
+
+  pre {
+    background: var(--code-bg); border: 1px solid var(--line); border-radius: 10px;
+    padding: 16px 18px; overflow-x: auto; font-size: 13px; line-height: 1.55; margin: 14px 0;
+  }
+  code { font-family: "SF Mono", "JetBrains Mono", Consolas, "Liberation Mono", monospace; }
+  pre code { color: #d6dee8; }
+  .c { color: #6b7785; }
+  .k { color: #7c9cff; }
+  .s { color: #58d39b; }
+  .f { color: #f0b34a; }
+  .tablabel { font-size: 12.5px; color: var(--muted); margin: 18px 0 -6px; }
+
+  .api-list { columns: 2; column-gap: 28px; font-size: 14px; color: var(--muted); margin: 0; padding-left: 18px; }
+  @media (max-width: 720px) { .api-list { columns: 1; } }
+  .api-list li { margin: 4px 0; break-inside: avoid; }
+  .api-list code { color: var(--accent-2); font-size: 12.5px; }
+
+  footer { color: var(--muted); font-size: 12.5px; padding: 24px 0; text-align: center; }
+  a { color: var(--accent); }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <h1>YantrikDB — capabilities overview</h1>
+    <p class="tagline">
+      A cognitive memory engine for AI agents and apps: vector search, a knowledge graph, a
+      temporal model, decay, and conflict detection in one embedded engine. Notes below on how it
+      lines up with a novel-writing app.
+    </p>
+    <div class="meta-row">
+      <span class="chip">Engine <b>v0.7.22</b></span>
+      <span class="chip">Rust core · <b>Python + MCP</b></span>
+      <span class="chip">Embedded · <b>single file</b></span>
+      <span class="chip"><b>Local-first</b>, offline</span>
+      <span class="chip">MIT (MCP) / AGPL (engine)</span>
+    </div>
+  </div>
+</header>
+
+<!-- WHAT IT IS -->
+<section>
+  <div class="wrap">
+    <h2>What it is</h2>
+    <p class="what">
+      YantrikDB stores facts as <b>memories</b> rather than rows. You write in natural language and
+      query in natural language; the engine decides what's relevant using semantic similarity
+      <em>plus</em> recency, importance, and graph connections. It runs <b>embedded</b> — a single
+      SQLite file, no server process — and works <b>offline</b>. The Rust core is wrapped by a Python
+      package (<code>yantrikdb</code>) and an MCP server (<code>yantrikdb-mcp</code>) that exposes the
+      same operations as tools to Claude, Cursor, Windsurf, or any MCP client.
+    </p>
+    <p class="what">
+      It's built around <b>cognitive operations</b> — <code>record</code>, <code>recall</code>,
+      <code>relate</code>, <code>think</code> — not SQL, and it does background work between calls
+      (consolidation, conflict scanning, decay).
+    </p>
+  </div>
+</section>
+
+<!-- CAPABILITIES -->
+<section>
+  <div class="wrap">
+    <h2>Current capabilities (v0.7.22)</h2>
+    <p class="sub">Each ships today across the engine, the Python package, and the MCP server.</p>
+    <div class="caps">
+      <div class="cap"><h4>Five indexes, one engine</h4><p>Vector (HNSW), graph (entities), temporal (events), decay heap, and key-value — queried together.</p></div>
+      <div class="cap"><h4>Relevance-conditioned recall</h4><p>Blends semantic similarity, temporal decay, importance, graph proximity, and retrieval feedback. Weights auto-tune from usage.</p></div>
+      <div class="cap"><h4>Knowledge graph</h4><p>Entity relations, profile aggregation, relationship-depth queries, and memory↔entity linking for graph-boosted recall. <code>relate · get_edges · entity_profile</code></p></div>
+      <div class="cap"><h4>First-class record links</h4><p>Link memory to memory: <code>advances</code>, <code>supersedes</code>, <code>contradicts</code>, <code>supports</code>, <code>questions</code>, <code>derived_from</code>, or <code>custom:&lt;name&gt;</code>. Recall can expand linked records.</p></div>
+      <div class="cap"><h4>Conflict detection &amp; resolution</h4><p>Contradicting facts become typed, prioritized conflict segments you resolve explicitly — no silent guessing. <code>scan_conflicts · resolve_conflict</code></p></div>
+      <div class="cap"><h4>Think / consolidate</h4><p><code>think()</code> merges similar memories, scans for conflicts, mines cross-domain patterns, and evaluates triggers.</p></div>
+      <div class="cap"><h4>Memory types</h4><p>Semantic (facts), episodic (events), procedural (strategies) — each carrying importance, valence, domain, source, certainty, timestamps.</p></div>
+      <div class="cap"><h4>Temporal awareness</h4><p>Decay models forgetting; <code>stale()</code> / <code>upcoming()</code> surface fading high-importance facts and approaching deadlines.</p></div>
+      <div class="cap"><h4>Proactive triggers</h4><p>Flags what's worth surfacing: unresolved conflicts, decaying important facts, detected patterns — all grounded in stored data.</p></div>
+      <div class="cap"><h4>Multi-device CRDT sync</h4><p>Append-only replication log; memories and graph edges merge conflict-free. Tombstones make "forget" propagate.</p></div>
+      <div class="cap"><h4>Sessions</h4><p>Group a working session's writes; auto-computes memory count, topics, average valence, duration.</p></div>
+      <div class="cap"><h4>Namespaces</h4><p>Isolated partitions in one database — e.g. one per book or series.</p></div>
+      <div class="cap"><h4>Embedded &amp; private</h4><p>Single SQLite file, no server, data stays local. A separate <code>yantrikdb-server</code> adds Raft-replicated cluster mode if needed.</p></div>
+      <div class="cap"><h4>Zero-setup embeddings</h4><p>Bundled ~7 MB embedder (~89% of MiniLM quality). One line swaps in a stronger model when wanted.</p></div>
+      <div class="cap"><h4>MCP + framework adapters</h4><p>Drop-in MCP server, plus LangChain, CrewAI, and OpenAI-Agents adapters.</p></div>
+      <div class="cap"><h4>Decoupled write path</h4><p>Two-tier LSM vector index: foreground writes touch a small delta; HNSW work amortizes on a background thread, so writes never starve reads.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- FULL API -->
+<section>
+  <div class="wrap">
+    <h2>Full operation set</h2>
+    <p class="sub">The complete API surface, by area.</p>
+    <ul class="api-list">
+      <li><b>Core</b> — <code>record</code>, <code>record_batch</code>, <code>recall</code>, <code>recall_with_response</code>, <code>recall_refine</code>, <code>forget</code>, <code>correct</code></li>
+      <li><b>Links</b> — <code>record_with_links</code>, <code>record_with_links_partial</code>, <code>recall_with_links</code></li>
+      <li><b>Knowledge graph</b> — <code>relate</code>, <code>get_edges</code>, <code>search_entities</code>, <code>entity_profile</code>, <code>relationship_depth</code>, <code>link_memory_entity</code></li>
+      <li><b>Cognition</b> — <code>think</code>, <code>get_patterns</code>, <code>scan_conflicts</code>, <code>resolve_conflict</code>, <code>derive_personality</code></li>
+      <li><b>Triggers</b> — <code>get_pending_triggers</code>, <code>acknowledge_trigger</code>, <code>deliver_trigger</code>, <code>act_on_trigger</code>, <code>dismiss_trigger</code></li>
+      <li><b>Sessions</b> — <code>session_start</code>, <code>session_end</code>, <code>session_history</code>, <code>active_session</code></li>
+      <li><b>Temporal</b> — <code>stale</code>, <code>upcoming</code></li>
+      <li><b>Procedural</b> — <code>record_procedural</code>, <code>surface_procedural</code>, <code>reinforce_procedural</code></li>
+      <li><b>Lifecycle</b> — <code>archive</code>, <code>hydrate</code>, <code>decay</code>, <code>evict</code>, <code>list_memories</code>, <code>stats</code></li>
+      <li><b>Sync</b> — <code>extract_ops_since</code>, <code>apply_ops</code>, <code>get_peer_watermark</code>, <code>set_peer_watermark</code></li>
+      <li><b>Maintenance</b> — <code>rebuild_vec_index</code>, <code>rebuild_graph_index</code>, <code>learned_weights</code></li>
+    </ul>
+  </div>
+</section>
+
+<!-- NOVEL MAPPING -->
+<section>
+  <div class="wrap">
+    <h2>How it maps to a novel-writing app</h2>
+    <p class="sub">The same primitives, applied to a story bible.</p>
+    <table>
+      <thead>
+        <tr><th>Capability</th><th>Use in the app</th><th class="tool">Tool</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><b>Semantic recall</b></td><td>"What is the protagonist afraid of?" surfaces the fact even 80k words later, without exact keywords.</td><td class="tool"><code>recall</code></td></tr>
+        <tr><td><b>Knowledge graph</b></td><td>Model the cast — alliances, feuds, oaths, family lines — and query a character's whole web of connections.</td><td class="tool"><code>relate · get_edges</code></td></tr>
+        <tr><td><b>Record links</b></td><td>Tie a ch.3 clue to its ch.18 payoff; recall the payoff and the seed comes with it.</td><td class="tool"><code>record_with_links</code></td></tr>
+        <tr><td><b>Conflict detection</b></td><td>"Aria's eyes are green" clashes with canonical "storm-grey" — surfaced for review.</td><td class="tool"><code>think · scan_conflicts</code></td></tr>
+        <tr><td><b>Temporal index</b></td><td>Keep in-story chronology straight and surface approaching plot deadlines.</td><td class="tool"><code>stale · upcoming</code></td></tr>
+        <tr><td><b>Memory types</b></td><td>Hard canon (semantic) vs. one-off scene beats (episodic) vs. writing strategies (procedural).</td><td class="tool"><code>record</code></td></tr>
+        <tr><td><b>Namespaces / sync</b></td><td>One book per namespace; draft on a laptop, edit on a tablet, bibles merge conflict-free.</td><td class="tool"><code>apply_ops</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3>Why selective recall matters here</h3>
+    <p class="sub" style="margin-bottom:8px">Token cost stays flat as the bible grows; precision rises with more data. (From the repo's benchmark.)</p>
+    <table class="bench">
+      <thead><tr><th>Bible size</th><th>Prompt-stuffed</th><th>YantrikDB</th><th>Token savings</th><th>Precision</th></tr></thead>
+      <tbody>
+        <tr><td>100 facts</td><td>1,770 tok</td><td>69 tok</td><td><b>96%</b></td><td>66%</td></tr>
+        <tr><td>500 facts</td><td>9,807 tok</td><td>72 tok</td><td><b>99.3%</b></td><td>77%</td></tr>
+        <tr><td>1,000 facts</td><td>19,988 tok</td><td>72 tok</td><td><b>99.6%</b></td><td>84%</td></tr>
+        <tr><td>5,000 facts</td><td>101,739 tok</td><td>53 tok</td><td><b>99.9%</b></td><td>88%</td></tr>
+      </tbody>
+    </table>
+    <p class="sub" style="margin-top:10px">At ~500 facts a stuffed bible already exceeds a 32K window; at 5,000 it fits in no window. YantrikDB stays near 70 tokens per query.</p>
+  </div>
+</section>
+
+<!-- USING IT -->
+<section>
+  <div class="wrap">
+    <h2>Using it</h2>
+    <p class="sub">As a Python library, or over MCP with no integration code.</p>
+
+    <p class="tablabel">Python — a story bible in ~25 lines</p>
+<pre><code><span class="k">import</span> yantrikdb
+
+db = yantrikdb.YantrikDB.<span class="f">with_default</span>(<span class="s">"novel_bible.db"</span>)   <span class="c"># single local file</span>
+
+<span class="c"># 1. store canon facts</span>
+db.<span class="f">record</span>(<span class="s">"Aria Veth has storm-grey eyes and fears deep water."</span>,
+          importance=<span class="s">0.9</span>, domain=<span class="s">"character"</span>)
+clue = db.<span class="f">record</span>(<span class="s">"In ch.3 Aria flinches at the harbour at dusk."</span>,
+                 importance=<span class="s">0.7</span>, domain=<span class="s">"plot"</span>)
+
+<span class="c"># 2. character / faction graph</span>
+db.<span class="f">relate</span>(src=<span class="s">"Aria Veth"</span>, dst=<span class="s">"House Veth"</span>, rel_type=<span class="s">"member_of"</span>)
+db.<span class="f">relate</span>(src=<span class="s">"House Veth"</span>, dst=<span class="s">"House Corin"</span>, rel_type=<span class="s">"blood_feud_with"</span>)
+
+<span class="c"># 3. fuzzy recall — no exact keywords needed</span>
+<span class="k">for</span> r <span class="k">in</span> db.<span class="f">recall</span>(<span class="s">"what is the protagonist afraid of?"</span>, top_k=<span class="s">3</span>):
+    <span class="f">print</span>(r[<span class="s">"score"</span>], r[<span class="s">"text"</span>])
+
+<span class="c"># 4. link a plant to its payoff</span>
+db.<span class="f">record_with_links</span>(
+    text=<span class="s">"In ch.18 Aria nearly drowns escaping the harbour ambush."</span>,
+    links=[{<span class="s">"target_rid"</span>: clue, <span class="s">"link_type"</span>: <span class="s">"custom:pays_off"</span>}])
+
+<span class="c"># 5. consistency check</span>
+db.<span class="f">record</span>(<span class="s">"Aria Veth's eyes are bright green."</span>)   <span class="c"># contradicts canon</span>
+db.<span class="f">think</span>()                                       <span class="c"># runs conflict scan</span>
+<span class="k">for</span> c <span class="k">in</span> db.<span class="f">get_conflicts</span>(status=<span class="s">"open"</span>):
+    <span class="f">print</span>(<span class="s">"conflict:"</span>, c)
+
+db.<span class="f">close</span>()</code></pre>
+
+    <p class="tablabel">MCP — expose the same operations to an AI assistant</p>
+<pre><code><span class="c">// .mcp.json</span>
+{
+  <span class="s">"mcpServers"</span>: {
+    <span class="s">"yantrikdb"</span>: {
+      <span class="s">"command"</span>: <span class="s">"uvx"</span>,
+      <span class="s">"args"</span>: [<span class="s">"yantrikdb-mcp"</span>],
+      <span class="s">"env"</span>: { <span class="s">"YANTRIKDB_DB_PATH"</span>: <span class="s">"./novels/storm-veth.db"</span> }
+    }
+  }
+}</code></pre>
+    <p class="sub" style="margin-top:6px">The assistant then has <code>remember · recall · relate · graph · record_with_links · recall_with_links · conflict · think</code> as callable tools — the writer just talks, the model calls the right one.</p>
+  </div>
+</section>
+
+<!-- NOTES -->
+<section>
+  <div class="wrap">
+    <h2>Notes &amp; limitations</h2>
+    <div class="caps">
+      <div class="cap"><h4>Suggests, doesn't auto-edit</h4><p>Conflict detection is semantic/heuristic, not a logic prover — it flags likely contradictions for review.</p></div>
+      <div class="cap"><h4>Embedded by design</h4><p>One file, ideal for desktop/offline. Multi-user cloud needs the separate <code>yantrikdb-server</code> (Raft cluster mode).</p></div>
+      <div class="cap"><h4>Licensing</h4><p>MCP server is MIT; core engine is AGPL. Fine for SaaS / self-host; check before shipping a closed-source binary.</p></div>
+      <div class="cap"><h4>Embeddings are tunable</h4><p>Default bundled model is ~89% of MiniLM at 7 MB; swap in a stronger model with one line for sharper recall.</p></div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    YantrikDB v0.7.22 · <code>pip install yantrikdb</code> · capabilities reflect the version shown.
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
**v0.10 Item 4a.6b — winner-only transactional calibration.** Losers no longer move state, on any ingest path. Plus an Enforce-mode gate bypass found while wiring, and a public provenance bypass closed with a compile-safe design.

## The core defect

`calibrate_importance` read the namespace stats, blended the EWMA in Rust, and wrote it back on a bare `conn()` — an **autocommit** — at the ingest entry point, **before routing**. So a write rejected afterwards (backpressure, delta capacity, the gate, a failed tx) had already advanced that namespace's calibration permanently. The warn-mode gate had the same shape: it ticked `provenance_flagged_since_boot` pre-routing, inflating the warn→enforce nudge metric with writes that never landed.

## The fix, per path

Split into read-only compute + an in-tx advance:
- `calibrated_importance[_on]` — read-only; the `_on` variant reads through a held conn (the batch path, where a re-lock would be the #83 deadlock).
- `advance_importance_stats_in_tx` — the write, in the winner's transaction, fed the **raw** value. **SQL blends against the stored EWMA** — the old read-in-Rust/write-back was a TOCTOU where two concurrent writers both blend from the same snapshot and the second silently clobbers the first. `EWMA_ALPHA` is a bound parameter, never spelled into the SQL (#83: one definition).
- `gate_provenance` returns a `#[must_use] GateVerdict`; warn flags tick via `note_flagged_write_committed` **only after the write is durable**.

Wired where each path's winner is decided: `record`/`record_text` inside the 4a.6a tx; `record_queued` in the pending-op tx; `record_batch` calibrates against the pre-batch snapshot inside the savepoint and **advances after the append loop wins** (deferred, so a compensated batch moves nothing).

Result: `record` / `record_text` / `record_queued` are **fully winner-only**; `record_batch` is winner-only for routing/gate/backpressure rejection **and** for the post-append failure.

## Two bypasses found and closed

- **Gate bypass (Enforce):** a text-changing correction dispatched to `correct_with_reembed` **before** the 4a.4b scalar-path gate ran, and merged `metadata_merge` all the same. `correct(new_text="…!", metadata_merge={"kind":"fact"})` on an inference record committed `kind=fact`. Now gated on the final merged metadata inside the tx closure.
- **`record_with_rid` public bypass:** it's `pub`, never gated, so a Rust caller could persist `source=inference`/`kind=fact` past Enforce. Closed with a **required** `WriteAdmission::{Origin, Admitted}` arg — Origin gates like `record()`, Admitted skips (the consensus-admission rule; re-gating the apply path wedges clusters). Required = a **compile error** for external appliers on pin, not a silent wedge — it forces a deliberate choice per call site. `yantrikdb-server` notified. (This is the 4a.4 gate, **orthogonal** to the pending origin-guard decision.)

## Every fix proven, not asserted

Tests proven to fail on the unfixed code (source stashed, tests kept) or mutation-proven:
- `record_backpressure_writes_nothing_at_all` — renamed from `..._writes_no_row_op_or_session_state`, which was honest about a lie; the lie is fixed and the name is now the contract. Rejected writes move neither stats nor the nudge counter.
- `text_changing_correction_cannot_launder_kind`, `record_with_rid_gates_origin_but_not_admitted`, `record_with_rid_origin_replay_does_not_overcount_flags`, `batch_append_failure_leaves_importance_stats_untouched`, `deferred_batch_leaves_importance_stats_untouched`, `flagged_committed_writes_tick_the_nudge_counter_exactly_once`, `stats_advance_seeds_from_raw_when_stored_count_is_zero`.

## Review: 4 sol rounds, and two of my own regressions caught

sol reviewed this four times. r1: count=0 EWMA seed + batch flag-tick. r2: batch EWMA fully winner-only + the `record_with_rid` split. **r3: two regressions from my *own* r2 fixes** — a deferred stats tx that returned `Err` after the batch was durable (retry → duplicate records; now best-effort) and a flag overcount on idempotent replay (now gated on `was_new_row`). Every round found something real; r3's were bugs I introduced fixing r2. That's the value of not self-certifying.

## Scoped out, filed

- **#94** — a **pre-existing** Err-after-commit class (`record_batch`'s `log_record_ops_batch`, `record_with_rid`'s `log_op`, `forget`'s link-repair all `?`-return after the row is durable; IO-failure-only; #79-era). NOT best-effortable — the correct fix is moving the oplog append inside the row tx (held-conn variants). Structural, cross-cutting, distinct from calibration.
- **#92** — the batch's entities/graph_index non-atomicity on vector-append failure (reserve-before-savepoint = 4a.6d).

sol confirmed the calibration/gate work is correct; its standing r4 REJECT is about #94's pre-existing class, which is deliberately out of scope.

**Ledger:** like #82, this ships with a standing sol REJECT whose remaining finding (#94) is a pre-existing bug this PR did not introduce — an explicit scope call, not a silent one. Tracked so it doesn't quietly become permanent.

Rust lib **1726** default / **1728** with `--features testing`; 3 kill proofs green; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
