### PR TITLE
feat(v0.10-4a.6d-2a): record_batch reserve-before-savepoint restructure

### DIFF
--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -53,6 +53,7 @@ pub mod repair;
 mod replay_engine;
 mod reservation;
 mod sanitize;
+mod savepoint;
 mod schema_induction_engine;
 mod session;
 mod skills;

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -739,6 +739,21 @@ impl YantrikDB {
             return Ok(vec![]);
         }
 
+        // 4a.6d-2a (#98): normalize namespaces ONCE at entry, positionally
+        // aligned with `inputs`, and use `namespaces[idx]` for EVERY consumer
+        // below — the row, the session lookup, the replicated op payload, the
+        // audit event, the scoring cache, the visible_seq bump, and the
+        // importance stats. record() and record_text coerce blank namespaces
+        // to "default" at entry; record_batch never did, while the calibration
+        // helpers it calls normalize INTERNALLY — so one blank-namespace batch
+        // item split across two partitions: the row landed under the raw "  "
+        // (which no reader queries) and its importance observation advanced
+        // "default"'s stats.
+        let namespaces: Vec<&str> = inputs
+            .iter()
+            .map(|i| normalize_namespace(&i.namespace))
+            .collect();
+
         // v0.9.3 contract gate: prevalidate the ENTIRE batch before any side
         // effect (calibration / SQL / oplog / index), so a bad element late
         // in the batch can't leave earlier elements half-committed.
@@ -803,15 +818,18 @@ impl YantrikDB {
             .collect();
 
         // Task 31 (Ingest Integrity): each input's importance is calibrated
-        // against its namespace distribution INSIDE the savepoint below (4a.6b),
-        // positionally aligned with `inputs` via push order. Computing +
-        // advancing per item under the savepoint's transaction view preserves
-        // the documented property that later items in the batch see the
-        // running-mean effect of earlier ones in the same namespace — while a
-        // ROLLBACK TO takes every advance with it, so a rejected batch leaves
-        // every namespace's distribution untouched. (The old pre-routing
-        // autocommit advanced ALL of them even when the batch then deferred on
-        // the write-router or died mid-savepoint.)
+        // against its namespace distribution INSIDE the savepoint below,
+        // positionally aligned with `inputs` via push order. Every item
+        // calibrates against the SAME pre-batch snapshot (4a.6b: a batch is
+        // one simultaneous act, no within-batch running mean): all the
+        // calibration READS happen in the item loop, and the stats ADVANCES
+        // run after it — still inside the savepoint, so a rejected batch
+        // rolls its advances back with everything else. That in-savepoint
+        // advance is safe again BECAUSE of 4a.6d-2a: capacity is reserved
+        // before the savepoint opens, so nothing can fail after RELEASE —
+        // the deferred best-effort advance (and its silently-skipped-
+        // observation gap) existed only to survive the post-RELEASE append
+        // failure that no longer exists.
         let mut calibrated_importances: Vec<f64> = Vec::with_capacity(inputs.len());
 
         // **Issue #41 layer 3.** Enter the write-router BEFORE snapshotting
@@ -872,45 +890,68 @@ impl YantrikDB {
                 })
                 .collect();
 
-        let mut rids = Vec::with_capacity(inputs.len());
+        let mut rids: Vec<String> = Vec::with_capacity(inputs.len());
+        let mut seqs: Vec<u64> = Vec::with_capacity(inputs.len());
         // One canonical "record" op per item, emitted after the savepoint
         // releases. See `log_record_ops_batch`: the old single "record_batch" op
         // was silently dropped by every peer, so batch writes never replicated.
         let mut record_op_entries: Vec<(String, serde_json::Value, Vec<u8>)> =
             Vec::with_capacity(inputs.len());
 
+        // 4a.6d-2a (#92): the batch's reserve → commit → publish guard.
+        // Declared OUTSIDE the conn scope: it publishes the vectors after the
+        // savepoint's fate is decided (and the conn lock is released), and on
+        // ANY pre-commit exit its Drop removes every reservation taken so far.
+        let mut batch_reservation =
+            super::reservation::BatchReservationGuard::new(&state, inputs.len());
+
         // Lock conn once for the entire batch SQL work
         {
             let conn = self.conn();
-            conn.execute_batch("SAVEPOINT batch_record")?;
+
+            // RESERVE delta capacity for ALL N items BEFORE the savepoint
+            // opens — the batch analogue of record()'s protocol (4a.6a). This
+            // is where Backpressure and dim mismatches surface: before a
+            // single durable byte. The old shape appended AFTER the RELEASE
+            // and compensated failure with a DELETE that reversed rows and
+            // session counts but could never reverse `entities` upserts,
+            // `memory_entities` links, or the in-memory graph_index (#92) —
+            // now there is nothing to compensate. Seqs are minted under the
+            // conn lock for the same reason record() mints there: search
+            // resolves a rid to its HIGHEST seq, so minting must serialize
+            // with the commits that act on it.
+            for input in inputs.iter() {
+                let rid = crate::id::new_id();
+                let seq = self.assign_seq(None);
+                batch_reservation.reserve(rid.clone(), input.embedding.clone(), seq)?;
+                rids.push(rid);
+                seqs.push(seq);
+            }
+
+            // #91: RAII, not manual unwinding. EVERY fallible statement below
+            // — serde, the encrypt wrappers, each INSERT, the stats advances —
+            // may `?`-return and the guard's Drop runs `ROLLBACK TO; RELEASE`.
+            // The old error arm rolled back WITHOUT releasing (and the paths
+            // before the INSERT returned without even the rollback), leaving
+            // the savepoint open on the engine's single shared connection so
+            // every later write silently nested inside it.
+            let savepoint = super::savepoint::SavepointGuard::new(&conn, "batch_record")?;
 
             for (idx, input) in inputs.iter().enumerate() {
-                let rid = crate::id::new_id();
+                let rid = &rids[idx];
                 let ts = now();
                 let emb_blob = serialize_f32(&input.embedding);
                 let meta_str = serde_json::to_string(&input.metadata)?;
 
-                // 4a.6b: calibrate + advance under the savepoint. The `_on`
-                // variant reads through the HELD guard — calling the locking
-                // wrapper here would re-lock `conn` on the same thread, the
-                // `learn_category_members` deadlock (#83).
-                //
-                // 4a.6b (sol r2 finding 1): the stats ADVANCE is NOT done here.
-                // The vector append happens after the savepoint RELEASE and can
-                // still fail, and a committed EWMA blend is irreversible by the
-                // compensating DELETE — so advancing inside the savepoint left a
-                // rejected batch having permanently moved calibration. The
-                // advance is deferred to the post-append-loop block below, run
-                // only once the append wins. Consequence: every item calibrates
-                // against the SAME pre-batch snapshot (no within-batch running
-                // mean). That intra-batch progression was never pinned by a test
-                // and is a defensible semantics change — a batch is one
-                // simultaneous act — and it buys winner-only correctness. The
-                // cross-batch running mean is unchanged (the deferred advances
-                // move the table).
+                // 4a.6b: calibrate under the savepoint. The `_on` variant
+                // reads through the HELD guard — calling the locking wrapper
+                // here would re-lock `conn` on the same thread, the
+                // `learn_category_members` deadlock (#83). Read-only: the
+                // matching advances run after this loop (same-snapshot
+                // calibration — see the `calibrated_importances` comment).
                 let calibrated = super::importance::calibrated_importance_on(
                     &conn,
-                    &input.namespace,
+                    namespaces[idx],
                     input.importance,
                 )?;
                 calibrated_importances.push(calibrated);
@@ -924,7 +965,7 @@ impl YantrikDB {
                 // **Issue #41 brainstorm-4 §6.** v28 embedding_generation
                 // stamped from the batch's snapshot.
                 let embedding_generation: i64 = state.generation as i64;
-                let result = conn.execute(
+                conn.execute(
                     "INSERT INTO memories \
                      (rid, type, text, embedding, created_at, updated_at, importance, \
                       half_life, last_access, valence, metadata, namespace, \
@@ -932,20 +973,17 @@ impl YantrikDB {
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                     params![rid, input.memory_type, stored_text, stored_emb, ts, ts,
                             calibrated_importances[idx], input.half_life, ts, input.valence, stored_meta,
-                            input.namespace, input.certainty, input.domain, input.source,
+                            namespaces[idx], input.certainty, input.domain, input.source,
                             input.emotional_state, embedding_generation],
-                );
-
-                if let Err(e) = result {
-                    conn.execute_batch("ROLLBACK TO batch_record")?;
-                    return Err(e.into());
-                }
+                )?;
 
                 // Byte-for-byte the payload `record()` emits (record.rs:325-340)
                 // so peers materialize batch items through the existing, tested
                 // "record" arm. Plaintext text/metadata, matching record() — the
                 // encrypted forms above are the at-rest representation, not the
-                // replication one.
+                // replication one. NORMALIZED namespace (#98): peers must land
+                // the row in the same partition this node did, not the raw
+                // blank one.
                 record_op_entries.push((
                     rid.clone(),
                     serde_json::json!({
@@ -958,7 +996,7 @@ impl YantrikDB {
                         "metadata": input.metadata,
                         "created_at": ts,
                         "updated_at": ts,
-                        "namespace": input.namespace,
+                        "namespace": namespaces[idx],
                         "certainty": input.certainty,
                         "domain": input.domain,
                         "source": input.source,
@@ -966,13 +1004,11 @@ impl YantrikDB {
                     }),
                     embedding_hash(&input.embedding),
                 ));
-
-                rids.push(rid);
             }
 
             // Auto-link batch to active sessions
-            for (rid, input) in rids.iter().zip(inputs.iter()) {
-                if let Some(session_id) = sessions.get(&input.namespace) {
+            for (idx, rid) in rids.iter().enumerate() {
+                if let Some(session_id) = sessions.get(namespaces[idx]) {
                     conn.execute(
                         "UPDATE memories SET session_id = ?1 WHERE rid = ?2",
                         params![session_id, rid],
@@ -1010,13 +1046,30 @@ impl YantrikDB {
                 }
             }
 
-            conn.execute_batch("RELEASE batch_record")?;
+            // 4a.6b winner-only calibration, 4a.6d-2a placement: the advances
+            // run INSIDE the savepoint, after every calibration READ above —
+            // so items still calibrate against the same pre-batch snapshot,
+            // and a rejected batch rolls its advances back with everything
+            // else instead of permanently moving a namespace's distribution.
+            // This retires the old post-commit best-effort advance: that
+            // deferral existed only because the vector append could fail
+            // after RELEASE, and with capacity reserved up front it cannot.
+            // An Err here is PRE-commit — the whole batch rolls back and a
+            // retry writes once — so `?` is correct where post-commit it was
+            // the retry-duplicates trap (sol 4a.6b r3 finding 1).
+            for (idx, input) in inputs.iter().enumerate() {
+                self.advance_importance_stats_in_tx(&conn, namespaces[idx], input.importance)?;
+            }
+
+            savepoint.release()?;
+            // The obligation inverts HERE: the rows are durable, so from this
+            // point the reservations owe publish, not removal. Nothing
+            // fallible may sit between the RELEASE and this call.
+            batch_reservation.mark_committed();
         }
-        // NOTE: warn-mode flag ticks are DEFERRED to after the vector-append
-        // loop below (4a.6b finding 1). The append is a post-RELEASE failure
-        // point whose compensation deletes the rows — so ticking here would
-        // count writes the caller then sees fail. See the tick loop past the
-        // append.
+        // NOTE: warn-mode flag ticks are DEFERRED to after the publish below
+        // (4a.6b finding 1): the nudge metric counts writes that landed and
+        // became visible, in the same order record() counts them.
         // conn dropped; now update graph_index in-memory.
         {
             let mut gi = self.graph_index.write();
@@ -1040,7 +1093,7 @@ impl YantrikDB {
                 crate::graph::analyze_text_features(sanitized_texts[idx].as_ref(), &heuristic_vec);
             tracing::info!(
                 target: "yantrikdb::audit::extraction",
-                namespace = %input.namespace,
+                namespace = %namespaces[idx],
                 memory_rid = %rid,
                 domain = %input.domain,
                 source = %input.source,
@@ -1059,91 +1112,45 @@ impl YantrikDB {
             );
         }
 
-        // Append to vec_index (DeltaIndex) after SQL commit.
-        // **v0.7.19 orphan-on-Backpressure fix.** If any append in
-        // the batch fails (delta saturation, dim mismatch), the
-        // SAVEPOINT above has already committed all N memories
-        // rows. Compensating DELETE clears the entire batch so the
-        // caller sees an atomic batch-fail outcome rather than
-        // partial-commit state. See record() for the rationale on
-        // single-row writes.
-        for (idx, (rid, input)) in rids.iter().zip(inputs.iter()).enumerate() {
-            let seq = self
-                .vec_seq
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                + 1;
-            if let Err(e) = state
-                .vec_index
-                .append(rid.clone(), input.embedding.clone(), seq)
-            {
-                // Roll back all N rows from memories (DELETE is fast
-                // under a single conn lock; idempotent via WHERE).
-                let conn = self.conn();
-                for r in &rids {
-                    let _ = conn.execute("DELETE FROM memories WHERE rid = ?1", params![r]);
-                }
-                // **v0.7.23 residual fix.** Reverse the per-session
-                // `memory_count` bumps committed in the SAVEPOINT above,
-                // once per memory that was session-linked — mirrors the
-                // increment loop exactly so the stat matches the rows the
-                // compensating DELETE just removed.
-                for input in inputs.iter() {
-                    if let Some(session_id) = sessions.get(&input.namespace) {
-                        let _ = conn.execute(
-                            "UPDATE sessions SET memory_count = memory_count - 1 WHERE session_id = ?1",
-                            params![session_id],
-                        );
-                    }
-                }
-                let _ = idx; // index of the failing entry, kept for future logging
-                return Err(e);
-            }
-            self.bump_visible_seq(&input.namespace, seq);
+        // Durable. PUBLISH all N vectors — infallible, so there is no failure
+        // window between "committed" and "visible", and therefore nothing to
+        // compensate. (This retires the v0.7.19 compensating DELETE and its
+        // v0.7.23 session-count reversal: both existed because the append used
+        // to happen HERE, after the commit, where it could still fail. The
+        // DELETE never reversed `entities`, `memory_entities`, or the
+        // in-memory graph_index — #92 — which is unfixable by adding more
+        // compensation and gone by construction with the up-front reserve.)
+        let all_published = batch_reservation.complete();
+        debug_assert!(
+            all_published,
+            "batch reservation vanished before publish (rids {rids:?})"
+        );
+        if !all_published {
+            tracing::error!(
+                batch_size = rids.len(),
+                "reserved batch vector entries missing at publish — rows are \
+                 durable but unsearchable until the index is rebuilt from SQL"
+            );
         }
-        // 4a.6b (sol r2 finding 1): every append landed, so the batch is durable
-        // AND visible — the winner is decided. Advance the calibration stats and
-        // count the warn-mode flags NOW, both winner-only. Ticking or advancing
-        // before this point would have moved state for a batch whose append then
-        // failed and whose rows were compensated away — and a committed EWMA
-        // blend cannot be un-done by the compensating DELETE.
-        //
-        // Grouped in one transaction so the N advances are all-or-nothing. Each
-        // is a plain upsert (SQL blend against the stored value; composes with
-        // concurrent writers), fed the RAW importance.
-        //
-        // BEST-EFFORT, deliberately NOT `?` (sol 4a.6b r3 finding 1): the rows
-        // and vectors are already durable and visible — the batch WON. Calibration
-        // is an approximate ranking prior, so failing to advance it is a benign
-        // skipped observation. Propagating a SQLITE_FULL/IO error from this tx
-        // would report Err for an already-committed batch, and a retrying caller
-        // would then write DUPLICATE records under fresh rids — turning a missed
-        // stat into data corruption. So it logs and continues.
-        //
-        // NB (sol r4 / #94): `log_record_ops_batch(...)?` below still `?`-returns
-        // after this winner point — a PRE-EXISTING Err-after-commit (#79-era)
-        // that is NOT best-effortable (the ops are what replicate the batch). Its
-        // correct fix is to move that append inside the savepoint above (needs a
-        // held-conn variant to avoid the #83 re-lock); tracked in #94, out of
-        // 4a.6b's scope. Calibration is best-effort ONLY because it is
-        // approximate — do not copy this pattern to the oplog append.
-        {
-            let conn = self.conn();
-            let advanced = (|| -> Result<()> {
-                let tx = conn.unchecked_transaction()?;
-                for input in inputs.iter() {
-                    self.advance_importance_stats_in_tx(&tx, &input.namespace, input.importance)?;
-                }
-                tx.commit()?;
-                Ok(())
-            })();
-            if let Err(e) = advanced {
-                tracing::warn!(
-                    error = %e,
-                    "record_batch: post-commit calibration advance failed; \
-                     batch is durable, calibration observation skipped"
-                );
-            }
+        drop(batch_reservation);
+
+        // LAST: a read-your-write waiter must not wake against a half-applied
+        // batch (CONCURRENCY.md: bump visible_seq AFTER the delta publish).
+        for (idx, _) in inputs.iter().enumerate() {
+            self.bump_visible_seq(namespaces[idx], seqs[idx]);
         }
+        // 4a.6b: the warn-mode flags are counted only now — the batch is
+        // durable AND visible, so the nudge metric counts writes that landed.
+        // (The matching calibration advances moved INSIDE the savepoint in
+        // 4a.6d-2a — see the comment there; the winner is decided at RELEASE
+        // now that nothing can fail after it.)
+        //
+        // NB (sol r4 / #94): `log_record_ops_batch(...)?` below still
+        // `?`-returns after the commit — a PRE-EXISTING Err-after-commit
+        // (#79-era) that is NOT best-effortable (the ops are what replicate
+        // the batch). Its correct fix is to move that append inside the
+        // savepoint above (needs a held-conn variant to avoid the #83
+        // re-lock); tracked in #94, out of 4a.6d-2a's scope.
         for verdict in gate_verdicts {
             self.note_flagged_write_committed(verdict);
         }
@@ -1163,7 +1170,7 @@ impl YantrikDB {
                         valence: input.valence,
                         consolidation_status: "active".to_string(),
                         memory_type: input.memory_type.clone(),
-                        namespace: input.namespace.clone(),
+                        namespace: namespaces[idx].to_string(),
                         certainty: input.certainty,
                         domain: input.domain.clone(),
                         source: input.source.clone(),

--- a/crates/yantrikdb-core/src/engine/reservation.rs
+++ b/crates/yantrikdb-core/src/engine/reservation.rs
@@ -144,6 +144,98 @@ impl Drop for ReservationGuard<'_> {
     }
 }
 
+/// The batch analogue of [`ReservationGuard`] (v0.10 Item 4a.6d-2a, #92):
+/// one phase, N `(rid, seq)` reservations, all owing the SAME obligation at
+/// the same moment — a batch is one write with one commit point.
+///
+/// `record_batch` reserves delta capacity for EVERY item before its savepoint
+/// opens, so capacity exhaustion (the old post-RELEASE append failure)
+/// surfaces before a single durable byte — there is nothing to compensate,
+/// which is what actually closes #92: the compensating DELETE reversed rows
+/// and session counts but could never reverse `entities` upserts,
+/// `memory_entities` links, or the in-memory graph_index.
+///
+/// Always publish-only, and deliberately WITHOUT a `with_pending_op`
+/// constructor: `record_batch`'s ops commit `applied = 1` via
+/// `log_record_ops_batch`, so it never enqueues a pending op. Counting here
+/// would inflate `pending_op_count` against zero pending rows — the v0.7.1
+/// counter-leak class the module doc describes. If a queued-batch primitive
+/// ever exists, add the constructor WITH its rationale; do not default to
+/// counting.
+pub(crate) struct BatchReservationGuard<'a> {
+    state: &'a SearchState,
+    /// Owned because the rids outlive no caller borrow this early: the guard
+    /// is constructed before the batch's SQL loop mints its row parameters.
+    entries: Vec<(String, u64)>,
+    phase: ResPhase,
+}
+
+impl<'a> BatchReservationGuard<'a> {
+    pub(crate) fn new(state: &'a SearchState, capacity: usize) -> Self {
+        Self {
+            state,
+            entries: Vec::with_capacity(capacity),
+            phase: ResPhase::Reserved,
+        }
+    }
+
+    /// Reserve one item. On `Err` the FAILED item was never reserved (the
+    /// delta rejects before inserting), and every PRIOR reservation is still
+    /// held by this guard — the caller just returns and `Drop` removes them
+    /// all. Partial reservation must never leak: that capacity is
+    /// unreclaimable by anyone else (compaction retains unpublished entries).
+    pub(crate) fn reserve(
+        &mut self,
+        rid: String,
+        embedding: Vec<f32>,
+        seq: u64,
+    ) -> crate::error::Result<()> {
+        self.state
+            .vec_index
+            .append_reserved(rid.clone(), embedding, seq)?;
+        self.entries.push((rid, seq));
+        Ok(())
+    }
+
+    /// The batch's savepoint RELEASEd: all N obligations invert to publish.
+    /// Nothing fallible may sit between the RELEASE and this call.
+    pub(crate) fn mark_committed(&mut self) {
+        self.phase = ResPhase::Committed;
+    }
+
+    /// Publish all N exactly once. Returns whether every publish found its
+    /// reservation.
+    pub(crate) fn complete(&mut self) -> bool {
+        let all_published = self.discharge_committed();
+        self.phase = ResPhase::Done;
+        all_published
+    }
+
+    fn discharge_committed(&self) -> bool {
+        let mut all_published = true;
+        for (rid, seq) in &self.entries {
+            all_published &= self.state.vec_index.publish(rid, *seq);
+        }
+        all_published
+    }
+}
+
+impl Drop for BatchReservationGuard<'_> {
+    fn drop(&mut self) {
+        match self.phase {
+            ResPhase::Reserved => {
+                for (rid, seq) in &self.entries {
+                    self.state.vec_index.remove_appended(rid, *seq);
+                }
+            }
+            ResPhase::Committed => {
+                self.discharge_committed();
+            }
+            ResPhase::Done => {}
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -295,6 +387,91 @@ mod tests {
             db.pending_op_count.load(Ordering::Relaxed),
             before,
             "publish_only must never move pending_op_count, on either discharge path"
+        );
+    }
+
+    // ── BatchReservationGuard (4a.6d-2a) ──
+
+    /// THE #92 shape: some items reserve, a later one fails (capacity/dim),
+    /// the batch returns Err — every reservation already taken must be
+    /// removed, or its capacity is held until restart.
+    #[test]
+    fn batch_drop_before_commit_removes_every_reservation() {
+        let db = db();
+        let state = db.search_state.load_full();
+
+        {
+            let mut g = BatchReservationGuard::new(&state, 3);
+            g.reserve("b1".into(), vec![0.1; 8], 21).unwrap();
+            g.reserve("b2".into(), vec![0.2; 8], 22).unwrap();
+            // A third item WOULD have failed here; the caller `?`-returns and
+            // the guard falls out of scope still Reserved.
+        }
+
+        assert!(
+            !state.vec_index.remove_appended("b1", 21),
+            "first reservation must have been removed by Drop"
+        );
+        assert!(
+            !state.vec_index.remove_appended("b2", 22),
+            "second reservation must have been removed by Drop"
+        );
+    }
+
+    #[test]
+    fn batch_unwind_after_commit_publishes_all_rather_than_stranding() {
+        let db = db();
+        let state = db.search_state.load_full();
+
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut g = BatchReservationGuard::new(&state, 2);
+            g.reserve("b3".into(), vec![0.1; 8], 23).unwrap();
+            g.reserve("b4".into(), vec![0.2; 8], 24).unwrap();
+            g.mark_committed();
+            panic!("simulated panic between the batch RELEASE and publish");
+        }));
+        assert!(res.is_err(), "panic must propagate");
+
+        // Post-commit the rows are durable: every vector must be published,
+        // none removed.
+        for (rid, seq) in [("b3", 23u64), ("b4", 24u64)] {
+            assert!(
+                !state.vec_index.publish(rid, seq),
+                "{rid} must already be published by Drop"
+            );
+            assert!(
+                state.vec_index.remove_appended(rid, seq),
+                "{rid} must still EXIST — post-commit it is published, never removed"
+            );
+        }
+    }
+
+    #[test]
+    fn batch_complete_then_drop_discharges_exactly_once_and_never_counts() {
+        let db = db();
+        let state = db.search_state.load_full();
+        let before = db.pending_op_count.load(Ordering::Relaxed);
+
+        {
+            let mut g = BatchReservationGuard::new(&state, 2);
+            g.reserve("b5".into(), vec![0.1; 8], 25).unwrap();
+            g.reserve("b6".into(), vec![0.2; 8], 26).unwrap();
+            g.mark_committed();
+            assert!(g.complete(), "complete() publishes all and reports it");
+            // Drop runs in Done phase: no second publish, no removal.
+        }
+
+        assert!(
+            state.vec_index.remove_appended("b5", 25),
+            "published entry must survive the Done-phase Drop"
+        );
+        // record_batch commits applied=1 ops (log_record_ops_batch), so the
+        // batch guard has NO counting mode at all — the v0.7.1 counter-leak
+        // class, kept impossible by construction.
+        assert_eq!(
+            db.pending_op_count.load(Ordering::Relaxed),
+            before,
+            "the batch guard must never move pending_op_count"
         );
     }
 }

--- a/crates/yantrikdb-core/src/engine/savepoint.rs
+++ b/crates/yantrikdb-core/src/engine/savepoint.rs
@@ -1,0 +1,159 @@
+//! RAII savepoint guard (v0.10 Item 4a.6d-2a, issue #91).
+//!
+//! `record_batch`'s error arms used to unwind the savepoint by hand — and got
+//! it wrong in every way that class of code gets it wrong. The INSERT-failure
+//! arm ran `ROLLBACK TO batch_record` and returned WITHOUT `RELEASE`, and the
+//! fallible calls before the INSERT (`serde_json::to_string`, the encrypt
+//! wrappers) `?`-returned without even the `ROLLBACK TO`. Both leave the
+//! outermost savepoint OPEN on the engine's single shared connection:
+//! `SAVEPOINT` on an autocommit conn starts a transaction that only ends when
+//! that savepoint is RELEASEd or the tx rolls back, so every later write on
+//! the conn silently nests inside the abandoned savepoint — durable only if
+//! some unrelated future write happens to close it, all lost together if
+//! anything rolls back. Two error arms, two different manual unwind attempts,
+//! both wrong: the rule wants ONE owner.
+//!
+//! The guard is that owner. Construct it right after `SAVEPOINT`; every early
+//! `?`-return and every unwinding panic hits `Drop`, which runs
+//! `ROLLBACK TO name; RELEASE name` — SQLite's idiom for "undo the work AND
+//! close the frame". The happy path calls [`SavepointGuard::release`], which
+//! consumes the guard so a released savepoint cannot also be rolled back.
+
+use rusqlite::Connection;
+
+/// RAII for `SAVEPOINT name … RELEASE name` on a shared connection.
+///
+/// The name is `&'static str` by design: savepoint names cannot be bound as
+/// SQL parameters, so accepting runtime strings here would invite injection
+/// through the back door. Every caller names its savepoint in source.
+pub(crate) struct SavepointGuard<'a> {
+    conn: &'a Connection,
+    name: &'static str,
+    released: bool,
+}
+
+impl<'a> SavepointGuard<'a> {
+    /// Open the savepoint. On an autocommit connection this BEGINS a
+    /// transaction that stays open until this guard releases or drops.
+    pub(crate) fn new(conn: &'a Connection, name: &'static str) -> rusqlite::Result<Self> {
+        conn.execute_batch(&format!("SAVEPOINT {name}"))?;
+        Ok(Self {
+            conn,
+            name,
+            released: false,
+        })
+    }
+
+    /// Commit the savepoint's work. Consumes the guard: released and rolled
+    /// back are mutually exclusive by construction.
+    ///
+    /// If the RELEASE itself fails (e.g. `SQLITE_FULL` at the outermost
+    /// commit), the guard drops un-released and `Drop` rolls the work back —
+    /// an Err from this method means NOT COMMITTED, never "maybe".
+    pub(crate) fn release(mut self) -> rusqlite::Result<()> {
+        self.conn.execute_batch(&format!("RELEASE {}", self.name))?;
+        self.released = true;
+        Ok(())
+    }
+}
+
+impl Drop for SavepointGuard<'_> {
+    fn drop(&mut self) {
+        if !self.released {
+            // ROLLBACK TO undoes the work but leaves the savepoint frame on
+            // the stack; the RELEASE closes it (and, for the outermost
+            // savepoint, ends the transaction). Best-effort: an unwind path
+            // has no way to surface a second error, and the conn poisons no
+            // locks — the next writer's own savepoint would otherwise nest.
+            let _ = self
+                .conn
+                .execute_batch(&format!("ROLLBACK TO {n}; RELEASE {n}", n = self.name));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::YantrikDB;
+
+    /// These pin the #91 property directly and deterministically — no failpoint
+    /// needed: `Connection::is_autocommit()` is false exactly while a
+    /// transaction (here: the outermost savepoint) is open.
+    fn db() -> YantrikDB {
+        YantrikDB::new(":memory:", 8).unwrap()
+    }
+
+    #[test]
+    fn release_commits_and_returns_conn_to_autocommit() {
+        let db = db();
+        let conn = db.conn();
+        assert!(conn.is_autocommit(), "precondition");
+
+        let sp = SavepointGuard::new(&conn, "sp_release").unwrap();
+        assert!(
+            !conn.is_autocommit(),
+            "outermost savepoint must open a transaction"
+        );
+        conn.execute_batch("CREATE TABLE sp_probe (x INTEGER)")
+            .unwrap();
+        sp.release().unwrap();
+
+        assert!(conn.is_autocommit(), "release must close the transaction");
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sp_probe", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "released work must be durable (table exists)");
+    }
+
+    /// THE #91 bug shape: an error path that abandons the savepoint. The old
+    /// manual arms left `is_autocommit() == false` here — every later write on
+    /// the shared conn then silently joined the abandoned transaction.
+    #[test]
+    fn drop_without_release_rolls_back_and_closes_the_frame() {
+        let db = db();
+        let conn = db.conn();
+
+        {
+            let _sp = SavepointGuard::new(&conn, "sp_drop").unwrap();
+            conn.execute_batch("CREATE TABLE sp_gone (x INTEGER)")
+                .unwrap();
+            // falls out of scope un-released — the early-`?`-return shape
+        }
+
+        assert!(
+            conn.is_autocommit(),
+            "drop must ROLLBACK TO *and* RELEASE — a bare ROLLBACK TO leaves \
+             the transaction open (#91)"
+        );
+        let missing = conn
+            .query_row("SELECT COUNT(*) FROM sp_gone", [], |r| r.get::<_, i64>(0))
+            .is_err();
+        assert!(missing, "dropped savepoint's work must be rolled back");
+    }
+
+    #[test]
+    fn unwind_rolls_back_and_closes_the_frame() {
+        let db = db();
+        let conn = db.conn();
+
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _sp = SavepointGuard::new(&conn, "sp_panic").unwrap();
+            conn.execute_batch("CREATE TABLE sp_panic_probe (x INTEGER)")
+                .unwrap();
+            panic!("simulated panic inside the savepoint");
+        }));
+        assert!(res.is_err(), "panic must propagate");
+
+        assert!(
+            conn.is_autocommit(),
+            "an unwinding panic must not leave the savepoint open"
+        );
+        let missing = conn
+            .query_row("SELECT COUNT(*) FROM sp_panic_probe", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .is_err();
+        assert!(missing, "unwound savepoint's work must be rolled back");
+    }
+}

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -8220,6 +8220,265 @@ fn record_text_normalizes_blank_namespace_like_record() {
     );
 }
 
+/// 4a.6d-2a (#92): a batch rejected for delta capacity must write NOTHING AT
+/// ALL. The pre-restructure code committed the savepoint (rows + sessions +
+/// entities + memory_entities), updated graph_index in-memory, and only THEN
+/// appended vectors — so a capacity failure triggered a compensating DELETE
+/// that reversed rows and session counts but left `entities`,
+/// `memory_entities`, and the in-memory graph_index permanently inflated with
+/// linkage for memories that do not exist. The fix reserves delta capacity for
+/// ALL N items BEFORE the savepoint opens, so capacity failure surfaces before
+/// a single durable byte — the same reserve→commit→publish protocol record()
+/// uses (4a.6a), batched.
+#[test]
+fn batch_append_failure_writes_nothing_at_all() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let dim = db.embedding_dim();
+
+    // CONTROL: prove this text shape actually drives entity extraction, so the
+    // absence assertions below are meaningful rather than vacuously true. A
+    // regression test whose branch never fires is decoration (#83 lesson).
+    db.record_batch(&[RecordInput {
+        text: "Quarterly sync with Klaxonberg about the roadmap".into(),
+        memory_type: "episodic".into(),
+        importance: 0.6,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: serde_json::json!({}),
+        embedding: vec_seed(1.5, 8),
+        namespace: "ctrl_ns".into(),
+        certainty: 0.8,
+        domain: "work".into(),
+        source: "user".into(),
+        emotional_state: None,
+    }])
+    .unwrap();
+    let ctrl_entities: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM entities WHERE name = 'Klaxonberg'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        ctrl_entities, 1,
+        "control precondition: batch entity extraction must fire for this \
+         text shape, or the absence assertions below prove nothing"
+    );
+
+    // Saturate the delta with single-record writes in a different namespace.
+    let mut saturated = false;
+    for i in 0..400 {
+        let emb: Vec<f32> = (0..dim).map(|j| ((i + j) as f32) * 0.001).collect();
+        match db.record(
+            &format!("filler-{i}"),
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &emb,
+            "filler_ns",
+            0.8,
+            "general",
+            "user",
+            None,
+        ) {
+            Ok(_) => {}
+            Err(crate::error::YantrikDbError::Backpressure { .. }) => {
+                saturated = true;
+                break;
+            }
+            Err(e) => panic!("unexpected: {e:?}"),
+        }
+    }
+    assert!(saturated, "delta never saturated");
+
+    let ops_before: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM oplog", [], |r| r.get(0))
+        .unwrap();
+
+    // The doomed batch: same text shape, a DIFFERENT unique entity.
+    let err = db
+        .record_batch(&[RecordInput {
+            text: "Quarterly sync with Quorvexia about the roadmap".into(),
+            memory_type: "episodic".into(),
+            importance: 0.9,
+            valence: 0.0,
+            half_life: 604800.0,
+            metadata: serde_json::json!({}),
+            embedding: vec_seed(2.0, 8),
+            namespace: "batch_ns".into(),
+            certainty: 0.8,
+            domain: "work".into(),
+            source: "user".into(),
+            emotional_state: None,
+        }])
+        .expect_err("batch into the saturated delta must fail");
+    assert!(
+        matches!(err, crate::error::YantrikDbError::Backpressure { .. }),
+        "expected Backpressure, got {err:?}"
+    );
+
+    // NOTHING may exist: not rows, not entities, not memory_entities, not the
+    // in-memory graph, not oplog entries. Pre-restructure, the first three SQL
+    // assertions below held only for `memories` — entities/memory_entities
+    // committed in the savepoint and the compensating DELETE never touched
+    // them (#92).
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'batch_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(rows, 0, "no memory rows for the rejected batch");
+
+    let orphan_entities: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM entities WHERE name = 'Quorvexia'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        orphan_entities, 0,
+        "a rejected batch left an orphaned `entities` row (#92)"
+    );
+
+    let orphan_links: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memory_entities WHERE entity_name = 'Quorvexia'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        orphan_links, 0,
+        "a rejected batch left orphaned `memory_entities` links (#92)"
+    );
+
+    assert!(
+        !db.graph_index
+            .read()
+            .all_entity_names()
+            .iter()
+            .any(|n| n == "Quorvexia"),
+        "a rejected batch polluted the in-memory graph_index (#92)"
+    );
+
+    let ops_after: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM oplog", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(ops_after, ops_before, "no oplog entries for a rejected batch");
+
+    // And the connection is back in autocommit — no savepoint left open (#91's
+    // class: an error arm that unwinds the savepoint must RELEASE it too, or
+    // every later write on this conn silently nests inside it).
+    assert!(
+        db.conn().is_autocommit(),
+        "record_batch failure left a savepoint open on the shared conn"
+    );
+}
+
+/// 4a.6d-2a (#98): record_batch never normalized blank namespaces, while the
+/// calibration helpers it calls normalize INTERNALLY — so a blank-namespace
+/// batch split across two partitions: the ROW landed under the raw "  " (a
+/// partition no reader queries), while its importance observation advanced the
+/// stats under "default". record() and (since #99) record_text both coerce at
+/// entry; the batch must behave identically, and the replicated op payload
+/// must carry the NORMALIZED namespace so peers land it in the same partition.
+#[test]
+fn record_batch_normalizes_blank_namespace_like_record() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+
+    let mk = |text: &str, ns: &str, emb: f32| RecordInput {
+        text: text.into(),
+        memory_type: "semantic".into(),
+        importance: 0.7,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: serde_json::json!({}),
+        embedding: vec_seed(emb, 8),
+        namespace: ns.into(),
+        certainty: 0.8,
+        domain: "work".into(),
+        source: "user".into(),
+        emotional_state: None,
+    };
+
+    let rids = db
+        .record_batch(&[
+            mk("blank ns batch item one", "   ", 1.0),
+            mk("blank ns batch item two", "", 2.0),
+        ])
+        .unwrap();
+    assert_eq!(rids.len(), 2);
+
+    let in_default: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'default'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        in_default, 2,
+        "blank-namespace batch rows must land under 'default', like record()"
+    );
+
+    let in_blank: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE TRIM(namespace) = ''",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        in_blank, 0,
+        "no row may persist under a raw blank namespace partition (#98)"
+    );
+
+    // The replicated op payload must carry the normalized namespace too —
+    // otherwise every PEER materializes the row back into the unreachable
+    // blank partition and the fix only holds locally.
+    for rid in &rids {
+        let payload: String = db
+            .conn()
+            .query_row(
+                "SELECT payload FROM oplog WHERE target_rid = ?1 AND op_type = 'record'",
+                rusqlite::params![rid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(
+            v["namespace"], "default",
+            "op payload must replicate the NORMALIZED namespace"
+        );
+    }
+
+    // Stats already normalized internally (that was the divergence); pin the
+    // now-consistent whole: one 'default' stats row observing both items.
+    let count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT count FROM namespace_importance_stats WHERE namespace = 'default'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 2, "both observations under the normalized namespace");
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -7424,8 +7424,11 @@ fn batch_append_failure_leaves_importance_stats_untouched() {
     };
     assert_eq!(stats(&db), None, "precondition: no stats for batch_ns");
 
-    // A batch into batch_ns: SQL savepoint commits, then the vector append hits
-    // the saturated delta and fails, triggering the compensating DELETE.
+    // A batch into batch_ns: since 4a.6d-2a the capacity reservation fails
+    // BEFORE the savepoint even opens (pre-restructure: the savepoint
+    // committed, the post-RELEASE append failed, and a compensating DELETE
+    // reversed the rows). Either way the caller sees Backpressure and the
+    // stats assertions below are what this test pins.
     let err = db
         .record_batch(&[RecordInput {
             text: "batch after saturation".into(),
@@ -7447,7 +7450,7 @@ fn batch_append_failure_leaves_importance_stats_untouched() {
         "expected Backpressure from the append, got {err:?}"
     );
 
-    // Rows compensated AND stats untouched (the winner-only guarantee).
+    // No rows AND stats untouched (the winner-only guarantee).
     let rows: i64 = db
         .conn()
         .query_row(
@@ -7456,7 +7459,7 @@ fn batch_append_failure_leaves_importance_stats_untouched() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(rows, 0, "compensating DELETE removed the batch rows");
+    assert_eq!(rows, 0, "a rejected batch must write no rows");
     assert_eq!(
         stats(&db),
         None,
@@ -8376,7 +8379,10 @@ fn batch_append_failure_writes_nothing_at_all() {
         .conn()
         .query_row("SELECT COUNT(*) FROM oplog", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(ops_after, ops_before, "no oplog entries for a rejected batch");
+    assert_eq!(
+        ops_after, ops_before,
+        "no oplog entries for a rejected batch"
+    );
 
     // And the connection is back in autocommit — no savepoint left open (#91's
     // class: an error arm that unwinds the savepoint must RELEASE it too, or


### PR DESCRIPTION
Closes #91, closes #92, closes #98. sol-ACCEPTed round 1, no blocking findings.

## Three silent bugs, one structural cause

`record_batch` committed its savepoint FIRST and appended vectors AFTER — so failure had to be compensated instead of prevented, and the compensation was partial.

1. **#92** — on append failure (delta saturation), the compensating DELETE reversed `memories` rows and session counts but never reversed `entities` upserts (mention_count inflation), `memory_entities` links, or the in-memory graph_index. Orphaned linkage for memories that don't exist.
2. **#91** — the INSERT-failure arm ran `ROLLBACK TO` and returned **without RELEASE**; the fallible calls before the INSERT (serde, encrypt wrappers) `?`-returned without even the rollback. Both leave the savepoint open on the single shared conn, so every later write silently nests inside it.
3. **#98** — batch never normalized blank namespaces while the calibration helpers normalize internally: the row landed under raw `"  "` (a partition no reader queries) while its importance observation advanced `default`'s stats.

## The fix: prevent, don't compensate

- **`BatchReservationGuard`** (reservation.rs): reserve delta capacity for ALL N items BEFORE the savepoint opens — capacity failure now surfaces before a single durable byte. Publish-only by design: batch ops commit `applied=1`, so counting would be the v0.7.1 counter-leak class (documented on the type). The compensating DELETE + session reversal are **deleted**, not patched.
- **`SavepointGuard`** (NEW engine/savepoint.rs): RAII — Drop runs `ROLLBACK TO; RELEASE` on every early return and panic unwind; `release(self)` consumes the guard so released and rolled-back are mutually exclusive. Unit-tested deterministically via `is_autocommit()`.
- **Per-input namespace normalization at entry**, used by the row, session lookup, **the replicated op payload** (peers must land the same partition), audit, scoring cache, visible_seq bump, and stats.
- **Calibration advances moved INSIDE the savepoint** (after all reads — same-pre-batch-snapshot semantics kept). The old post-commit best-effort deferral existed ONLY because the append could fail after RELEASE; that failure mode no longer exists, so an Err in the advance is now pre-commit and `?` is correct where post-commit it was the retry-duplicates trap (4a.6b r3).

## Evidence

- Both regression tests **proven to fail on unfixed code** (14ca6f4): #92's on the orphaned entities row, #98's with 0 rows under 'default'. The #92 test carries an extraction-control precondition so its absence assertions can never go vacuous.
- **5/5 mutants killed** by named tests (fail-loud harness, 'test result: FAILED' required in output): reserve-noop, drop-leaks-reservations, rollback-without-release (the literal #91 bug), no-normalization, no-stats-advance.
- 1744 Rust lib tests · workspace `--features testing` (kill proofs) · 234 Python tests against a wheel rebuilt from this branch.

## Sweep (assume under-generalization)

- The 7 other manual SAVEPOINT sites (graph_ops, importance, learning, links, record_with_rid, repair, reembed ×2) all use catch-closures with CORRECT Err arms — none has the #91 bug, but all share the panic-unwind hole. **#100** filed to migrate them to SavepointGuard.
- `record_with_rid` is the LAST commit-then-append + partial-compensation site (#92 class) → 4a.6d-3.
- `log_record_ops_batch(...)?` Err-after-commit is pre-existing **#94**, deliberately out of scope (comment updated to say so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)