### PR TITLE
feat(v0.10-4a.6d-1): record_text idempotency — the generated-vector digest variant

### DIFF
--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1768,6 +1768,55 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
     ) -> Result<String> {
+        self.record_text_with_idempotency(
+            text,
+            memory_type,
+            importance,
+            valence,
+            half_life,
+            metadata,
+            namespace,
+            certainty,
+            domain,
+            source,
+            emotional_state,
+            None,
+        )
+    }
+
+    /// `record_text()` plus a durable idempotency key (v0.10 Item 4a.6d).
+    ///
+    /// Same contract as [`Self::record_with_idempotency`] with ONE deliberate
+    /// difference: the digest uses [`PayloadVariant::RecordText`], which
+    /// **excludes the engine-generated embedding**. The engine embeds the text
+    /// itself here, and an embedder can legitimately be swapped (or drift)
+    /// between attempts — digesting the generated vector would turn an honest
+    /// retry into a false conflict. Idempotency is decided from the TEXT and
+    /// scalars, before any embedding work: the pre-admission probe runs before
+    /// the (slow) embed, so a duplicate retry never pays the embed cost at all.
+    ///
+    /// The variant is also part of the digest's op_kind discriminator, so the
+    /// SAME key used across `record()` (embedding-inclusive) and
+    /// `record_text()` (embedding-exclusive) is a typed conflict, not a hit —
+    /// a cross-surface retry is not the same write.
+    ///
+    /// `None` is byte-for-byte `record_text()`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_text_with_idempotency(
+        &self,
+        text: &str,
+        memory_type: &str,
+        importance: f64,
+        valence: f64,
+        half_life: f64,
+        metadata: &serde_json::Value,
+        namespace: &str,
+        certainty: f64,
+        domain: &str,
+        source: &str,
+        emotional_state: Option<&str>,
+        idempotency_key: Option<&str>,
+    ) -> Result<String> {
         // v0.9.3 contract gate: scalars validated BEFORE calibration mutates
         // the namespace's running distribution. (The embedding is engine-
         // generated below and validated inside the embed step.)
@@ -1798,6 +1847,52 @@ impl YantrikDB {
         // transaction, and a retry loop commits at most once.
         let raw_importance = importance;
         let importance = self.calibrated_importance(namespace, importance)?;
+        // 4a.6d: the RecordText digest — RAW canonical payload with the
+        // embedding EXCLUDED (the engine generates it below, and idempotency
+        // must be decided before re-embedding; see the method doc). Then the
+        // pre-admission probe: a duplicate retry resolves HERE, before the
+        // slow embed, before the router, before any admission machinery.
+        let idem: Option<(&str, [u8; 32])> = match idempotency_key {
+            None => None,
+            Some(key) => {
+                if key.trim().is_empty() || key.len() > 512 {
+                    return Err(YantrikDbError::InvalidIdempotencyKey {
+                        reason: if key.len() > 512 {
+                            format!("key is {} bytes; max 512", key.len())
+                        } else {
+                            "key is empty or whitespace-only".to_string()
+                        },
+                    });
+                }
+                let view = crate::payload_digest::PayloadView {
+                    variant: crate::payload_digest::PayloadVariant::RecordText,
+                    namespace,
+                    text,
+                    memory_type,
+                    importance: raw_importance,
+                    valence,
+                    half_life,
+                    certainty,
+                    domain,
+                    source,
+                    emotional_state,
+                    metadata,
+                    embedding: None,
+                };
+                Some((key, crate::payload_digest::payload_digest(&view)))
+            }
+        };
+        if let Some((key, digest)) = idem.as_ref() {
+            if let Some(existing_rid) = idempotency::probe_committed_claim(
+                &self.conn(),
+                &self.actor_id,
+                namespace,
+                key,
+                digest,
+            )? {
+                return Ok(existing_rid);
+            }
+        }
         loop {
             // Step 1: snapshot SearchState for the embed — capture
             // generation + digest so we can revalidate after the embed.
@@ -1853,9 +1948,7 @@ impl YantrikDB {
                         source,
                         emotional_state,
                         gate_verdict,
-                        // record_text idempotency fans out in 4a.6d (its digest
-                        // variant excludes the generated embedding).
-                        None,
+                        idem,
                     );
                 }
             };
@@ -1904,7 +1997,7 @@ impl YantrikDB {
                 source,
                 emotional_state,
                 gate_verdict,
-                None,
+                idem,
             );
         }
     }

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1840,6 +1840,16 @@ impl YantrikDB {
         // artifact. Borrowed (no allocation) on the clean path.
         let sanitized = sanitize::sanitize_tool_call_artifacts(text);
         let text = sanitized.as_ref();
+        // v0.7.23 normalization, APPLIED HERE for the first time (sol 4a.6d-1
+        // finding): record_text never normalized blank namespaces — a
+        // pre-existing divergence from record(), which coerces ""/whitespace to
+        // "default" at its entry (record.rs). It went unnoticed while the
+        // Python wrapper routed embedding=None through record(); routing it
+        // through THIS path exposed the gap: rows and idempotency claims would
+        // scope under "" while every reader queries "default". Normalize once,
+        // before calibration, digest, probe, and routing — the same
+        // engine-boundary contract every other write entry keeps.
+        let namespace = record::normalize_namespace(namespace);
         // Task 31 (Ingest Integrity): compute the calibrated importance once,
         // before the (retryable) embed loop — READ-ONLY as of 4a.6b, so the
         // "retry must not double-count" property this comment used to defend is

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -8132,6 +8132,94 @@ fn same_key_across_record_and_record_text_is_a_conflict() {
     );
 }
 
+/// 4a.6d-1 sol finding: record_text never normalized blank namespaces — a
+/// pre-existing divergence from record() (which coerces ""/whitespace to
+/// "default" at entry) that surfaced when the Python wrapper's
+/// embedding=None flow was rerouted through record_text. A blank-namespace
+/// record_text write must land in "default" — rows, calibration stats, AND
+/// the idempotency claim scope — or every reader querying "default" misses it.
+#[test]
+fn record_text_normalizes_blank_namespace_like_record() {
+    struct Fake;
+    impl crate::types::Embedder for Fake {
+        fn embed(
+            &self,
+            t: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+            let mut v = vec![0.1; 8];
+            v[0] = (t.len() % 7) as f32 * 0.1;
+            Ok(v)
+        }
+        fn dim(&self) -> usize {
+            8
+        }
+    }
+    let mut db = YantrikDB::new(":memory:", 8).unwrap();
+    db.set_embedder(Box::new(Fake)).unwrap();
+
+    let rid = db
+        .record_text_with_idempotency(
+            "blank namespace probe",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "   ",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("ns-key"),
+        )
+        .unwrap();
+
+    let ns: String = db
+        .conn()
+        .query_row(
+            "SELECT namespace FROM memories WHERE rid = ?1",
+            rusqlite::params![rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(ns, "default", "blank namespace must normalize to default");
+
+    let claim_ns: String = db
+        .conn()
+        .query_row(
+            "SELECT namespace FROM idempotency_claims WHERE idempotency_key = 'ns-key'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        claim_ns, "default",
+        "the claim must scope under the NORMALIZED namespace"
+    );
+
+    // And the retry with the same blank namespace resolves (same scope).
+    let rid2 = db
+        .record_text_with_idempotency(
+            "blank namespace probe",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("ns-key"),
+        )
+        .unwrap();
+    assert_eq!(
+        rid2, rid,
+        "'' and '   ' resolve to the same normalized scope"
+    );
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7993,6 +7993,145 @@ fn keyed_duplicate_resolves_under_pending_queue_saturation() {
         .store(real, std::sync::atomic::Ordering::SeqCst);
 }
 
+/// 4a.6d: record_text idempotency. The digest EXCLUDES the engine-generated
+/// embedding, and the pre-admission probe runs BEFORE the embed — proven with a
+/// counting embedder: the duplicate retry returns the original rid without
+/// invoking the embedder at all. (Also the reason a drifting embedder can never
+/// fake a conflict on this surface.)
+#[test]
+fn record_text_keyed_retry_hits_without_embedding_again() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct CountingEmbedder(Arc<AtomicUsize>);
+    impl crate::types::Embedder for CountingEmbedder {
+        fn embed(
+            &self,
+            t: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            let mut v = vec![0.1; 8];
+            v[0] = (t.len() % 7) as f32 * 0.1;
+            Ok(v)
+        }
+        fn dim(&self) -> usize {
+            8
+        }
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut db = YantrikDB::new(":memory:", 8).unwrap();
+    db.set_embedder(Box::new(CountingEmbedder(Arc::clone(&calls))))
+        .unwrap();
+
+    let write = |db: &YantrikDB| {
+        db.record_text_with_idempotency(
+            "keyed text write",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "rt_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("rt-key"),
+        )
+    };
+    let rid = write(&db).unwrap();
+    let embeds_after_first = calls.load(Ordering::SeqCst);
+    assert!(embeds_after_first >= 1, "first write embeds");
+
+    let rid2 = write(&db).unwrap();
+    assert_eq!(rid2, rid, "retry returns the original rid");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        embeds_after_first,
+        "the duplicate retry must resolve at the probe, BEFORE the embed — \
+         zero additional embedder invocations"
+    );
+
+    // And nothing was written by the retry.
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'rt_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(rows, 1, "one row total");
+}
+
+/// 4a.6d: the SAME key used across record() (embedding-inclusive digest) and
+/// record_text() (embedding-exclusive digest) is a typed conflict — a
+/// cross-surface retry is not the same write.
+#[test]
+fn same_key_across_record_and_record_text_is_a_conflict() {
+    struct Fake;
+    impl crate::types::Embedder for Fake {
+        fn embed(
+            &self,
+            t: &str,
+        ) -> std::result::Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+            let mut v = vec![0.1; 8];
+            v[0] = (t.len() % 7) as f32 * 0.1;
+            Ok(v)
+        }
+        fn dim(&self) -> usize {
+            8
+        }
+    }
+    let mut db = YantrikDB::new(":memory:", 8).unwrap();
+    db.set_embedder(Box::new(Fake)).unwrap();
+
+    // First write via record() with an explicit vector.
+    db.record_with_idempotency(
+        "cross surface text",
+        "semantic",
+        0.7,
+        0.0,
+        604800.0,
+        &empty_meta(),
+        &vec_seed(1.0, 8),
+        "xs_ns",
+        0.8,
+        "work",
+        "user",
+        None,
+        Some("xs-key"),
+    )
+    .unwrap();
+
+    // Same key, same text, via record_text — different surface, different
+    // digest variant: typed conflict, never a silent hit.
+    let err = db
+        .record_text_with_idempotency(
+            "cross surface text",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "xs_ns",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("xs-key"),
+        )
+        .expect_err("cross-surface same-key must conflict");
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::IdempotencyConflict { .. }
+        ),
+        "expected IdempotencyConflict, got {err:?}"
+    );
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -37,49 +37,82 @@ impl PyYantrikDB {
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("YantrikDB is closed"))?;
 
-        // 4a.6c (sol r4 note): a key with an ENGINE-GENERATED embedding is
-        // refused for now. record()'s digest includes the embedding (API-byte
-        // identity — the sync route stores it), so if this wrapper embedded the
-        // text itself, an embedder drift across retries would turn an honest
-        // retry into a false IdempotencyConflict. The generated-vector variant
-        // (digest excludes it) ships with record_text idempotency in 4a.6d;
-        // until then, fail loud rather than subtly mis-dedup.
-        if idempotency_key.is_some() && embedding.is_none() {
-            return Err(PyValueError::new_err(
-                "idempotency_key with an engine-generated embedding is not \
-                 supported yet: record()'s payload digest includes the \
-                 embedding, and a regenerated vector would make an honest \
-                 retry a false conflict. Pass an explicit `embedding` to use \
-                 a key today (generated-embedding idempotency lands with \
-                 record_text support).",
-            ));
-        }
-        let emb = match embedding {
-            Some(e) => e,
-            None => self.embed_text(py, text)?,
-        };
-
         let meta = match metadata {
             Some(d) => py_to_json(&d.as_any())?,
             None => serde_json::json!({}),
         };
 
-        db.record_with_idempotency(
-            text,
-            memory_type,
-            importance,
-            valence,
-            half_life,
-            &meta,
-            &emb,
-            namespace,
-            certainty,
-            domain,
-            source,
-            emotional_state,
-            idempotency_key,
-        )
-        .map_err(map_err)
+        // 4a.6d: routing decides the digest variant. An EXPLICIT embedding is
+        // part of the payload (record()'s API-byte identity — different vectors
+        // are different writes). No embedding + an ENGINE embedder routes
+        // through record_text_with_idempotency, whose digest EXCLUDES the
+        // generated vector — embedder drift across retries can never fake a
+        // conflict. This lifts the 4a.6c interim guard. The one remaining
+        // refusal: a key with a PYTHON-object fallback embedder (wrapper-side
+        // vector generation the engine cannot reproduce — same drift hazard the
+        // guard existed for, still real on that path only).
+        match embedding {
+            Some(emb) => db
+                .record_with_idempotency(
+                    text,
+                    memory_type,
+                    importance,
+                    valence,
+                    half_life,
+                    &meta,
+                    &emb,
+                    namespace,
+                    certainty,
+                    domain,
+                    source,
+                    emotional_state,
+                    idempotency_key,
+                )
+                .map_err(map_err),
+            None if db.has_embedder() => db
+                .record_text_with_idempotency(
+                    text,
+                    memory_type,
+                    importance,
+                    valence,
+                    half_life,
+                    &meta,
+                    namespace,
+                    certainty,
+                    domain,
+                    source,
+                    emotional_state,
+                    idempotency_key,
+                )
+                .map_err(map_err),
+            None => {
+                if idempotency_key.is_some() {
+                    return Err(PyValueError::new_err(
+                        "idempotency_key with a Python-side fallback embedder is \
+                         not supported: the wrapper generates the vector outside \
+                         the engine, so a drift across retries would fake a \
+                         conflict. Pass an explicit `embedding`, or attach an \
+                         engine embedder (bundled/named).",
+                    ));
+                }
+                let emb = self.embed_text(py, text)?;
+                db.record(
+                    text,
+                    memory_type,
+                    importance,
+                    valence,
+                    half_life,
+                    &meta,
+                    &emb,
+                    namespace,
+                    certainty,
+                    domain,
+                    source,
+                    emotional_state,
+                )
+                .map_err(map_err)
+            }
+        }
     }
 
     #[pyo3(signature = (query=None, query_embedding=None, top_k=10, time_window=None, memory_type=None, include_consolidated=false, expand_entities=true, skip_reinforce=false, namespace=None, domain=None, source=None, certainty_min=None, order=None, include_superseded=false))]


### PR DESCRIPTION
Part 1 of 3 of the 4a.6d fan-out (design doc step 5). **sol-ACCEPTed after 2 rounds.**

## What it does

`record_text_with_idempotency(..., idempotency_key: Option<&str>)` — same claim contract as `record()` ([#97](https://github.com/yantrikos/yantrikdb/pull/97)), with the design doc's one deliberate difference: the digest uses `PayloadVariant::RecordText`, **excluding the engine-generated embedding**. The engine embeds here, and embedders can be swapped or drift between attempts — digesting the generated vector would turn honest retries into false conflicts.

- **Duplicates never pay the embed**: the pre-admission probe runs before the (slow) embed. Proven with a counting embedder — the retry returns the original rid with zero additional embedder invocations (probe-removed mutation fails exactly that assertion).
- **Cross-surface safety**: the same key via `record()` (embedding-inclusive) vs `record_text()` (embedding-exclusive) is a typed conflict — the variant tag is load-bearing (sol-confirmed), independent of the embedding presence marker.
- **The 4a.6c Python guard is lifted**: `record(embedding=None, idempotency_key=...)` routes through `record_text_with_idempotency` when the engine has an embedder (drift-safe by construction; routing key verified against the wrapper's `has_embedder()` precedence). Explicit embeddings keep `record_with_idempotency`. The one remaining refusal: a key with a Python-object *fallback* embedder, where wrapper-side generation keeps the original drift hazard real.
- Bonus: keyless Python `record(embedding=None)` now flows through `record_text`'s revalidation loop, closing a latent embed-under-gen-N/commit-under-gen-N+1 window.

## sol r1 finding, fixed: record_text never normalized blank namespaces

A **pre-existing** divergence from `record()` (which coerces `""`/whitespace to `"default"` at entry), invisible while the Python wrapper routed around it — my rerouting exposed it: rows *and idempotency claims* would scope under `""` while every reader queries `"default"`. Normalized once at entry (after sanitize, before calibration/digest/probe/routing — placement sol-confirmed). Test pins row namespace, claim scope, and `""`/`"   "` retry equivalence; mutation-proven.

The where-else sweep found the class's third instance: **`record_batch` writes rows under the raw namespace while its stats advance normalizes internally** — row and stats in different partitions. Pre-existing, sol-confirmed, filed as [#98](https://github.com/yantrikos/yantrikdb/issues/98); the fix rides 4a.6d-2, which restructures those lines anyway.

## Remaining 4a.6d

- **Part 2**: `record_batch` — in-batch dup handling + reserve-before-savepoint (closes [#92](https://github.com/yantrikos/yantrikdb/issues/92) and [#98](https://github.com/yantrikos/yantrikdb/issues/98))
- **Part 3**: `record_with_rid(Origin)` keys

Rust lib **1736** default / **1738** with `--features testing`; kill proofs green; python crate compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)