### PR TITLE
feat(v0.10-4a.6c): durable idempotency claim — repetition is not corroboration (T07)

### DIFF
--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -261,6 +261,33 @@ pub enum YantrikDbError {
     #[error("provenance rejected at {path}: {reason}")]
     ProvenanceInconsistent { path: &'static str, reason: String },
 
+    /// **v0.10 Item 4a.6c — durable idempotency (T07).** The caller reused an
+    /// idempotency key whose committed claim does not match this write —
+    /// normally a DIFFERENT payload digest under the same key ("repetition is
+    /// not corroboration": the first write's content stands; a same-key rewrite
+    /// must be loud, never a silent near-dup merge). `existing_rid` is the
+    /// record the key already binds to, so the caller can inspect what it
+    /// conflicts with. Also raised, with a distinguishing `reason`, for
+    /// anomalous claim states (e.g. a crashed pre-commit claim from a future
+    /// engine version) where returning a rid would assert a write that may not
+    /// exist.
+    #[error(
+        "idempotency conflict in namespace '{namespace}' (existing rid {existing_rid}): {reason}"
+    )]
+    IdempotencyConflict {
+        namespace: String,
+        existing_rid: String,
+        reason: String,
+    },
+
+    /// **v0.10 Item 4a.6c.** The caller passed an idempotency key the engine
+    /// refuses to accept (empty / whitespace-only / over-long). Rejected
+    /// loudly instead of coerced: silently treating `""` as "no key" would
+    /// leave a caller believing they have dedup protection they don't have —
+    /// the same silent-failure class the rest of Item 4a exists to kill.
+    #[error("invalid idempotency key: {reason}")]
+    InvalidIdempotencyKey { reason: String },
+
     /// **Phase 6 RYW**: caller-requested visible_seq was not reached within
     /// the timeout window. Either the write that should have bumped the seq
     /// has not yet materialized (legitimate timeout — caller should retry or

--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -574,14 +574,19 @@ fn materialize_record(
     let domain = payload["domain"].as_str().unwrap_or("general");
     let source = payload["source"].as_str().unwrap_or("user");
     let emotional_state = payload["emotional_state"].as_str();
+    // 4a.6c: the v37 idempotency columns, mirrored from the origin (same
+    // extend-the-#69-pattern as source above). Absent/null on pre-4a.6c ops
+    // and keyless writes -> NULL, identical to the old row shape.
+    let idempotency_key = payload["idempotency_key"].as_str();
+    let claim_origin_actor = payload["origin_actor"].as_str();
 
     // Add-Wins Set: INSERT OR IGNORE means first writer wins (UUIDv7 = no collisions)
     conn.execute(
         "INSERT OR IGNORE INTO memories \
          (rid, type, text, created_at, updated_at, importance, \
           half_life, last_access, valence, metadata, namespace, \
-          certainty, domain, source, emotional_state) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+          certainty, domain, source, emotional_state, idempotency_key, origin_actor) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
         params![
             rid,
             mem_type,
@@ -598,6 +603,8 @@ fn materialize_record(
             domain,
             source,
             emotional_state,
+            idempotency_key,
+            claim_origin_actor,
         ],
     )?;
 

--- a/crates/yantrikdb-core/src/engine/idempotency.rs
+++ b/crates/yantrikdb-core/src/engine/idempotency.rs
@@ -43,6 +43,20 @@
 //! `'pending'` (and the startup sweep that reconciles it) becomes real the day
 //! a claim must be visible across a transaction boundary (4b multi-writer /
 //! cross-process claims); the column is schema-reserved for that, not dead.
+//!
+//! ## Claims are immutable, and `forget()` does not clean them — deliberately
+//!
+//! Nothing UPDATEs or DELETEs a claim row (verified: one INSERT, two SELECTs,
+//! nothing else touches the table — this immutability is what makes the
+//! pre-admission probe's lock-free HIT sound). Consequence: retrying a key
+//! whose record was since `forget()`-ten returns the TOMBSTONED rid. That is
+//! the honest answer — the write happened exactly once, and forgetting it was
+//! a separate, later act; deleting the claim instead would make a retry
+//! silently RE-CREATE forgotten content (resurrection). Callers that want to
+//! re-record forgotten content use a new key. (Same family as #88's
+//! forget-cascade question; if a future sweep ever reaps claims for
+//! tombstoned rids, the probe's immutability assumption must be revisited
+//! together with it.)
 
 use rusqlite::{params, OptionalExtension};
 

--- a/crates/yantrikdb-core/src/engine/idempotency.rs
+++ b/crates/yantrikdb-core/src/engine/idempotency.rs
@@ -95,6 +95,82 @@ pub(crate) enum ClaimAttempt {
     Hit { existing_rid: String },
 }
 
+/// Resolve an EXISTING claim row against this attempt's digest — the single
+/// owner of hit/conflict semantics, shared by the pre-admission probe and the
+/// in-transaction lost-INSERT branch (#83: one rule, one spelling).
+fn resolve_existing(
+    namespace: &str,
+    payload_digest: &[u8; 32],
+    existing_rid: String,
+    existing_digest: &[u8],
+    state: &str,
+) -> Result<ClaimAttempt> {
+    if existing_digest != &payload_digest[..] {
+        return Err(YantrikDbError::IdempotencyConflict {
+            namespace: namespace.to_string(),
+            existing_rid,
+            reason: "same idempotency key with a DIFFERENT payload — the first \
+                     write's content stands; change the key or the payload"
+                .to_string(),
+        });
+    }
+    if state != "committed" {
+        // 4a.6c never durably writes 'pending' (claim + op share one tx). A
+        // pending row here means a crash artifact from a future engine version
+        // whose claim/commit are split; refuse loudly rather than return a rid
+        // whose write may not exist.
+        return Err(YantrikDbError::IdempotencyConflict {
+            namespace: namespace.to_string(),
+            existing_rid,
+            reason: format!(
+                "claim is in state '{state}', not 'committed' — a crashed \
+                 prior attempt; the recovery sweep that reconciles this is \
+                 not yet implemented"
+            ),
+        });
+    }
+    Ok(ClaimAttempt::Hit { existing_rid })
+}
+
+/// **Pre-admission probe** (sol 4a.6c finding 1): a READ-ONLY lookup of the
+/// claim, run BEFORE backpressure checks, delta reservation, and seq/HLC
+/// allocation. A duplicate retry writes nothing, so it must resolve to its
+/// Hit/conflict even when the engine is saturated — Backpressure storms are
+/// exactly when clients retry, and a dup retry that can only ever see
+/// `Backpressure` is a retry loop that never converges.
+///
+/// Race window: a MISS here is advisory only — the authoritative decision
+/// remains the `ON CONFLICT` INSERT inside the write transaction
+/// ([`claim_in_tx`]), exactly as the design doc specifies for this probe. A
+/// HIT here is final: committed claims are immutable in 4a (single writer, no
+/// delete path), so acting on one read outside the lock is sound.
+pub(crate) fn probe_committed_claim(
+    conn: &rusqlite::Connection,
+    origin_actor: &str,
+    namespace: &str,
+    idempotency_key: &str,
+    payload_digest: &[u8; 32],
+) -> Result<Option<String>> {
+    let existing: Option<(String, Vec<u8>, String)> = conn
+        .query_row(
+            "SELECT rid, payload_digest, state FROM idempotency_claims \
+             WHERE origin_actor = ?1 AND namespace = ?2 AND idempotency_key = ?3",
+            params![origin_actor, namespace, idempotency_key],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .optional()?;
+    match existing {
+        None => Ok(None),
+        Some((rid, digest, state)) => {
+            match resolve_existing(namespace, payload_digest, rid, &digest, &state)? {
+                ClaimAttempt::Hit { existing_rid } => Ok(Some(existing_rid)),
+                // resolve_existing never returns Won.
+                ClaimAttempt::Won => unreachable!("resolve_existing cannot yield Won"),
+            }
+        }
+    }
+}
+
 /// INSERT-or-resolve the claim inside the caller's open transaction. See the
 /// module doc for the rule. MUST be the first write of the transaction.
 pub(crate) fn claim_in_tx(
@@ -149,29 +225,11 @@ pub(crate) fn claim_in_tx(
         });
     };
 
-    if existing_digest.as_slice() != &claim.payload_digest[..] {
-        return Err(YantrikDbError::IdempotencyConflict {
-            namespace: claim.namespace.to_string(),
-            existing_rid,
-            reason: "same idempotency key with a DIFFERENT payload — the first \
-                     write's content stands; change the key or the payload"
-                .to_string(),
-        });
-    }
-    if state != "committed" {
-        // 4a.6c never durably writes 'pending' (claim + op share one tx). A
-        // pending row here means a crash artifact from a future engine version
-        // whose claim/commit are split; refuse loudly rather than return a rid
-        // whose write may not exist.
-        return Err(YantrikDbError::IdempotencyConflict {
-            namespace: claim.namespace.to_string(),
-            existing_rid,
-            reason: format!(
-                "claim is in state '{state}', not 'committed' — a crashed \
-                 prior attempt; the recovery sweep that reconciles this is \
-                 not yet implemented"
-            ),
-        });
-    }
-    Ok(ClaimAttempt::Hit { existing_rid })
+    resolve_existing(
+        claim.namespace,
+        claim.payload_digest,
+        existing_rid,
+        &existing_digest,
+        &state,
+    )
 }

--- a/crates/yantrikdb-core/src/engine/idempotency.rs
+++ b/crates/yantrikdb-core/src/engine/idempotency.rs
@@ -1,0 +1,176 @@
+//! **v0.10 Item 4a.6c — the durable idempotency claim** (design doc §E,
+//! "claim-after-routing saga").
+//!
+//! One owner for the claim's INSERT-or-resolve, used by BOTH write routes
+//! (sync: `record_under_guard_and_state`'s transaction; queued: the pending-op
+//! transaction in `log_op_pending_for_reembed_queue`). The routes differ in
+//! what their authoritative op is; the claim rule is identical — which is
+//! exactly why it must not be spelled twice (#83).
+//!
+//! ## The rule
+//!
+//! `INSERT ... ON CONFLICT(origin_actor, namespace, idempotency_key) DO
+//! NOTHING` **is the serialization point** — never a prior SELECT (that would
+//! be the TOCTOU shape). If the INSERT wins, this write owns the key and
+//! proceeds; the claim commits atomically with the authoritative op. If it
+//! loses, the surviving claim is read back and resolved by payload digest:
+//!
+//! - same digest  → **idempotent hit**: return the ORIGINAL rid; the caller
+//!   aborts its transaction (nothing it wrote survives) and skips every
+//!   post-commit effect — no second row, no second op, no stats advance, no
+//!   flag tick, no session bump. Repetition is not corroboration (T07).
+//! - different digest → typed `IdempotencyConflict` — same key reused for a
+//!   semantically different write is a caller bug and must be loud, never a
+//!   silent near-dup merge.
+//!
+//! ## Why the claim is the FIRST statement in the caller's transaction
+//!
+//! v37 ships a defense-in-depth partial unique index on
+//! `memories(origin_actor, namespace, idempotency_key)`. If the row INSERT ran
+//! before the claim check, a dup retry would hit that index and surface as a
+//! bare constraint error instead of resolving to a hit/conflict. Claim-first
+//! also makes the dup path cheap: the losing transaction has written nothing
+//! when it aborts.
+//!
+//! ## Why `state` is written as `'committed'` directly (and `'pending'` is
+//! unused here)
+//!
+//! The design doc's pending→committed lifecycle exists so a claim that is
+//! durable BEFORE its write can be reconciled after a crash. In 4a.6c both
+//! routes insert the claim INSIDE the same transaction as their authoritative
+//! op, so there is no instant where a claim is durable and its op is not — a
+//! crash rolls back both, and `'pending'` would be unobservable theater.
+//! `'pending'` (and the startup sweep that reconciles it) becomes real the day
+//! a claim must be visible across a transaction boundary (4b multi-writer /
+//! cross-process claims); the column is schema-reserved for that, not dead.
+
+use rusqlite::{params, OptionalExtension};
+
+use crate::error::{Result, YantrikDbError};
+
+use super::now;
+
+/// Everything the claim row needs. Built by the route that owns the
+/// transaction; digested BEFORE routing from the RAW caller payload.
+pub(crate) struct ClaimRow<'a> {
+    pub origin_actor: &'a str,
+    pub namespace: &'a str,
+    pub idempotency_key: &'a str,
+    /// The rid THIS attempt minted (stored only if the claim wins).
+    pub rid: &'a str,
+    /// blake3 over the canonical RAW payload (`payload_digest::payload_digest`).
+    pub payload_digest: &'a [u8; 32],
+    /// The authoritative op this claim binds to — recovery evidence, minted by
+    /// the caller BEFORE the transaction so claim and op agree.
+    pub op_id: &'a str,
+    /// 'sync' | 'queued'.
+    pub route: &'static str,
+    /// Search generation at claim time.
+    pub generation: i64,
+}
+
+/// The queued route's claim inputs. The pending-op helper owns the transaction
+/// AND mints the op id, so the route hands over everything else and the helper
+/// assembles the full [`ClaimRow`] (op_id = the pending op it is about to
+/// write, route = "queued") — keeping op and claim agreeing by construction.
+pub(crate) struct PendingClaim<'a> {
+    pub idempotency_key: &'a str,
+    pub payload_digest: &'a [u8; 32],
+    /// The rid the queued write minted (returned to the caller; the
+    /// materializer creates the row under it later).
+    pub rid: &'a str,
+    /// Search generation at claim time.
+    pub generation: i64,
+}
+
+/// Outcome of [`claim_in_tx`]. A conflict is an `Err`, not a variant — it must
+/// propagate.
+#[must_use]
+pub(crate) enum ClaimAttempt {
+    /// This write owns the key. Proceed; the claim commits with the op.
+    Won,
+    /// The key is already committed with the SAME payload — return this rid to
+    /// the caller and abort the surrounding transaction untouched.
+    Hit { existing_rid: String },
+}
+
+/// INSERT-or-resolve the claim inside the caller's open transaction. See the
+/// module doc for the rule. MUST be the first write of the transaction.
+pub(crate) fn claim_in_tx(
+    conn: &rusqlite::Connection,
+    claim: &ClaimRow<'_>,
+) -> Result<ClaimAttempt> {
+    let inserted = conn.execute(
+        "INSERT INTO idempotency_claims \
+         (origin_actor, namespace, idempotency_key, rid, payload_digest, \
+          op_id, route, generation, state, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'committed', ?9) \
+         ON CONFLICT(origin_actor, namespace, idempotency_key) DO NOTHING",
+        params![
+            claim.origin_actor,
+            claim.namespace,
+            claim.idempotency_key,
+            claim.rid,
+            &claim.payload_digest[..],
+            claim.op_id,
+            claim.route,
+            claim.generation,
+            now(),
+        ],
+    )?;
+    if inserted == 1 {
+        return Ok(ClaimAttempt::Won);
+    }
+
+    // Lost: read the surviving claim — under the same conn lock, same tx view,
+    // so this cannot race the insert that beat us (#83: re-read the winner,
+    // never assume).
+    let existing: Option<(String, Vec<u8>, String)> = conn
+        .query_row(
+            "SELECT rid, payload_digest, state FROM idempotency_claims \
+             WHERE origin_actor = ?1 AND namespace = ?2 AND idempotency_key = ?3",
+            params![claim.origin_actor, claim.namespace, claim.idempotency_key],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .optional()?;
+    let Some((existing_rid, existing_digest, state)) = existing else {
+        // DO NOTHING fired yet no row is visible: unreachable under the conn
+        // lock (nobody can delete between our INSERT and this SELECT). Loud,
+        // not silent, if the invariant ever breaks — and retryable, since the
+        // next attempt re-runs the INSERT.
+        return Err(YantrikDbError::IdempotencyConflict {
+            namespace: claim.namespace.to_string(),
+            existing_rid: String::new(),
+            reason: "claim row vanished between ON CONFLICT and read-back \
+                     (engine invariant violation — retry; if it persists, the \
+                     claims table is being mutated outside the engine)"
+                .to_string(),
+        });
+    };
+
+    if existing_digest.as_slice() != &claim.payload_digest[..] {
+        return Err(YantrikDbError::IdempotencyConflict {
+            namespace: claim.namespace.to_string(),
+            existing_rid,
+            reason: "same idempotency key with a DIFFERENT payload — the first \
+                     write's content stands; change the key or the payload"
+                .to_string(),
+        });
+    }
+    if state != "committed" {
+        // 4a.6c never durably writes 'pending' (claim + op share one tx). A
+        // pending row here means a crash artifact from a future engine version
+        // whose claim/commit are split; refuse loudly rather than return a rid
+        // whose write may not exist.
+        return Err(YantrikDbError::IdempotencyConflict {
+            namespace: claim.namespace.to_string(),
+            existing_rid,
+            reason: format!(
+                "claim is in state '{state}', not 'committed' — a crashed \
+                 prior attempt; the recovery sweep that reconciles this is \
+                 not yet implemented"
+            ),
+        });
+    }
+    Ok(ClaimAttempt::Hit { existing_rid })
+}

--- a/crates/yantrikdb-core/src/engine/idempotency.rs
+++ b/crates/yantrikdb-core/src/engine/idempotency.rs
@@ -74,6 +74,7 @@ pub(crate) struct ClaimRow<'a> {
 /// assembles the full [`ClaimRow`] (op_id = the pending op it is about to
 /// write, route = "queued") — keeping op and claim agreeing by construction.
 pub(crate) struct PendingClaim<'a> {
+    pub namespace: &'a str,
     pub idempotency_key: &'a str,
     pub payload_digest: &'a [u8; 32],
     /// The rid the queued write minted (returned to the caller; the

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -1153,6 +1153,7 @@ impl YantrikDB {
             emb_hash,
             embedding,
             applied_generation,
+            None,
         )?;
         Ok(())
     }

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -23,6 +23,7 @@ mod flywheel;
 pub mod graph_ops;
 pub mod graph_state;
 mod hawkes;
+mod idempotency;
 pub mod importance;
 mod impressions;
 mod indices;
@@ -46,7 +47,6 @@ mod procedural;
 mod query_dsl;
 mod recall;
 mod receptivity;
-mod idempotency;
 mod record;
 pub mod reembed;
 pub mod repair;
@@ -1853,6 +1853,9 @@ impl YantrikDB {
                         source,
                         emotional_state,
                         gate_verdict,
+                        // record_text idempotency fans out in 4a.6d (its digest
+                        // variant excludes the generated embedding).
+                        None,
                     );
                 }
             };
@@ -1901,6 +1904,7 @@ impl YantrikDB {
                 source,
                 emotional_state,
                 gate_verdict,
+                None,
             );
         }
     }

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -46,6 +46,7 @@ mod procedural;
 mod query_dsl;
 mod recall;
 mod receptivity;
+mod idempotency;
 mod record;
 pub mod reembed;
 pub mod repair;

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -67,6 +67,67 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
     ) -> Result<String> {
+        self.record_with_idempotency(
+            text,
+            memory_type,
+            importance,
+            valence,
+            half_life,
+            metadata,
+            embedding,
+            namespace,
+            certainty,
+            domain,
+            source,
+            emotional_state,
+            None,
+        )
+    }
+
+    /// `record()` plus a durable idempotency key (v0.10 Item 4a.6c, T07
+    /// "repetition is not corroboration").
+    ///
+    /// With `idempotency_key = Some(k)`, the write is deduplicated on
+    /// `(origin_actor, namespace, k)` against the canonical RAW payload digest
+    /// (`base/payload_digest`):
+    ///
+    /// - **same key + same payload** -> the original rid is returned and NOTHING
+    ///   is written or moved — no second row, no oplog op, no calibration
+    ///   advance, no session bump, no warn-flag tick, certainty untouched. A
+    ///   retry is a retry, not corroboration.
+    /// - **same key + different payload** -> typed
+    ///   [`crate::error::YantrikDbError::IdempotencyConflict`] carrying the
+    ///   existing rid. The first write's content stands; a silent near-dup
+    ///   merge is exactly what T07 forbids.
+    ///
+    /// The claim commits atomically with the route's authoritative op (the
+    /// memories row + record op on the sync route; the pending oplog op on the
+    /// queued route), so a crash leaves either both or neither — recovery never
+    /// has to guess from row existence. The digest uses the RAW caller
+    /// importance (pre-calibration) deliberately: calibration output depends on
+    /// the namespace's running EWMA, which the first attempt itself advances,
+    /// so a digest over the calibrated value would make an honest retry into a
+    /// false conflict.
+    ///
+    /// `None` is byte-for-byte `record()`.
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(self, metadata, embedding), fields(memory_type, namespace))]
+    pub fn record_with_idempotency(
+        &self,
+        text: &str,
+        memory_type: &str,
+        importance: f64,
+        valence: f64,
+        half_life: f64,
+        metadata: &serde_json::Value,
+        embedding: &[f32],
+        namespace: &str,
+        certainty: f64,
+        domain: &str,
+        source: &str,
+        emotional_state: Option<&str>,
+        idempotency_key: Option<&str>,
+    ) -> Result<String> {
         // v0.9.3 contract gate: validate before anything else. (Historically
         // "before any side effect" because importance calibration used to
         // autocommit here; as of 4a.6b nothing below this point mutates state
@@ -108,6 +169,42 @@ impl YantrikDB {
         // and oplog paths all store/replicate the calibrated value below.
         let raw_importance = importance;
         let importance = self.calibrated_importance(namespace, importance)?;
+        // 4a.6c: the idempotency digest — canonical RAW payload (post-sanitize
+        // text, post-normalize namespace, PRE-calibration importance). Raw on
+        // purpose: calibration output depends on the namespace EWMA, which the
+        // first attempt itself advances, so digesting the calibrated value
+        // would turn an honest retry into a false conflict. Computed BEFORE
+        // routing so both routes resolve the same key identically.
+        let idem: Option<(&str, [u8; 32])> = match idempotency_key {
+            None => None,
+            Some(key) => {
+                if key.trim().is_empty() || key.len() > 512 {
+                    return Err(crate::error::YantrikDbError::InvalidIdempotencyKey {
+                        reason: if key.len() > 512 {
+                            format!("key is {} bytes; max 512", key.len())
+                        } else {
+                            "key is empty or whitespace-only".to_string()
+                        },
+                    });
+                }
+                let view = crate::payload_digest::PayloadView {
+                    variant: crate::payload_digest::PayloadVariant::Record,
+                    namespace,
+                    text,
+                    memory_type,
+                    importance: raw_importance,
+                    valence,
+                    half_life,
+                    certainty,
+                    domain,
+                    source,
+                    emotional_state,
+                    metadata,
+                    embedding: Some(embedding),
+                };
+                Some((key, crate::payload_digest::payload_digest(&view)))
+            }
+        };
         // Issue #41 layer 3: route on write_router state. The guard
         // (if acquired) is held for the full sync path and drops via
         // RAII at function return, panic-safe.
@@ -131,6 +228,7 @@ impl YantrikDB {
                 source,
                 emotional_state,
                 gate_verdict,
+                idem,
             );
         }
         // guard is held; RAII Drop at function exit decrements inflight.
@@ -165,6 +263,7 @@ impl YantrikDB {
             source,
             emotional_state,
             gate_verdict,
+            idem,
         )
     }
 
@@ -203,11 +302,17 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
         gate_verdict: crate::provenance::GateVerdict,
+        idem: Option<(&str, [u8; 32])>,
     ) -> Result<String> {
         let rid = crate::id::new_id();
         let ts = now();
         let emb_blob = serialize_f32(embedding);
         let meta_str = serde_json::to_string(metadata)?;
+        // 4a.6c: the record op's id is minted BEFORE the transaction when a
+        // claim rides it — the claim binds to this op as recovery evidence and
+        // must be the tx's FIRST statement (the v37 partial unique index on
+        // memories would otherwise fire before a dup resolves to a hit).
+        let record_op_id = crate::id::new_id();
 
         // Encrypt fields if encryption is enabled
         let stored_text = self.encrypt_text(text)?;
@@ -332,16 +437,43 @@ impl YantrikDB {
         let mut reservation =
             ReservationGuard::with_pending_op(&state, &self.pending_op_count, &rid, seq);
 
-        // ONE transaction: row + session links + the record op + the
-        // post-materialization enqueue. Either all of it is durable or none is.
-        let committed = (|| -> Result<()> {
+        // ONE transaction: claim (if keyed) + row + session links + the record
+        // op + the post-materialization enqueue. Either all of it is durable or
+        // none is. Returns Some(existing_rid) on an idempotent hit, in which
+        // case the transaction is dropped un-committed (it wrote nothing — the
+        // claim lost its ON CONFLICT and everything else comes after).
+        let committed = (|| -> Result<Option<String>> {
             let tx = conn.unchecked_transaction()?;
+            // 4a.6c: the claim is the FIRST statement — a dup must resolve to a
+            // hit/conflict here, not surface later as a bare constraint error
+            // from the memories partial unique index.
+            if let Some((key, digest)) = idem.as_ref() {
+                use super::idempotency::{claim_in_tx, ClaimAttempt, ClaimRow};
+                match claim_in_tx(
+                    &tx,
+                    &ClaimRow {
+                        origin_actor: &self.actor_id,
+                        namespace,
+                        idempotency_key: key,
+                        rid: &rid,
+                        payload_digest: digest,
+                        op_id: &record_op_id,
+                        route: "sync",
+                        generation: embedding_generation,
+                    },
+                )? {
+                    ClaimAttempt::Won => {}
+                    ClaimAttempt::Hit { existing_rid } => return Ok(Some(existing_rid)),
+                }
+            }
             tx.execute(
                 "INSERT INTO memories \
                  (rid, type, text, embedding, created_at, updated_at, importance, \
                   half_life, last_access, valence, metadata, namespace, \
-                  certainty, domain, source, emotional_state, embedding_generation) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+                  certainty, domain, source, emotional_state, embedding_generation, \
+                  idempotency_key, origin_actor) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
+                         ?18, ?19)",
                 params![
                     rid,
                     memory_type,
@@ -360,6 +492,12 @@ impl YantrikDB {
                     source,
                     emotional_state,
                     embedding_generation,
+                    // v37 idempotency columns: set only for keyed writes (the
+                    // partial unique index ignores NULLs, so keyless behavior
+                    // is unchanged). origin_actor scopes the key per the
+                    // claims-table PK.
+                    idem.as_ref().map(|(k, _)| *k),
+                    idem.as_ref().map(|_| self.actor_id.as_str()),
                 ],
             )?;
 
@@ -404,6 +542,9 @@ impl YantrikDB {
                 Some(&emb_hash),
                 None,
                 embedding_generation,
+                // The claim (if any) already bound to this id as its recovery
+                // evidence — the op and the claim must agree.
+                Some(&record_op_id),
             )?;
 
             // Plain INSERT: if this cannot land, the whole write must fail
@@ -419,7 +560,7 @@ impl YantrikDB {
             )?;
 
             tx.commit()?;
-            Ok(())
+            Ok(None)
         })();
 
         match committed {
@@ -427,7 +568,18 @@ impl YantrikDB {
             // reservation" to "publish it and count the pending op". It is not
             // defused — an unwind between here and complete() must still finish
             // the job, because the row is already committed.
-            Ok(()) => reservation.mark_committed(),
+            Ok(None) => reservation.mark_committed(),
+            // 4a.6c idempotent hit: the SAME payload already committed under
+            // this key. The transaction above was dropped un-committed (it had
+            // written nothing), the reservation drops here in Reserved phase and
+            // removes the reserved vector entry, and EVERY post-commit effect is
+            // skipped — no publish, no pending count, no flag tick, no scoring
+            // cache, no visible_seq bump. Repetition is not corroboration: the
+            // caller gets the ORIGINAL rid and the store is untouched.
+            Ok(Some(existing_rid)) => {
+                drop(conn);
+                return Ok(existing_rid);
+            }
             Err(e) => {
                 // Nothing durable exists. `reservation` drops here and removes the
                 // entry — a removal, NOT a tombstone (a tombstone would suppress
@@ -1349,6 +1501,7 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
         gate_verdict: crate::provenance::GateVerdict,
+        idem: Option<(&str, [u8; 32])>,
     ) -> Result<String> {
         let rid = crate::id::new_id();
         let ts = now();
@@ -1393,7 +1546,21 @@ impl YantrikDB {
         // materializer knows this needs re-encoding (vs being a
         // legacy pre-v27 op where embedding_model IS NULL and the
         // materializer trusts the embedding bytes as-is).
-        self.log_op_pending_for_reembed_queue(
+        // 4a.6c: the claim rides the pending-op transaction — the op IS the
+        // queued write's only durable record, so claim + op commit atomically.
+        // The helper mints the op id and assembles the full claim row so the
+        // two agree by construction.
+        let generation = self.search_state.load().generation as i64;
+        let pending_claim = idem
+            .as_ref()
+            .map(|(key, digest)| super::idempotency::PendingClaim {
+                namespace,
+                idempotency_key: key,
+                payload_digest: digest,
+                rid: &rid,
+                generation,
+            });
+        if let Some(existing_rid) = self.log_op_pending_for_reembed_queue(
             "record",
             Some(&rid),
             &payload,
@@ -1402,7 +1569,14 @@ impl YantrikDB {
             // pending op — the queued write's only durable record. RAW value:
             // the EWMA tracks writer intent, not the deflated output.
             Some((namespace, raw_importance)),
-        )?;
+            pending_claim.as_ref(),
+        )? {
+            // Idempotent hit: the SAME payload is already durably enqueued (or
+            // committed) under this key. Nothing was written — the helper's
+            // transaction aborted before its INSERT — and the flag tick below
+            // is skipped: a retry that landed nothing is not a flagged write.
+            return Ok(existing_rid);
+        }
 
         // 4a.6b: the pending op is durable, so a warn-mode flag counts now.
         self.note_flagged_write_committed(gate_verdict);
@@ -1423,6 +1597,11 @@ impl YantrikDB {
     /// op types that are not a record write (none today; the parameter exists so
     /// a future non-record caller cannot silently inherit a stats advance that
     /// does not belong to it).
+    /// `claim` (4a.6c): a durable idempotency claim to commit atomically WITH
+    /// the pending op — the op is the queued write's only durable record, so
+    /// this transaction is the claim's only honest home. On a dup, returns
+    /// `Ok(Some(existing_rid))` with the transaction aborted before any write.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn log_op_pending_for_reembed_queue(
         &self,
         op_type: &str,
@@ -1430,7 +1609,8 @@ impl YantrikDB {
         payload: &serde_json::Value,
         embedding_model: Option<&str>,
         stats_advance: Option<(&str, f64)>,
-    ) -> Result<String> {
+        claim: Option<&super::idempotency::PendingClaim<'_>>,
+    ) -> Result<Option<String>> {
         use rusqlite::params;
         use std::sync::atomic::Ordering;
 
@@ -1452,6 +1632,30 @@ impl YantrikDB {
         // happy path and makes the stats advance winner-only — an INSERT failure
         // rolls the observation back with it.
         let tx = conn.unchecked_transaction()?;
+        // 4a.6c: claim FIRST (cheap dup exit — the losing transaction has
+        // written nothing when it aborts). stats_advance's namespace is the
+        // claim's namespace: both come from the same normalized caller value.
+        if let Some(pc) = claim {
+            use super::idempotency::{claim_in_tx, ClaimAttempt, ClaimRow};
+            match claim_in_tx(
+                &tx,
+                &ClaimRow {
+                    origin_actor: &self.actor_id,
+                    namespace: pc.namespace,
+                    idempotency_key: pc.idempotency_key,
+                    rid: pc.rid,
+                    payload_digest: pc.payload_digest,
+                    op_id: &op_id,
+                    route: "queued",
+                    generation: pc.generation,
+                },
+            )? {
+                ClaimAttempt::Won => {}
+                // tx drops un-committed: it has written nothing (the claim
+                // lost its ON CONFLICT; the op INSERT comes after).
+                ClaimAttempt::Hit { existing_rid } => return Ok(Some(existing_rid)),
+            }
+        }
         // Plain INSERT, not OR IGNORE. This is the QUEUED write's only durable
         // record — record_queued() writes no memories row (by design), so this op
         // IS the write. `OR IGNORE` here meant any swallowed constraint violation
@@ -1489,6 +1693,7 @@ impl YantrikDB {
         // counter high. See the fuller note in `log_op_pending` (sol #83
         // finding 3).
         self.pending_op_count.fetch_add(1, Ordering::Relaxed);
-        Ok(op_id)
+        let _ = op_id; // the op is bound to the claim; callers get the hit signal
+        Ok(None)
     }
 }

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1539,6 +1539,14 @@ impl YantrikDB {
             "domain": domain,
             "source": source,
             "emotional_state": emotional_state,
+            // 4a.6c: carried so the materializer writes the same v37 columns
+            // the sync route writes — the memories partial unique index is the
+            // claims table's defense-in-depth mirror, and a queued keyed write
+            // must not materialize with a NULL key while its claim exists.
+            // null for keyless writes; pre-4a.6c ops lack the fields and the
+            // materializer defaults both to NULL, so old rows are unchanged.
+            "idempotency_key": idem.as_ref().map(|(k, _)| *k),
+            "origin_actor": idem.as_ref().map(|_| self.actor_id.as_str()),
         });
 
         // Write to oplog with applied=0. The v27 `embedding_model`

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -175,6 +175,16 @@ impl YantrikDB {
         // first attempt itself advances, so digesting the calibrated value
         // would turn an honest retry into a false conflict. Computed BEFORE
         // routing so both routes resolve the same key identically.
+        //
+        // The caller-supplied embedding IS in the digest (PayloadVariant::
+        // Record), even though the QUEUED route discards it (the materializer
+        // re-encodes). Deliberate, decided at sol's 4a.6c review: record()'s
+        // idempotency is API-BYTE identity — on the sync route the embedding is
+        // stored, so two calls with different vectors ARE different writes, and
+        // the digest must not depend on which route the router happened to pick.
+        // A caller whose embedder is non-deterministic across retries belongs on
+        // record_text (whose RecordText variant EXCLUDES the generated vector,
+        // 4a.6d) — regeneration is legitimate there and only there.
         let idem: Option<(&str, [u8; 32])> = match idempotency_key {
             None => None,
             Some(key) => {
@@ -205,6 +215,26 @@ impl YantrikDB {
                 Some((key, crate::payload_digest::payload_digest(&view)))
             }
         };
+        // 4a.6c pre-admission probe (sol finding 1): a duplicate retry writes
+        // nothing, so it resolves BEFORE any admission machinery — before the
+        // router, the backpressure checks, the delta reservation, and the
+        // seq/HLC allocation. Backpressure storms are exactly when clients
+        // retry; without this, a keyed dup against a saturated engine could
+        // only ever see Backpressure and the retry loop would never converge.
+        // A probe MISS is advisory (the ON CONFLICT INSERT in the write tx
+        // stays authoritative); a probe HIT is final — committed claims are
+        // immutable in 4a.
+        if let Some((key, digest)) = idem.as_ref() {
+            if let Some(existing_rid) = super::idempotency::probe_committed_claim(
+                &self.conn(),
+                &self.actor_id,
+                namespace,
+                key,
+                digest,
+            )? {
+                return Ok(existing_rid);
+            }
+        }
         // Issue #41 layer 3: route on write_router state. The guard
         // (if acquired) is held for the full sync path and drops via
         // RAII at function return, panic-safe.
@@ -387,6 +417,13 @@ impl YantrikDB {
             "domain": domain,
             "source": source,
             "emotional_state": emotional_state,
+            // 4a.6c: carried so replication's materialize_record writes the
+            // same v37 columns the origin row has — a follower's keyed row must
+            // mirror its leader's, or the memories partial unique index (the
+            // claims table's defense-in-depth) never covers followers. Null for
+            // keyless writes; peers on older payloads default to NULL.
+            "idempotency_key": idem.as_ref().map(|(k, _)| *k),
+            "origin_actor": idem.as_ref().map(|_| self.actor_id.as_str()),
         });
         // **Phase 4.3 Commit B (saga task 3, 2026-05-08).** The unbounded entity
         // / memory_entities / claims loops that used to run inline are enqueued

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -443,6 +443,30 @@ impl YantrikDB {
 
         let conn = self.conn();
 
+        // 4a.6c sol r2: the LOCKED probe. The unlocked pre-admission probe can
+        // race — two same-key writers both MISS, A commits the claim and
+        // saturates the engine, and B would then die on the backpressure check
+        // below without ever resolving its duplicate. Re-probing here, under
+        // the SAME conn guard that stays held through the transaction, closes
+        // that window completely: nothing can commit a claim between this read
+        // and our tx. A hit resolves BEFORE admission (no backpressure, no seq,
+        // no reservation), which is the point — a duplicate writes nothing, so
+        // saturation must not be able to fail it. (The in-tx ON CONFLICT stays
+        // as the authoritative serialization point; under this locking it is
+        // belt-and-suspenders, reachable only by raw-`conn()` writers outside
+        // the engine.)
+        if let Some((key, digest)) = idem.as_ref() {
+            if let Some(existing_rid) = super::idempotency::probe_committed_claim(
+                &conn,
+                &self.actor_id,
+                namespace,
+                key,
+                digest,
+            )? {
+                return Ok(existing_rid);
+            }
+        }
+
         // THE authoritative admission check: under the lock, before the
         // reservation and before any durable write. The pre-lock check above is a
         // TOCTOU on its own (sol 4a.6a finding 1) — at MAX_PENDING_OPS-1, N
@@ -1543,15 +1567,6 @@ impl YantrikDB {
         let rid = crate::id::new_id();
         let ts = now();
 
-        // Assign a seq for caller's RYW use. Note we do NOT bump
-        // visible_seq — the active generation doesn't yet cover this
-        // op; the post-swap materializer is responsible for advancing
-        // visible_seq as it drains queued ops.
-        let _seq = self
-            .vec_seq
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
-
         // Capture the current runtime embedder name (the one active
         // before reembed flipped the router). The post-swap materializer
         // uses this to discriminate ops queued under the old embedder
@@ -1617,11 +1632,22 @@ impl YantrikDB {
             pending_claim.as_ref(),
         )? {
             // Idempotent hit: the SAME payload is already durably enqueued (or
-            // committed) under this key. Nothing was written — the helper's
-            // transaction aborted before its INSERT — and the flag tick below
-            // is skipped: a retry that landed nothing is not a flagged write.
+            // committed) under this key. Nothing was written — the helper
+            // resolved before its INSERT — and both the seq mint and the flag
+            // tick below are skipped: a retry that landed nothing is not a
+            // flagged write and does not advance sequencing (sol 4a.6c r2
+            // finding 2).
             return Ok(existing_rid);
         }
+
+        // Assign a seq for caller's RYW use, only now that the write really
+        // enqueued. Note we do NOT bump visible_seq — the active generation
+        // doesn't yet cover this op; the post-swap materializer is responsible
+        // for advancing visible_seq as it drains queued ops.
+        let _seq = self
+            .vec_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
 
         // 4a.6b: the pending op is durable, so a warn-mode flag counts now.
         self.note_flagged_write_committed(gate_verdict);
@@ -1659,9 +1685,6 @@ impl YantrikDB {
         use rusqlite::params;
         use std::sync::atomic::Ordering;
 
-        let op_id = crate::id::new_id();
-        let hlc_ts = self.tick_hlc();
-        let hlc_bytes = hlc_ts.to_bytes().to_vec();
         let payload_str = serde_json::to_string(payload)?;
 
         // Advisory fast reject (unlocked); the AUTHORITATIVE check is under the
@@ -1671,7 +1694,27 @@ impl YantrikDB {
         self.check_pending_backpressure_fast()?;
 
         let conn = self.conn.lock();
+        // 4a.6c sol r2: locked probe BEFORE admission — same rationale as the
+        // sync route's (see record_under_guard_and_state): a race-window
+        // duplicate must resolve to its hit even when the queue is full, and
+        // under this continuously-held guard nothing can commit a claim between
+        // this read and our transaction. A hit exits before the backpressure
+        // check and before the op id / HLC mint below, burning nothing.
+        if let Some(pc) = claim {
+            if let Some(existing_rid) = super::idempotency::probe_committed_claim(
+                &conn,
+                &self.actor_id,
+                pc.namespace,
+                pc.idempotency_key,
+                pc.payload_digest,
+            )? {
+                return Ok(Some(existing_rid));
+            }
+        }
         self.check_pending_backpressure_locked()?;
+        let op_id = crate::id::new_id();
+        let hlc_ts = self.tick_hlc();
+        let hlc_bytes = hlc_ts.to_bytes().to_vec();
         // ONE transaction: the pending op + the namespace stats advance. This
         // used to be a bare autocommit INSERT; wrapping it costs nothing on the
         // happy path and makes the stats advance winner-only — an INSERT failure

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -399,7 +399,18 @@ impl YantrikDB {
         // so a rejection here (or anywhere later) leaves no trace anywhere.
         // `record_backpressure_writes_nothing_at_all` is the enforcing test,
         // and its name is the contract.
-        self.check_pending_backpressure_fast()?;
+        //
+        // KEYED writes skip the fast check (sol 4a.6c r3): it is a
+        // work-avoidance optimization, and for a keyed write the priority
+        // inverts — a race-window duplicate must REACH the locked probe below
+        // even when the pending queue is full, or saturation can permanently
+        // fail a retry that would write nothing. The AUTHORITATIVE locked
+        // check still gates every keyed write that wins its claim, so the
+        // ceiling holds; the only cost is that a keyed loser does slightly
+        // more work before hearing Backpressure.
+        if idem.is_none() {
+            self.check_pending_backpressure_fast()?;
+        }
 
         let emb_hash = embedding_hash(embedding);
         let record_payload = serde_json::json!({
@@ -1691,7 +1702,12 @@ impl YantrikDB {
         // lock below. Same TOCTOU, same fix as log_op_pending (sol 4a.6a r2
         // finding 1): two queued writers at MAX_PENDING_OPS-1 could both pass an
         // unlocked load and then serialize their inserts past the ceiling.
-        self.check_pending_backpressure_fast()?;
+        // KEYED writes skip it (sol 4a.6c r3): a race-window duplicate must
+        // reach the locked probe below even when the pending queue is full —
+        // see the sync route's twin comment.
+        if claim.is_none() {
+            self.check_pending_backpressure_fast()?;
+        }
 
         let conn = self.conn.lock();
         // 4a.6c sol r2: locked probe BEFORE admission — same rationale as the

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -840,6 +840,17 @@ impl YantrikDB {
             .get("emotional_state")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        // 4a.6c: the v37 idempotency columns, carried by keyed queued writes.
+        // Absent/null (every pre-4a.6c op, every keyless write) stores NULL —
+        // identical to the pre-4a.6c row shape.
+        let idempotency_key = payload
+            .get("idempotency_key")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let origin_actor = payload
+            .get("origin_actor")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
 
         // Snapshot the active SearchState. The embedder + generation
         // here are the post-swap ones (caller verified no reembed in
@@ -889,8 +900,10 @@ impl YantrikDB {
                 "INSERT OR IGNORE INTO memories \
                  (rid, type, text, embedding, created_at, updated_at, importance, \
                   half_life, last_access, valence, metadata, namespace, \
-                  certainty, domain, source, emotional_state, embedding_generation) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+                  certainty, domain, source, emotional_state, embedding_generation, \
+                  idempotency_key, origin_actor) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
+                         ?18, ?19)",
                 params![
                     rid,
                     memory_type,
@@ -909,6 +922,8 @@ impl YantrikDB {
                     source,
                     emotional_state,
                     embedding_generation,
+                    idempotency_key,
+                    origin_actor,
                 ],
             )?;
         }

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -185,6 +185,7 @@ impl YantrikDB {
     /// here: the caller holds a `SyncWriteGuard` pinning the generation for its
     /// whole critical section, and must stamp the same generation its vector
     /// entry was written against.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn log_op_in_tx(
         &self,
         tx: &rusqlite::Transaction<'_>,
@@ -194,8 +195,17 @@ impl YantrikDB {
         emb_hash: Option<&[u8]>,
         embedding: Option<&[u8]>,
         applied_generation: i64,
+        // 4a.6c: an idempotency claim binds to the authoritative op's id as its
+        // recovery evidence, and the claim must be the FIRST statement of the
+        // transaction (the v37 partial unique index on memories would otherwise
+        // fire before the claim resolves a dup). So the keyed path mints the
+        // op_id BEFORE the tx and passes it here; None keeps minting inline.
+        preminted_op_id: Option<&str>,
     ) -> Result<String> {
-        let op_id = crate::id::new_id();
+        let op_id = match preminted_op_id {
+            Some(id) => id.to_string(),
+            None => crate::id::new_id(),
+        };
         let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
         let payload_str = serde_json::to_string(payload)?;
         tx.execute(

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7910,6 +7910,19 @@ fn keyed_duplicate_resolves_even_under_backpressure() {
         matches!(err, crate::error::YantrikDbError::Backpressure { .. }),
         "expected Backpressure for the new keyed write, got {err:?}"
     );
+
+    // The QUEUED route under the same saturation: the dup must resolve there
+    // too. (No new-key backpressure assert here, and its absence is itself a
+    // finding from writing this test: the saturation above is DELTA capacity,
+    // and the queued route consumes none — it writes no vector, which is
+    // exactly why it is the escape valve during reembed cutover. A new keyed
+    // queued write legitimately succeeds under delta saturation; only a full
+    // PENDING queue gates it, and the helper's locked probe precedes that
+    // check by the same one-owner code path the sync mutation proof covers.)
+    db.write_router.switch_to_queueing();
+    let rid3 = keyed(&db).expect("queued dup under saturation must resolve");
+    assert_eq!(rid3, rid, "queued dup returns the original rid");
+    db.write_router.switch_to_normal();
 }
 
 // ── Relationship-Based Entity Type Tests ──

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7821,6 +7821,97 @@ fn invalid_idempotency_keys_are_rejected() {
     assert_eq!(rows, 0, "refused keys wrote nothing");
 }
 
+/// 4a.6c sol finding 1: a keyed DUPLICATE retry must resolve to its hit even
+/// when the engine is saturated — Backpressure storms are exactly when clients
+/// retry, and the dup writes nothing, so admission machinery (router, delta
+/// reservation, backpressure checks, seq/HLC) must not run before the claim
+/// probe. Pre-probe, this test dies with Backpressure instead of the Hit.
+#[cfg(feature = "bundled-embedder")]
+#[test]
+fn keyed_duplicate_resolves_even_under_backpressure() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let dim = db.embedding_dim();
+
+    // The keyed write lands FIRST, while there is capacity.
+    let keyed = |db: &YantrikDB| {
+        db.record_with_idempotency(
+            "the keyed write that must stay resolvable",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(9.0, 8),
+            "bp_idem_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("bp-key"),
+        )
+    };
+    let rid = keyed(&db).unwrap();
+
+    // Saturate the delta with keyless writes until Backpressure.
+    let mut saturated = false;
+    for i in 0..400 {
+        let emb: Vec<f32> = (0..dim).map(|j| ((i + j) as f32) * 0.001).collect();
+        match db.record(
+            &format!("bp-filler-{i}"),
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &emb,
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        ) {
+            Ok(_) => {}
+            Err(crate::error::YantrikDbError::Backpressure { .. }) => {
+                saturated = true;
+                break;
+            }
+            Err(e) => panic!("unexpected: {e:?}"),
+        }
+    }
+    assert!(saturated, "delta never saturated");
+
+    // The DUPLICATE retry resolves to its hit despite saturation.
+    let rid2 = keyed(&db).expect(
+        "a keyed duplicate writes nothing and must resolve to its Hit, \
+         not die on Backpressure",
+    );
+    assert_eq!(rid2, rid, "the hit returns the original rid");
+
+    // Sanity: a keyed NEW write (different key) is still subject to
+    // backpressure — the probe only short-circuits duplicates.
+    let err = db
+        .record_with_idempotency(
+            "a genuinely new keyed write",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(10.0, 8),
+            "bp_idem_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("bp-key-new"),
+        )
+        .expect_err("a NEW keyed write under saturation must still backpressure");
+    assert!(
+        matches!(err, crate::error::YantrikDbError::Backpressure { .. }),
+        "expected Backpressure for the new keyed write, got {err:?}"
+    );
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7925,6 +7925,74 @@ fn keyed_duplicate_resolves_even_under_backpressure() {
     db.write_router.switch_to_normal();
 }
 
+/// 4a.6c sol r3: the FAST (pre-lock) backpressure check ran before the locked
+/// probe, so a race-window duplicate under PENDING-queue saturation (a
+/// different resource from the delta saturation the sibling test exercises)
+/// still died with Backpressure before it could resolve. Keyed writes now skip
+/// the fast check — the authoritative locked check still gates keyed WINNERS,
+/// proven by the second half.
+#[test]
+fn keyed_duplicate_resolves_under_pending_queue_saturation() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let write = |db: &YantrikDB, key: &str| {
+        db.record_with_idempotency(
+            "pending-saturation probe",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "pq_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some(key),
+        )
+    };
+    // The keyed write lands while there is capacity.
+    let rid = write(&db, "pq-key").unwrap();
+
+    // Force the PENDING queue to read as saturated — the exact resource in
+    // sol's scenario. The cached counter is what both backpressure checks
+    // consult, so storing past the ceiling makes every admission check reject
+    // deterministically, with no timing dependence.
+    let real = db
+        .pending_op_count
+        .swap(1_000_000, std::sync::atomic::Ordering::SeqCst);
+
+    // The duplicate must resolve despite full-pending admission rejecting
+    // everything: keyed writes skip the fast check and the locked probe runs
+    // before the locked check.
+    let rid2 = write(&db, "pq-key").expect("keyed dup must resolve under pending-queue saturation");
+    assert_eq!(rid2, rid, "dup returns the original rid");
+
+    // A keyed NEW write must still hear Backpressure — from the AUTHORITATIVE
+    // locked check, which keyed writes do not skip.
+    let err = write(&db, "pq-key-new")
+        .expect_err("a NEW keyed write under pending saturation must backpressure");
+    assert!(
+        matches!(err, crate::error::YantrikDbError::Backpressure { .. }),
+        "expected Backpressure from the locked check, got {err:?}"
+    );
+
+    // And the queued route, same resource: dup resolves, new key rejects.
+    db.write_router.switch_to_queueing();
+    let rid3 = write(&db, "pq-key").expect("queued dup must resolve under pending saturation");
+    assert_eq!(rid3, rid);
+    let err = write(&db, "pq-key-new-q")
+        .expect_err("a NEW keyed queued write under pending saturation must backpressure");
+    assert!(
+        matches!(err, crate::error::YantrikDbError::Backpressure { .. }),
+        "expected Backpressure on the queued route, got {err:?}"
+    );
+    db.write_router.switch_to_normal();
+
+    db.pending_op_count
+        .store(real, std::sync::atomic::Ordering::SeqCst);
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7513,6 +7513,314 @@ fn stats_advance_seeds_from_raw_when_stored_count_is_zero() {
     assert_eq!(count, 1, "count advances to 1");
 }
 
+/// 4a.6c (T07 "repetition is not corroboration"), sync route: an exact retry
+/// under the same idempotency key returns the ORIGINAL rid and writes NOTHING —
+/// no second row, no second op, no pending-op count, no calibration advance.
+#[test]
+fn idempotent_retry_returns_original_rid_and_writes_nothing() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let write = |db: &YantrikDB| {
+        db.record_with_idempotency(
+            "the deploy uses zorbium for caching",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &serde_json::json!({"k": "v"}),
+            &vec_seed(1.0, 8),
+            "idem_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("client-req-001"),
+        )
+    };
+    let rid1 = write(&db).unwrap();
+
+    let rows = |db: &YantrikDB| -> i64 {
+        db.conn()
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE namespace = 'idem_ns'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    let ops = |db: &YantrikDB| -> i64 {
+        db.conn()
+            .query_row("SELECT COUNT(*) FROM oplog", [], |r| r.get(0))
+            .unwrap()
+    };
+    let stats_count = |db: &YantrikDB| -> i64 {
+        db.conn()
+            .query_row(
+                "SELECT count FROM namespace_importance_stats WHERE namespace = 'idem_ns'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    let (r1, o1, s1, p1) = (
+        rows(&db),
+        ops(&db),
+        stats_count(&db),
+        db.count_pending_ops().unwrap(),
+    );
+    assert_eq!(r1, 1, "first keyed write lands one row");
+    assert_eq!(s1, 1, "first keyed write advances stats once");
+
+    // The exact retry.
+    let rid2 = write(&db).unwrap();
+    assert_eq!(rid2, rid1, "retry returns the ORIGINAL rid");
+    assert_eq!(rows(&db), r1, "retry wrote no second row");
+    assert_eq!(ops(&db), o1, "retry wrote no oplog op of any kind");
+    assert_eq!(stats_count(&db), s1, "retry advanced no calibration stats");
+    assert_eq!(
+        db.count_pending_ops().unwrap(),
+        p1,
+        "retry enqueued no pending op"
+    );
+    let claims: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM idempotency_claims", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(claims, 1, "one claim row, state committed");
+
+    // Keyless behavior is untouched: the same content twice makes two rows.
+    for _ in 0..2 {
+        db.record(
+            "keyless duplicate content",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(2.0, 8),
+            "idem_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+        )
+        .unwrap();
+    }
+    assert_eq!(rows(&db), r1 + 2, "keyless writes still append");
+}
+
+/// 4a.6c: the same key with a DIFFERENT payload is a typed conflict carrying
+/// the existing rid — never a silent merge, and it writes nothing.
+#[test]
+fn idempotency_conflict_on_different_payload() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let write = |db: &YantrikDB, importance: f64| {
+        db.record_with_idempotency(
+            "conflicting payload probe",
+            "semantic",
+            importance,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "conf_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("key-x"),
+        )
+    };
+    let rid1 = write(&db, 0.7).unwrap();
+
+    // Same key, different importance — the mutable scalars are IN the digest
+    // (design doc: they alter the first write's observable state).
+    let err = write(&db, 0.9).expect_err("scalar diff under the same key must conflict");
+    match &err {
+        crate::error::YantrikDbError::IdempotencyConflict { existing_rid, .. } => {
+            assert_eq!(existing_rid, &rid1, "conflict names the existing record");
+        }
+        other => panic!("expected IdempotencyConflict, got {other:?}"),
+    }
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'conf_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(rows, 1, "the conflicting write persisted nothing");
+    let stats: i64 = db
+        .conn()
+        .query_row(
+            "SELECT count FROM namespace_importance_stats WHERE namespace = 'conf_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(stats, 1, "the conflicting write advanced no stats");
+}
+
+/// 4a.6c, queued route: the claim rides the pending-op transaction. A retry
+/// during reembed cutover enqueues exactly one op; cross-route retries (sync
+/// then queued) also resolve to the same rid — the claim is route-agnostic.
+#[test]
+fn idempotency_holds_on_and_across_the_queued_route() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let write = |db: &YantrikDB, key: &str| {
+        db.record_with_idempotency(
+            "queued idempotent probe",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "q_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some(key),
+        )
+    };
+
+    // Queued-only: both attempts under Queueing.
+    db.write_router.switch_to_queueing();
+    let rid_q = write(&db, "q-key").unwrap();
+    let pending_after_first = db.count_pending_ops().unwrap();
+    let rid_q2 = write(&db, "q-key").unwrap();
+    assert_eq!(rid_q2, rid_q, "queued retry returns the original rid");
+    assert_eq!(
+        db.count_pending_ops().unwrap(),
+        pending_after_first,
+        "queued retry enqueued no second op"
+    );
+    db.write_router.switch_to_normal();
+
+    // Cross-route: first write lands sync, retry arrives during Queueing.
+    let rid_s = write(&db, "cross-key").unwrap();
+    db.write_router.switch_to_queueing();
+    let pending_before = db.count_pending_ops().unwrap();
+    let rid_s2 = write(&db, "cross-key").unwrap();
+    assert_eq!(rid_s2, rid_s, "cross-route retry resolves to the sync rid");
+    assert_eq!(
+        db.count_pending_ops().unwrap(),
+        pending_before,
+        "cross-route retry enqueued nothing"
+    );
+    db.write_router.switch_to_normal();
+}
+
+/// 4a.6c: the digest is computed from the RAW caller importance, never the
+/// calibrated value. Discriminating setup: in a saturated namespace the EWMA
+/// deepens with every write, so the CALIBRATED value of an identical retry
+/// differs from the first attempt's — a digest over calibrated output would
+/// turn the honest retry into a false conflict.
+#[test]
+fn idempotency_digest_uses_raw_importance_not_calibrated() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    // Saturate: 8 keyless writes at 1.0 puts the namespace at MIN_COUNT with
+    // ewma 1.0, so calibration engages (and keeps deepening) from write 9 on.
+    for i in 0..8 {
+        db.record(
+            &format!("sat-{i}"),
+            "semantic",
+            1.0,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0 + i as f32 * 0.01, 8),
+            "sat_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+        )
+        .unwrap();
+    }
+    // raw = 0.9, NOT 1.0, and this is load-bearing for the discrimination:
+    // with all-1.0 saturation the EWMA sits pinned at exactly 1.0, so an
+    // identical retry calibrates to the SAME deflated value and a digest over
+    // calibrated output would accidentally still hit. 0.9 moves the EWMA on
+    // the first attempt's own advance (1.0 -> 0.985), so the retry's
+    // calibrated value differs (0.7333 -> 0.7458) — a calibrated digest now
+    // MUST conflict, and only a raw digest hits. (The first draft used 1.0
+    // and survived exactly that mutation.)
+    let write = |db: &YantrikDB| {
+        db.record_with_idempotency(
+            "saturated keyed write",
+            "semantic",
+            0.9, // raw — deflated by calibration when stored
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(2.0, 8),
+            "sat_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("sat-key"),
+        )
+    };
+    let rid1 = write(&db).unwrap();
+    let stored: f64 = db
+        .conn()
+        .query_row(
+            "SELECT importance FROM memories WHERE rid = ?1",
+            rusqlite::params![rid1],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        stored < 0.9,
+        "precondition: calibration deflated the stored importance, got {stored}"
+    );
+    // The honest retry: same RAW payload. Stats advanced since attempt 1, so
+    // the calibrated value now differs — a calibrated-digest would conflict.
+    let rid2 = write(&db).expect("identical RAW retry must be a hit, not a conflict");
+    assert_eq!(rid2, rid1);
+}
+
+/// 4a.6c: empty / oversized keys are refused loudly — silently treating "" as
+/// "no key" would leave the caller believing they have dedup they don't have.
+#[test]
+fn invalid_idempotency_keys_are_rejected() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    for bad in ["", "   ", &"k".repeat(513)] {
+        let err = db
+            .record_with_idempotency(
+                "probe",
+                "semantic",
+                0.7,
+                0.0,
+                604800.0,
+                &empty_meta(),
+                &vec_seed(1.0, 8),
+                "default",
+                0.8,
+                "work",
+                "user",
+                None,
+                Some(bad),
+            )
+            .expect_err("bad key must be refused");
+        assert!(
+            matches!(
+                err,
+                crate::error::YantrikDbError::InvalidIdempotencyKey { .. }
+            ),
+            "expected InvalidIdempotencyKey, got {err:?}"
+        );
+    }
+    let rows: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(rows, 0, "refused keys wrote nothing");
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/lib.rs
+++ b/crates/yantrikdb-core/src/lib.rs
@@ -11,8 +11,8 @@ mod vector;
 
 // ── Re-exports at original crate paths ──
 pub use base::{
-    bench_utils, compression, encryption, error, fitting, hlc, provenance, schema, scoring,
-    serde_helpers, testing, types, validate, vault,
+    bench_utils, compression, encryption, error, fitting, hlc, payload_digest, provenance, schema,
+    scoring, serde_helpers, testing, types, validate, vault,
 };
 pub use cognition::{
     action, agenda, analogy, attention, belief, belief_network, belief_query, benchmark,

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -9,7 +9,12 @@ use super::{map_err, PyYantrikDB};
 
 #[pymethods]
 impl PyYantrikDB {
-    #[pyo3(signature = (text, memory_type="episodic", importance=0.5, valence=0.0, half_life=604800.0, metadata=None, embedding=None, namespace="default", certainty=0.8, domain="general", source="user", emotional_state=None))]
+    /// `idempotency_key` (v0.10, 4a.6c): dedups caller retries durably. Same
+    /// key + same payload returns the ORIGINAL rid with nothing re-written;
+    /// same key + different payload raises an idempotency-conflict error. The
+    /// trailing kwarg default keeps every existing Python caller unchanged.
+    #[pyo3(signature = (text, memory_type="episodic", importance=0.5, valence=0.0, half_life=604800.0, metadata=None, embedding=None, namespace="default", certainty=0.8, domain="general", source="user", emotional_state=None, idempotency_key=None))]
+    #[allow(clippy::too_many_arguments)]
     fn record(
         &self,
         py: Python<'_>,
@@ -25,6 +30,7 @@ impl PyYantrikDB {
         domain: &str,
         source: &str,
         emotional_state: Option<&str>,
+        idempotency_key: Option<&str>,
     ) -> PyResult<String> {
         let db = self
             .inner
@@ -41,7 +47,7 @@ impl PyYantrikDB {
             None => serde_json::json!({}),
         };
 
-        db.record(
+        db.record_with_idempotency(
             text,
             memory_type,
             importance,
@@ -54,6 +60,7 @@ impl PyYantrikDB {
             domain,
             source,
             emotional_state,
+            idempotency_key,
         )
         .map_err(map_err)
     }

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -37,6 +37,23 @@ impl PyYantrikDB {
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("YantrikDB is closed"))?;
 
+        // 4a.6c (sol r4 note): a key with an ENGINE-GENERATED embedding is
+        // refused for now. record()'s digest includes the embedding (API-byte
+        // identity — the sync route stores it), so if this wrapper embedded the
+        // text itself, an embedder drift across retries would turn an honest
+        // retry into a false IdempotencyConflict. The generated-vector variant
+        // (digest excludes it) ships with record_text idempotency in 4a.6d;
+        // until then, fail loud rather than subtly mis-dedup.
+        if idempotency_key.is_some() && embedding.is_none() {
+            return Err(PyValueError::new_err(
+                "idempotency_key with an engine-generated embedding is not \
+                 supported yet: record()'s payload digest includes the \
+                 embedding, and a regenerated vector would make an honest \
+                 retry a false conflict. Pass an explicit `embedding` to use \
+                 a key today (generated-embedding idempotency lands with \
+                 record_text support).",
+            ));
+        }
         let emb = match embedding {
             Some(e) => e,
             None => self.embed_text(py, text)?,


### PR DESCRIPTION
**v0.10 Item 4a.6c — the durable idempotency claim** (design doc §E, "claim-after-routing saga"). T07 is now real: repetition is not corroboration. **sol-ACCEPTed after 4 rounds.**

## What it does

`record_with_idempotency(..., idempotency_key: Option<&str>)` — `record()` delegates `None` (all 315 call sites untouched); Python gets a non-breaking trailing `record(..., idempotency_key=None)` kwarg.

With a key, the write dedups on `(origin_actor, namespace, key)` against the canonical **raw** payload digest:

- **same key + same payload** → the ORIGINAL rid, and *nothing* moves — no second row, no oplog op, no pending count, no calibration advance, no warn-flag tick, no seq, no HLC tick. Certainty untouched.
- **same key + different payload** → typed `IdempotencyConflict` naming the existing rid. The first write's content stands; silent near-dup merges are exactly what T07 forbids.
- empty/oversize keys → typed `InvalidIdempotencyKey` (silently treating `""` as no-key would fake dedup protection).

## How it's built

- **One owner** (`engine/idempotency.rs`): the `ON CONFLICT DO NOTHING` insert is the serialization point (never a prior SELECT); every resolution path — two probes and the in-tx branch — goes through one `resolve_existing`.
- **Claim-first in the tx**, bound to a preminted op id, because the v37 partial unique index on `memories` would otherwise fire before a dup resolves. The claim commits atomically with each route's authoritative op (sync: the 4a.6a tx; queued: the pending-op tx), so `state='committed'` is written directly — a durable claim-without-op is impossible by construction, and the doc's pending→committed lifecycle stays schema-reserved for 4b (sol agreed).
- **Digest = raw canonical payload, pre-routing.** Raw importance deliberately: calibration depends on the EWMA the first attempt itself advances, so a calibrated digest turns honest retries into false conflicts (mutation-proven — and the proof itself needed a retarget: all-1.0 saturation pins the EWMA, so the first draft's mutation *survived*; raw=0.9 moves it).
- **Claims are immutable and `forget()` does not reap them** — verified (one INSERT, two SELECTs, nothing else) and decided: a retry after forget returns the tombstoned rid, because deleting the claim would let a retry silently *resurrect* forgotten content (#88 family, documented in the module).
- Keyed rows carry the v37 `idempotency_key`/`origin_actor` columns on **every** materialization path: sync INSERT, queued materializer replay, and replication `materialize_record` (the extend-#69 pattern).

## The invariant sol spent 4 rounds sharpening

*"Nothing may reject a duplicate that would write nothing."* Each round cut finer:

- **r1**: admission (backpressure/reservation/seq/HLC) ran before the claim → a dup under saturation got `Backpressure` — and saturation is exactly when clients retry. Fix: the unlocked **pre-admission probe**.
- **r2**: the probe races — both writers MISS, A commits + saturates, B dies on admission. Fix: a second **locked probe** under the conn guard held continuously through the tx; the window is closed, not narrowed. Queued seq/HLC mints moved behind it — resolved dups burn nothing.
- **r3**: the *fast* (advisory) backpressure checks still ran before the locked probe → death under **pending** saturation (a different resource from the delta saturation my test used). Fix: keyed writes skip the fast check; the authoritative locked check still gates every keyed winner, so the ceiling holds.
- **r4**: **ACCEPT** — sol traced the full keyed admission order on both routes and found no remaining R3-class hole, and confirmed a keyed-new flood gains no capacity bypass (a latency-only PLAUSIBLE residual, noted below).

## Tests — 7, every discriminating property mutation-proven *by content*

(compiled-then-ran verified before reading any result; one earlier harness silently no-op'd and nearly recorded a good test as decoration)

- sync claim disabled → 2 tests fail; queued claim disabled → 1 fails; calibrated-in-digest → 1 fails (after the raw=0.9 retarget)
- **two-layer probe proof**: unlocked probe removed → still passes (locked probe carries it); both removed → fails
- **composed race proof**: probe removed + fast-check gating reverted = sol's exact r3 scenario → fails; gating kept → passes
- pending-queue saturation forced deterministically (counter swapped past the ceiling): dup resolves on both routes, new key still backpressures from the locked check
- plus: cross-route resolution (sync claim ↔ queued retry), keyless-unchanged, invalid keys

**A finding *from* a failing test:** a new keyed QUEUED write legitimately succeeds under **delta** saturation — the queued route writes no vector (it is the reembed escape valve), so only a full pending queue gates it. My assertion was wrong; the engine corrected it; the test now states the true property.

## Noted, non-blocking (sol r4)

- Keyed NEW writes skipping the fast check is a latency surface under saturation (more lock-wait before hearing Backpressure), not a ceiling violation.
- Python `record(embedding=None, idempotency_key=...)` would digest an engine-*generated* vector → embedder drift = false conflicts. **Refused loudly** with the workaround (pass an explicit embedding) until `record_text` idempotency ships the generated-vector digest variant in 4a.6d.

## Also worth knowing

This is the **pack-marketplace import primitive**: pack records with keys make re-attachment a no-op and pack v2 upgrades diff-aware (changed records surface as typed conflicts per record) — the 4a machinery and the packs directive keep converging.

Built twice: an external `git reset --hard` from another workspace wiped the first, uncommitted implementation mid-flight; the rebuild is checkpointed across 12 commits.

Rust lib **1733** default / **1735** with `--features testing`; kill proofs green; python crate compiles; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
