### PR TITLE
feat(v0.10-4a.6d-2b): record_batch per-item idempotency keys (claim-first; subsumes #94)

### DIFF
--- a/crates/yantrikdb-core/benches/engine_bench.rs
+++ b/crates/yantrikdb-core/benches/engine_bench.rs
@@ -272,6 +272,7 @@ fn bench_record_batch(c: &mut Criterion) {
             let (db, _workers) = open_db_with_workers(dim);
             let inputs: Vec<RecordInput> = (0..500)
                 .map(|i| RecordInput {
+                    idempotency_key: None,
                     text: format!("batch memory {i}"),
                     memory_type: "episodic".to_string(),
                     importance: 0.5,
@@ -666,6 +667,7 @@ fn bench_record_batch_scaled(c: &mut Criterion) {
                     let (db, _workers) = open_db_with_workers(dim);
                     let inputs: Vec<RecordInput> = (0..bs)
                         .map(|i| RecordInput {
+                            idempotency_key: None,
                             text: format!("batch memory {i}"),
                             memory_type: "episodic".to_string(),
                             importance: 0.5,

--- a/crates/yantrikdb-core/src/base/bench_utils.rs
+++ b/crates/yantrikdb-core/src/base/bench_utils.rs
@@ -64,6 +64,7 @@ pub fn seed_db_scaled(db: &YantrikDB, n: usize, dim: usize, with_graph: bool) {
                 let topic = i % 20;
                 let entity_idx = i % entity_names.len();
                 RecordInput {
+                    idempotency_key: None,
                     text: format!(
                         "Memory {} about topic {} involving {} in context {}",
                         i,

--- a/crates/yantrikdb-core/src/base/payload_digest.rs
+++ b/crates/yantrikdb-core/src/base/payload_digest.rs
@@ -541,6 +541,7 @@ mod tests {
     #[test]
     fn caller_supplied_embedding_is_digested_but_generated_one_is_not() {
         let mk = |emb: Vec<f32>| RecordInput {
+            idempotency_key: None,
             text: "t".to_string(),
             memory_type: "semantic".to_string(),
             importance: 0.5,

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -433,6 +433,15 @@ pub struct RecordInput {
     pub domain: String,
     pub source: String,
     pub emotional_state: Option<String>,
+    /// v0.10 4a.6d-2b: per-item idempotency key, same contract and scope as
+    /// `record_with_idempotency` — (origin_actor, normalized namespace, key),
+    /// digest variant `Record` (the caller-supplied embedding is part of the
+    /// payload). `None` = unkeyed item. A key that already committed with the
+    /// SAME payload makes this item an idempotent hit (its position in the
+    /// returned rids carries the ORIGINAL rid; the item writes nothing);
+    /// the same key with a DIFFERENT payload fails the WHOLE batch with a
+    /// typed `IdempotencyConflict` — batches stay all-or-nothing on failure.
+    pub idempotency_key: Option<String>,
 }
 
 // ── Conflict types (V2) ──

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1863,6 +1863,10 @@ impl YantrikDB {
         // must be decided before re-embedding; see the method doc). Then the
         // pre-admission probe: a duplicate retry resolves HERE, before the
         // slow embed, before the router, before any admission machinery.
+        // "Admission" is precise (sol 4a.6d-2b r1 finding 2): the validation
+        // gates above still precede the probe — deterministic payload-shape
+        // checks an identical retry passes identically, unlike the
+        // saturation-dependent admission this probe exists to bypass.
         let idem: Option<(&str, [u8; 32])> = match idempotency_key {
             None => None,
             Some(key) => {

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -221,6 +221,10 @@ impl YantrikDB {
         // seq/HLC allocation. Backpressure storms are exactly when clients
         // retry; without this, a keyed dup against a saturated engine could
         // only ever see Backpressure and the retry loop would never converge.
+        // "Admission" is the precise word (sol 4a.6d-2b r1 finding 2): the
+        // validation gates above still run first, because they are
+        // deterministic payload-shape checks an identical retry passes
+        // identically — not saturation-dependent rejection.
         // A probe MISS is advisory (the ON CONFLICT INSERT in the write tx
         // stays authoritative); a probe HIT is final — committed claims are
         // immutable in 4a.
@@ -907,14 +911,20 @@ impl YantrikDB {
         }
 
         // 4a.6d-2b unlocked pre-admission probe (the 4a.6c invariant on the
-        // batch surface): NOTHING may reject a duplicate that would write
-        // nothing. Committed hits leave the write set here — BEFORE the
-        // write-router, the delta reservation, and the seq mint — so a
-        // fully-duplicate batch resolves to its rids even during a reembed
-        // cutover or under full delta saturation. That is exactly when clients
-        // retry. A MISS is advisory (the locked probe under the conn guard
-        // below is what closes the race window); a HIT is final — committed
-        // claims are immutable in 4a.
+        // batch surface): no RESOURCE admission check may reject a duplicate
+        // that would write nothing. Committed hits leave the write set here —
+        // BEFORE the write-router, the delta reservation, and the seq mint —
+        // so a fully-duplicate batch resolves to its rids even during a
+        // reembed cutover or under full delta saturation. That is exactly
+        // when clients retry. The guarantee is deliberately NARROWER than
+        // "nothing rejects a duplicate": prevalidation (embedding/scalar/
+        // provenance gates, key format, in-batch divergence) runs above and
+        // still errors first — those are deterministic payload-shape checks
+        // an identical retry passes identically, not saturation-dependent
+        // admission that would starve a retry loop (sol 4a.6d-2b r1
+        // finding 2). A MISS is advisory (the locked probe under the conn
+        // guard below is what closes the race window); a HIT is final —
+        // committed claims are immutable in 4a.
         if digests.iter().any(Option::is_some) {
             let conn = self.conn();
             for i in 0..n {

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -817,6 +817,132 @@ impl YantrikDB {
             .map(|i| sanitize::sanitize_tool_call_artifacts(&i.text))
             .collect();
 
+        // ── 4a.6d-2b: per-item idempotency, prevalidated with everything else ──
+        //
+        // Digests are the canonical RAW payload exactly as
+        // `record_with_idempotency` computes them — SANITIZED text, NORMALIZED
+        // namespace, RAW importance, the caller-supplied embedding included
+        // (PayloadVariant::Record) — so the same key with a byte-identical
+        // payload is the SAME write whether it arrives via record() or a batch
+        // item, and a divergent payload conflicts identically. The two
+        // overrides below are load-bearing: `from_record_input` views the raw
+        // struct, and digesting raw text/namespace would make an honest
+        // cross-surface retry a false conflict.
+        //
+        // In-batch duplicates resolve here, before any probe or side effect:
+        // the same (namespace, key) twice with the same digest makes the later
+        // item an ALIAS of the first (one write, both positions return its
+        // rid); with a different digest the whole batch fails typed — batches
+        // are all-or-nothing on failure, and silently dropping one divergent
+        // item would leave a retry unable to tell which content won.
+        let n = inputs.len();
+        let mut digests: Vec<Option<[u8; 32]>> = vec![None; n];
+        let mut alias_of: Vec<Option<usize>> = vec![None; n];
+        // resolved[i] = the committed rid a keyed item hit — set by the probes.
+        let mut resolved: Vec<Option<String>> = vec![None; n];
+        {
+            let mut first_by_key: std::collections::HashMap<(&str, &str), usize> =
+                std::collections::HashMap::new();
+            for (i, input) in inputs.iter().enumerate() {
+                let Some(key) = input.idempotency_key.as_deref() else {
+                    continue;
+                };
+                if key.trim().is_empty() || key.len() > 512 {
+                    return Err(crate::error::YantrikDbError::InvalidIdempotencyKey {
+                        reason: if key.len() > 512 {
+                            format!("inputs[{i}]: key is {} bytes; max 512", key.len())
+                        } else {
+                            format!("inputs[{i}]: key is empty or whitespace-only")
+                        },
+                    });
+                }
+                let mut view = crate::payload_digest::PayloadView::from_record_input(
+                    input,
+                    crate::payload_digest::PayloadVariant::Record,
+                );
+                view.namespace = namespaces[i];
+                view.text = sanitized_texts[i].as_ref();
+                let digest = crate::payload_digest::payload_digest(&view);
+                match first_by_key.entry((namespaces[i], key)) {
+                    std::collections::hash_map::Entry::Occupied(e) => {
+                        let j = *e.get();
+                        if digests[j] != Some(digest) {
+                            return Err(crate::error::YantrikDbError::IdempotencyConflict {
+                                namespace: namespaces[i].to_string(),
+                                existing_rid: String::new(),
+                                reason: format!(
+                                    "inputs[{i}] reuses inputs[{j}]'s idempotency key \
+                                     with a DIFFERENT payload — change the key or make \
+                                     the payloads identical"
+                                ),
+                            });
+                        }
+                        alias_of[i] = Some(j);
+                    }
+                    std::collections::hash_map::Entry::Vacant(v) => {
+                        v.insert(i);
+                    }
+                }
+                digests[i] = Some(digest);
+            }
+        }
+
+        // Positional result assembly, shared by the two early-resolution exits
+        // and the final return. alias roots are always original (non-alias)
+        // items, so one hop suffices.
+        fn assemble_rids(
+            resolved: &[Option<String>],
+            alias_of: &[Option<usize>],
+            rid_slots: &[Option<String>],
+        ) -> Vec<String> {
+            (0..resolved.len())
+                .map(|i| {
+                    let root = alias_of[i].unwrap_or(i);
+                    resolved[root]
+                        .clone()
+                        .or_else(|| rid_slots[root].clone())
+                        .expect("every position resolves to a hit or a written rid")
+                })
+                .collect()
+        }
+
+        // 4a.6d-2b unlocked pre-admission probe (the 4a.6c invariant on the
+        // batch surface): NOTHING may reject a duplicate that would write
+        // nothing. Committed hits leave the write set here — BEFORE the
+        // write-router, the delta reservation, and the seq mint — so a
+        // fully-duplicate batch resolves to its rids even during a reembed
+        // cutover or under full delta saturation. That is exactly when clients
+        // retry. A MISS is advisory (the locked probe under the conn guard
+        // below is what closes the race window); a HIT is final — committed
+        // claims are immutable in 4a.
+        if digests.iter().any(Option::is_some) {
+            let conn = self.conn();
+            for i in 0..n {
+                if alias_of[i].is_some() {
+                    continue;
+                }
+                if let (Some(digest), Some(key)) =
+                    (digests[i].as_ref(), inputs[i].idempotency_key.as_deref())
+                {
+                    if let Some(existing_rid) = super::idempotency::probe_committed_claim(
+                        &conn,
+                        &self.actor_id,
+                        namespaces[i],
+                        key,
+                        digest,
+                    )? {
+                        resolved[i] = Some(existing_rid);
+                    }
+                }
+            }
+        }
+        let all_resolved = (0..n).all(|i| resolved[alias_of[i].unwrap_or(i)].is_some());
+        if all_resolved {
+            // Every item is an idempotent hit: the batch writes nothing and
+            // returns the original rids, saturated engine or not.
+            return Ok(assemble_rids(&resolved, &alias_of, &vec![None; n]));
+        }
+
         // Task 31 (Ingest Integrity): each input's importance is calibrated
         // against its namespace distribution INSIDE the savepoint below,
         // positionally aligned with `inputs` via push order. Every item
@@ -830,7 +956,10 @@ impl YantrikDB {
         // the deferred best-effort advance (and its silently-skipped-
         // observation gap) existed only to survive the post-RELEASE append
         // failure that no longer exists.
-        let mut calibrated_importances: Vec<f64> = Vec::with_capacity(inputs.len());
+        //
+        // 4a.6d-2b: indexed by ORIGINAL input position, `Some` only for items
+        // that write — hits and aliases never calibrate (they store nothing).
+        let mut calibrated_importances: Vec<Option<f64>> = vec![None; n];
 
         // **Issue #41 layer 3.** Enter the write-router BEFORE snapshotting
         // SearchState, exactly as `record()` does (record.rs:105/138).
@@ -872,10 +1001,20 @@ impl YantrikDB {
         //   (a) heuristic extraction from text (capitalized proper-nouns)
         //   (b) match against already-known entities in graph_index
         let known_entities = self.graph_index.read().all_entity_names();
-        let per_memory_linkage: Vec<(Vec<String>, std::collections::HashSet<String>)> =
+        // 4a.6d-2b: `None` for items leaving the write set as idempotent hits
+        // or in-batch aliases — a hit writes nothing, so it must not
+        // re-extract entities (mention_count would inflate on every retry,
+        // the #80 class), and an alias is the SAME text as its root (one
+        // write, one extraction). Locked-probe hits below leave an unused
+        // `Some` here; unused is harmless, used-would-be-the-bug.
+        let per_memory_linkage: Vec<Option<(Vec<String>, std::collections::HashSet<String>)>> =
             sanitized_texts
                 .iter()
-                .map(|text| {
+                .enumerate()
+                .map(|(i, text)| {
+                    if resolved[i].is_some() || alias_of[i].is_some() {
+                        return None;
+                    }
                     let text = text.as_ref();
                     let text_tokens = crate::graph::tokenize(text);
                     let heuristic = crate::graph::extract_heuristic_entities(text);
@@ -886,17 +1025,19 @@ impl YantrikDB {
                             candidates.insert(known.clone());
                         }
                     }
-                    (heuristic, candidates)
+                    Some((heuristic, candidates))
                 })
                 .collect();
 
-        let mut rids: Vec<String> = Vec::with_capacity(inputs.len());
-        let mut seqs: Vec<u64> = Vec::with_capacity(inputs.len());
-        // One canonical "record" op per item, emitted after the savepoint
-        // releases. See `log_record_ops_batch`: the old single "record_batch" op
-        // was silently dropped by every peer, so batch writes never replicated.
-        let mut record_op_entries: Vec<(String, serde_json::Value, Vec<u8>)> =
-            Vec::with_capacity(inputs.len());
+        // Per-ORIGINAL-index slots: `Some` only for items that actually write.
+        // Hits and aliases stay `None` and resolve positionally at return.
+        let mut rid_slots: Vec<Option<String>> = vec![None; n];
+        let mut seq_slots: Vec<Option<u64>> = vec![None; n];
+        // 4a.6d-2b (#94): op ids preminted BEFORE the transaction, exactly as
+        // record() premints `record_op_id` — a keyed item's claim binds to its
+        // op id as recovery evidence, so the id must exist before the claim
+        // INSERT, and the op itself now commits INSIDE the savepoint.
+        let mut op_ids: Vec<Option<String>> = vec![None; n];
 
         // 4a.6d-2a (#92): the batch's reserve → commit → publish guard.
         // Declared OUTSIDE the conn scope: it publishes the vectors after the
@@ -909,23 +1050,63 @@ impl YantrikDB {
         {
             let conn = self.conn();
 
-            // RESERVE delta capacity for ALL N items BEFORE the savepoint
-            // opens — the batch analogue of record()'s protocol (4a.6a). This
-            // is where Backpressure and dim mismatches surface: before a
-            // single durable byte. The old shape appended AFTER the RELEASE
-            // and compensated failure with a DELETE that reversed rows and
-            // session counts but could never reverse `entities` upserts,
+            // 4a.6d-2b LOCKED probe (4a.6c sol r2, batch surface): the
+            // unlocked probe above can race — another same-key writer may
+            // commit between it and this lock. Re-probing under the SAME conn
+            // guard that stays held through the transaction closes the window
+            // completely: nothing can commit a claim between this read and our
+            // tx. Items hitting here leave the write set before any capacity
+            // is reserved. (The in-tx ON CONFLICT below stays the
+            // authoritative serialization point; under this locking it is
+            // belt-and-suspenders, reachable only by raw-`conn()` writers
+            // outside the engine.)
+            for i in 0..n {
+                if resolved[i].is_some() || alias_of[i].is_some() {
+                    continue;
+                }
+                if let (Some(digest), Some(key)) =
+                    (digests[i].as_ref(), inputs[i].idempotency_key.as_deref())
+                {
+                    if let Some(existing_rid) = super::idempotency::probe_committed_claim(
+                        &conn,
+                        &self.actor_id,
+                        namespaces[i],
+                        key,
+                        digest,
+                    )? {
+                        resolved[i] = Some(existing_rid);
+                    }
+                }
+            }
+            if (0..n).all(|i| resolved[alias_of[i].unwrap_or(i)].is_some()) {
+                // The race resolved every remaining item: nothing to write.
+                drop(conn);
+                return Ok(assemble_rids(&resolved, &alias_of, &rid_slots));
+            }
+
+            // RESERVE delta capacity for every WRITING item BEFORE the
+            // savepoint opens — the batch analogue of record()'s protocol
+            // (4a.6a). This is where Backpressure and dim mismatches surface:
+            // before a single durable byte. The old shape appended AFTER the
+            // RELEASE and compensated failure with a DELETE that reversed rows
+            // and session counts but could never reverse `entities` upserts,
             // `memory_entities` links, or the in-memory graph_index (#92) —
-            // now there is nothing to compensate. Seqs are minted under the
-            // conn lock for the same reason record() mints there: search
-            // resolves a rid to its HIGHEST seq, so minting must serialize
-            // with the commits that act on it.
-            for input in inputs.iter() {
+            // now there is nothing to compensate. Idempotent hits and in-batch
+            // aliases reserve NOTHING: a duplicate writes nothing, so it must
+            // never consume capacity a fresh write is then denied. Seqs are
+            // minted under the conn lock for the same reason record() mints
+            // there: search resolves a rid to its HIGHEST seq, so minting must
+            // serialize with the commits that act on it.
+            for (i, input) in inputs.iter().enumerate() {
+                if resolved[i].is_some() || alias_of[i].is_some() {
+                    continue;
+                }
                 let rid = crate::id::new_id();
                 let seq = self.assign_seq(None);
                 batch_reservation.reserve(rid.clone(), input.embedding.clone(), seq)?;
-                rids.push(rid);
-                seqs.push(seq);
+                rid_slots[i] = Some(rid);
+                seq_slots[i] = Some(seq);
+                op_ids[i] = Some(crate::id::new_id());
             }
 
             // #91: RAII, not manual unwinding. EVERY fallible statement below
@@ -937,8 +1118,61 @@ impl YantrikDB {
             // every later write silently nested inside it.
             let savepoint = super::savepoint::SavepointGuard::new(&conn, "batch_record")?;
 
+            // 4a.6c rule, batch surface: the claims are the FIRST statements of
+            // the transaction — a dup must resolve to a hit/conflict at the
+            // claim, never surface later as a bare constraint error from the
+            // v37 partial unique index on memories. All claims precede all row
+            // INSERTs; each binds to its item's preminted op id.
+            for (i, input) in inputs.iter().enumerate() {
+                if resolved[i].is_some() || alias_of[i].is_some() {
+                    continue;
+                }
+                let (Some(digest), Some(key)) =
+                    (digests[i].as_ref(), input.idempotency_key.as_deref())
+                else {
+                    continue;
+                };
+                use super::idempotency::{claim_in_tx, ClaimAttempt, ClaimRow};
+                match claim_in_tx(
+                    &conn,
+                    &ClaimRow {
+                        origin_actor: &self.actor_id,
+                        namespace: namespaces[i],
+                        idempotency_key: key,
+                        rid: rid_slots[i].as_deref().expect("write items have rids"),
+                        payload_digest: digest,
+                        op_id: op_ids[i].as_deref().expect("write items have op ids"),
+                        route: "batch",
+                        generation: state.generation as i64,
+                    },
+                )? {
+                    ClaimAttempt::Won => {}
+                    // Unreachable in 4a: the LOCKED probe above runs under the
+                    // SAME conn guard held continuously through this
+                    // transaction, and the conn mutex is the engine's single
+                    // write lock — no other claim can commit in between. Loud,
+                    // not silent, if that invariant ever breaks; the savepoint
+                    // guard rolls the whole batch back.
+                    ClaimAttempt::Hit { existing_rid } => {
+                        return Err(crate::error::YantrikDbError::IdempotencyConflict {
+                            namespace: namespaces[i].to_string(),
+                            existing_rid,
+                            reason: format!(
+                                "inputs[{i}]: claim committed between the locked probe \
+                                 and the batch transaction — impossible under the \
+                                 engine's single-writer conn unless the claims table \
+                                 is written outside the engine"
+                            ),
+                        });
+                    }
+                }
+            }
+
             for (idx, input) in inputs.iter().enumerate() {
-                let rid = &rids[idx];
+                if resolved[idx].is_some() || alias_of[idx].is_some() {
+                    continue;
+                }
+                let rid = rid_slots[idx].as_ref().expect("write items have rids");
                 let ts = now();
                 let emb_blob = serialize_f32(&input.embedding);
                 let meta_str = serde_json::to_string(&input.metadata)?;
@@ -954,7 +1188,7 @@ impl YantrikDB {
                     namespaces[idx],
                     input.importance,
                 )?;
-                calibrated_importances.push(calibrated);
+                calibrated_importances[idx] = Some(calibrated);
 
                 // Encrypt fields if encryption is enabled. Task 29: store the
                 // sanitized text (positionally aligned with `inputs`).
@@ -969,45 +1203,66 @@ impl YantrikDB {
                     "INSERT INTO memories \
                      (rid, type, text, embedding, created_at, updated_at, importance, \
                       half_life, last_access, valence, metadata, namespace, \
-                      certainty, domain, source, emotional_state, embedding_generation) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+                      certainty, domain, source, emotional_state, embedding_generation, \
+                      idempotency_key, origin_actor) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
+                             ?18, ?19)",
                     params![rid, input.memory_type, stored_text, stored_emb, ts, ts,
-                            calibrated_importances[idx], input.half_life, ts, input.valence, stored_meta,
+                            calibrated, input.half_life, ts, input.valence, stored_meta,
                             namespaces[idx], input.certainty, input.domain, input.source,
-                            input.emotional_state, embedding_generation],
+                            input.emotional_state, embedding_generation,
+                            // v37 idempotency columns, exactly as record()
+                            // stamps them: set only for keyed items (the
+                            // partial unique index ignores NULLs, so unkeyed
+                            // behavior is unchanged).
+                            input.idempotency_key.as_deref(),
+                            input.idempotency_key.as_ref().map(|_| self.actor_id.as_str())],
                 )?;
 
-                // Byte-for-byte the payload `record()` emits (record.rs:325-340)
+                // The canonical "record" op, byte-for-byte what record() emits,
                 // so peers materialize batch items through the existing, tested
-                // "record" arm. Plaintext text/metadata, matching record() — the
-                // encrypted forms above are the at-rest representation, not the
-                // replication one. NORMALIZED namespace (#98): peers must land
-                // the row in the same partition this node did, not the raw
-                // blank one.
-                record_op_entries.push((
-                    rid.clone(),
-                    serde_json::json!({
-                        "rid": rid,
-                        "type": input.memory_type,
-                        "text": sanitized_texts[idx].as_ref(),
-                        "importance": calibrated_importances[idx],
-                        "valence": input.valence,
-                        "half_life": input.half_life,
-                        "metadata": input.metadata,
-                        "created_at": ts,
-                        "updated_at": ts,
-                        "namespace": namespaces[idx],
-                        "certainty": input.certainty,
-                        "domain": input.domain,
-                        "source": input.source,
-                        "emotional_state": input.emotional_state,
-                    }),
-                    embedding_hash(&input.embedding),
-                ));
+                // "record" arm. Plaintext text/metadata (the encrypted forms
+                // above are the at-rest representation, not the replication
+                // one); NORMALIZED namespace (#98) so peers land the row in the
+                // same partition this node did. 4a.6d-2b (#94): committed HERE,
+                // inside the savepoint, under the item's preminted op id — the
+                // op the claim binds to either commits with the row or neither
+                // exists. The old shape logged all ops AFTER the release, so a
+                // crash in between left durable rows that never replicated,
+                // and an Err there surfaced as a failure for a batch that had
+                // already committed (a retry then duplicated every row).
+                let record_payload = serde_json::json!({
+                    "rid": rid,
+                    "type": input.memory_type,
+                    "text": sanitized_texts[idx].as_ref(),
+                    "importance": calibrated,
+                    "valence": input.valence,
+                    "half_life": input.half_life,
+                    "metadata": input.metadata,
+                    "created_at": ts,
+                    "updated_at": ts,
+                    "namespace": namespaces[idx],
+                    "certainty": input.certainty,
+                    "domain": input.domain,
+                    "source": input.source,
+                    "emotional_state": input.emotional_state,
+                });
+                let emb_hash = embedding_hash(&input.embedding);
+                self.log_op_in_tx(
+                    &conn,
+                    "record",
+                    Some(rid),
+                    &record_payload,
+                    Some(&emb_hash),
+                    None,
+                    embedding_generation,
+                    Some(op_ids[idx].as_deref().expect("write items have op ids")),
+                )?;
             }
 
             // Auto-link batch to active sessions
-            for (idx, rid) in rids.iter().enumerate() {
+            for (idx, rid_slot) in rid_slots.iter().enumerate() {
+                let Some(rid) = rid_slot else { continue };
                 if let Some(session_id) = sessions.get(namespaces[idx]) {
                     conn.execute(
                         "UPDATE memories SET session_id = ?1 WHERE rid = ?2",
@@ -1022,8 +1277,13 @@ impl YantrikDB {
 
             // Persist entity linkage (SQL side). graph_index in-memory update
             // happens after conn is dropped to avoid holding two write locks.
+            // Gated on rid_slots, not the linkage Option: a locked-probe hit
+            // has a stale Some(linkage) that must not be persisted.
             let batch_ts = now();
-            for (rid, (heuristic, candidates)) in rids.iter().zip(per_memory_linkage.iter()) {
+            for (rid, linkage) in rid_slots.iter().zip(per_memory_linkage.iter()) {
+                let (Some(rid), Some((heuristic, candidates))) = (rid, linkage) else {
+                    continue;
+                };
                 for entity in heuristic {
                     let entity_type = crate::graph::classify_entity_type(entity);
                     conn.execute(
@@ -1057,7 +1317,13 @@ impl YantrikDB {
             // An Err here is PRE-commit — the whole batch rolls back and a
             // retry writes once — so `?` is correct where post-commit it was
             // the retry-duplicates trap (sol 4a.6b r3 finding 1).
+            // Write items only: an idempotent hit stores nothing, so it must
+            // not advance the distribution — repetition is not corroboration
+            // (T07), and record()'s hit path skips this identically.
             for (idx, input) in inputs.iter().enumerate() {
+                if rid_slots[idx].is_none() {
+                    continue;
+                }
                 self.advance_importance_stats_in_tx(&conn, namespaces[idx], input.importance)?;
             }
 
@@ -1070,10 +1336,14 @@ impl YantrikDB {
         // NOTE: warn-mode flag ticks are DEFERRED to after the publish below
         // (4a.6b finding 1): the nudge metric counts writes that landed and
         // became visible, in the same order record() counts them.
-        // conn dropped; now update graph_index in-memory.
+        // conn dropped; now update graph_index in-memory. Write items only —
+        // gated on rid_slots (a hit's stale linkage must not re-link).
         {
             let mut gi = self.graph_index.write();
-            for (rid, (_, candidates)) in rids.iter().zip(per_memory_linkage.iter()) {
+            for (rid, linkage) in rid_slots.iter().zip(per_memory_linkage.iter()) {
+                let (Some(rid), Some((_, candidates))) = (rid, linkage) else {
+                    continue;
+                };
                 for entity in candidates {
                     let entity_type = crate::graph::classify_entity_type(entity);
                     gi.add_entity(entity, entity_type);
@@ -1082,12 +1352,15 @@ impl YantrikDB {
             }
         }
 
-        // RFC 006 Phase 0: emit one audit event per memory in the batch.
-        for (idx, (rid, (input, (heuristic_entities, candidates)))) in rids
-            .iter()
-            .zip(inputs.iter().zip(per_memory_linkage.iter()))
-            .enumerate()
-        {
+        // RFC 006 Phase 0: emit one audit event per memory WRITTEN in the
+        // batch. Hits and aliases extracted nothing and stored nothing, so an
+        // audit event for them would attest an extraction that never ran.
+        for (idx, input) in inputs.iter().enumerate() {
+            let (Some(rid), Some((heuristic_entities, candidates))) =
+                (rid_slots[idx].as_ref(), per_memory_linkage[idx].as_ref())
+            else {
+                continue;
+            };
             let heuristic_vec: Vec<String> = heuristic_entities.iter().cloned().collect();
             let features =
                 crate::graph::analyze_text_features(sanitized_texts[idx].as_ref(), &heuristic_vec);
@@ -1123,11 +1396,11 @@ impl YantrikDB {
         let all_published = batch_reservation.complete();
         debug_assert!(
             all_published,
-            "batch reservation vanished before publish (rids {rids:?})"
+            "batch reservation vanished before publish (rids {rid_slots:?})"
         );
         if !all_published {
             tracing::error!(
-                batch_size = rids.len(),
+                batch_size = rid_slots.iter().flatten().count(),
                 "reserved batch vector entries missing at publish — rows are \
                  durable but unsearchable until the index is rebuilt from SQL"
             );
@@ -1136,34 +1409,36 @@ impl YantrikDB {
 
         // LAST: a read-your-write waiter must not wake against a half-applied
         // batch (CONCURRENCY.md: bump visible_seq AFTER the delta publish).
-        for (idx, _) in inputs.iter().enumerate() {
-            self.bump_visible_seq(namespaces[idx], seqs[idx]);
+        for idx in 0..n {
+            if let Some(seq) = seq_slots[idx] {
+                self.bump_visible_seq(namespaces[idx], seq);
+            }
         }
         // 4a.6b: the warn-mode flags are counted only now — the batch is
         // durable AND visible, so the nudge metric counts writes that landed.
-        // (The matching calibration advances moved INSIDE the savepoint in
-        // 4a.6d-2a — see the comment there; the winner is decided at RELEASE
-        // now that nothing can fail after it.)
-        //
-        // NB (sol r4 / #94): `log_record_ops_batch(...)?` below still
-        // `?`-returns after the commit — a PRE-EXISTING Err-after-commit
-        // (#79-era) that is NOT best-effortable (the ops are what replicate
-        // the batch). Its correct fix is to move that append inside the
-        // savepoint above (needs a held-conn variant to avoid the #83
-        // re-lock); tracked in #94, out of 4a.6d-2a's scope.
-        for verdict in gate_verdicts {
+        // Write items only: a hit landed nothing, so its verdict must not
+        // tick (record()'s hit path returns before its tick identically).
+        for (idx, verdict) in gate_verdicts.into_iter().enumerate() {
+            if rid_slots[idx].is_none() {
+                continue;
+            }
             self.note_flagged_write_committed(verdict);
         }
-        // vec_index dropped, now scoring_cache
+        // vec_index dropped, now scoring_cache — write items only (a hit's
+        // row already has its cache entry from its original write).
         {
             let mut cache = self.scoring_cache.write();
-            for (idx, (rid, input)) in rids.iter().zip(inputs.iter()).enumerate() {
+            for (idx, input) in inputs.iter().enumerate() {
+                let Some(rid) = rid_slots[idx].as_ref() else {
+                    continue;
+                };
                 let ts = now();
                 cache.insert(
                     rid.clone(),
                     ScoringRow {
                         created_at: ts,
-                        importance: calibrated_importances[idx],
+                        importance: calibrated_importances[idx]
+                            .expect("write items calibrated in the savepoint"),
                         half_life: input.half_life,
                         last_access: ts,
                         access_count: 0,
@@ -1180,17 +1455,12 @@ impl YantrikDB {
             }
         }
 
-        // One canonical "record" op per item, under a single conn lock.
-        //
-        // This REPLACES a single `log_op("record_batch", {count, rids})`. That op
-        // was unreplicable twice over: replication has no "record_batch" arm, so
-        // peers hit the `_ =>` forward-compat catch-all and silently dropped it;
-        // and the payload carried no text/embedding/scalars, so it could not have
-        // rebuilt the memories even with an arm. Batch-written memories simply
-        // never reached peers. Nothing consumes the old op type locally.
-        self.log_record_ops_batch(&record_op_entries)?;
-
-        Ok(rids)
+        // The per-item "record" ops committed INSIDE the savepoint above
+        // (4a.6d-2b, closing #94 for this path) — there is no post-commit
+        // oplog write left to fail. Positional assembly: written items return
+        // their fresh rids, hits their original rids, in-batch aliases their
+        // root's rid.
+        Ok(assemble_rids(&resolved, &alias_of, &rid_slots))
     }
 
     /// **Issue #9 — deterministic mutation primitive for cluster replication.**

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1256,6 +1256,16 @@ impl YantrikDB {
                     "domain": input.domain,
                     "source": input.source,
                     "emotional_state": input.emotional_state,
+                    // 4a.6c/4a.6d-2b (sol r2 finding 1): carried so
+                    // replication's materialize_record writes the same v37
+                    // columns the origin row has — a follower's keyed row must
+                    // mirror its leader's, or the memories partial unique
+                    // index (the claims table's defense-in-depth) never covers
+                    // followers for batch writes. Null for keyless items;
+                    // peers on older payloads default to NULL. Same two
+                    // fields record() and record_queued emit.
+                    "idempotency_key": input.idempotency_key.as_deref(),
+                    "origin_actor": input.idempotency_key.as_ref().map(|_| self.actor_id.as_str()),
                 });
                 let emb_hash = embedding_hash(&input.embedding);
                 self.log_op_in_tx(

--- a/crates/yantrikdb-core/src/engine/reservation.rs
+++ b/crates/yantrikdb-core/src/engine/reservation.rs
@@ -156,8 +156,8 @@ impl Drop for ReservationGuard<'_> {
 /// `memory_entities` links, or the in-memory graph_index.
 ///
 /// Always publish-only, and deliberately WITHOUT a `with_pending_op`
-/// constructor: `record_batch`'s ops commit `applied = 1` via
-/// `log_record_ops_batch`, so it never enqueues a pending op. Counting here
+/// constructor: `record_batch`'s ops commit `applied = 1` (in-savepoint
+/// `log_op_in_tx` since 4a.6d-2b), so it never enqueues a pending op. Counting here
 /// would inflate `pending_op_count` against zero pending rows — the v0.7.1
 /// counter-leak class the module doc describes. If a queued-batch primitive
 /// ever exists, add the constructor WITH its rationale; do not default to
@@ -465,7 +465,7 @@ mod tests {
             state.vec_index.remove_appended("b5", 25),
             "published entry must survive the Done-phase Drop"
         );
-        // record_batch commits applied=1 ops (log_record_ops_batch), so the
+        // record_batch commits applied=1 ops (in-savepoint log_op_in_tx), so the
         // batch guard has NO counting mode at all — the v0.7.1 counter-leak
         // class, kept impossible by construction.
         assert_eq!(

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -188,7 +188,11 @@ impl YantrikDB {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn log_op_in_tx(
         &self,
-        tx: &rusqlite::Transaction<'_>,
+        // &Connection, not &Transaction: a `Transaction` derefs to it, so tx
+        // callers are unchanged, while SAVEPOINT-guarded callers (record_batch,
+        // 4a.6d-2b) have no `Transaction` to offer — same generalization
+        // `advance_importance_stats_in_tx` made in 4a.6b.
+        tx: &rusqlite::Connection,
         op_type: &str,
         target_rid: Option<&str>,
         payload: &serde_json::Value,
@@ -337,74 +341,11 @@ impl YantrikDB {
         Ok(())
     }
 
-    /// Batched sibling of [`Self::log_op`] that writes one canonical `"record"`
-    /// op per entry under a SINGLE connection lock.
-    ///
-    /// `record_batch` used to log one opaque `"record_batch"` op carrying only
-    /// `{count, rids}`. Replication has no arm for that op type, so peers hit the
-    /// `_ =>` catch-all and silently dropped it — and the payload could not have
-    /// reconstructed the memories anyway. Batch-written memories therefore never
-    /// replicated. Emitting the same canonical `"record"` op that `record()`
-    /// emits makes them replicate through the existing, tested materializer
-    /// rather than needing a new one.
-    ///
-    /// op_ids and HLCs are minted BEFORE the conn lock is taken: `log_op` ticks
-    /// the HLC and *then* locks the connection, so nothing in the codebase ever
-    /// holds `self.hlc` while acquiring `self.conn`. Pre-minting keeps it that
-    /// way and lets the whole batch share one lock instead of taking N.
-    /// HLCs are ticked in batch order, so the ops carry increasing timestamps
-    /// and replicate in their natural causal order.
-    pub(crate) fn log_record_ops_batch(
-        &self,
-        entries: &[(String, serde_json::Value, Vec<u8>)],
-    ) -> Result<Vec<String>> {
-        if entries.is_empty() {
-            return Ok(Vec::new());
-        }
-        let applied_generation: i64 = self.search_state.load().generation as i64;
-
-        // Pre-mint everything that needs a non-conn lock or can fail, so the
-        // critical section below is pure SQL.
-        let mut prepared: Vec<(String, Vec<u8>, String, &[u8], &str)> =
-            Vec::with_capacity(entries.len());
-        for (rid, payload, emb_hash) in entries {
-            let op_id = crate::id::new_id();
-            let hlc_bytes = self.tick_hlc().to_bytes().to_vec();
-            let payload_str = serde_json::to_string(payload)?;
-            prepared.push((
-                op_id,
-                hlc_bytes,
-                payload_str,
-                emb_hash.as_slice(),
-                rid.as_str(),
-            ));
-        }
-
-        let ts = now();
-        let conn = self.conn.lock();
-        let mut stmt = conn.prepare(
-            "INSERT INTO oplog (op_id, op_type, timestamp, target_rid, payload, \
-             actor_id, hlc, embedding_hash, origin_actor, applied, applied_generation) \
-             VALUES (?1, 'record', ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?9)",
-        )?;
-        for (op_id, hlc_bytes, payload_str, emb_hash, rid) in &prepared {
-            stmt.execute(params![
-                op_id,
-                ts,
-                rid,
-                payload_str,
-                self.actor_id,
-                hlc_bytes,
-                emb_hash,
-                self.actor_id,
-                applied_generation,
-            ])?;
-        }
-        drop(stmt);
-        drop(conn);
-
-        Ok(prepared.into_iter().map(|(op_id, ..)| op_id).collect())
-    }
+    // NOTE (4a.6d-2b): `log_record_ops_batch` — the post-commit batched
+    // "record"-op writer introduced by #79's fix — was deleted here. Its one
+    // caller, `record_batch`, now commits each item's op INSIDE its savepoint
+    // via `log_op_in_tx` under a preminted op id (the id an idempotency claim
+    // binds to), which is what closed #94's Err-after-commit for that path.
 
     /// **Decoupled write path RFC, Phase 1.**
     ///

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -104,6 +104,7 @@ fn test_record_batch_auto_extracts_entities() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let inputs = vec![
         RecordInput {
+            idempotency_key: None,
             text: "Alice Chen is the CEO of Acme Corp".to_string(),
             memory_type: "semantic".to_string(),
             importance: 0.8,
@@ -118,6 +119,7 @@ fn test_record_batch_auto_extracts_entities() {
             emotional_state: None,
         },
         RecordInput {
+            idempotency_key: None,
             text: "Sarah Kim is the CTO of Acme Corp".to_string(),
             memory_type: "semantic".to_string(),
             importance: 0.8,
@@ -630,6 +632,7 @@ fn contract_gate_rejects_invalid_writes() {
     // (no earlier element half-committed), and the error names the position.
     let batch = vec![
         crate::types::RecordInput {
+            idempotency_key: None,
             text: "good".into(),
             memory_type: "episodic".into(),
             importance: 0.5,
@@ -644,6 +647,7 @@ fn contract_gate_rejects_invalid_writes() {
             emotional_state: None,
         },
         crate::types::RecordInput {
+            idempotency_key: None,
             text: "bad".into(),
             memory_type: "episodic".into(),
             importance: 0.5,
@@ -1578,6 +1582,7 @@ fn gate_batch_rejects_inconsistent_element_atomically() {
     // side effect — earlier elements must not be half-committed.
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let mk = |text: &str, source: &str, meta: serde_json::Value| RecordInput {
+        idempotency_key: None,
         text: text.to_string(),
         memory_type: "semantic".to_string(),
         importance: 0.5,
@@ -4528,6 +4533,7 @@ fn test_record_batch() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let inputs: Vec<RecordInput> = (0..10)
         .map(|i| RecordInput {
+            idempotency_key: None,
             text: format!("batch memory {i}"),
             memory_type: "episodic".to_string(),
             importance: 0.5,
@@ -4937,6 +4943,7 @@ fn test_encrypted_record_batch() {
 
     let inputs: Vec<RecordInput> = (0..5)
         .map(|i| RecordInput {
+            idempotency_key: None,
             text: format!("encrypted batch {i}"),
             memory_type: "episodic".to_string(),
             importance: 0.5,
@@ -5568,6 +5575,7 @@ fn test_batch_record_with_dimensions() {
 
     let inputs: Vec<RecordInput> = vec![
         RecordInput {
+            idempotency_key: None,
             text: "batch work meeting".to_string(),
             memory_type: "episodic".to_string(),
             importance: 0.6,
@@ -5582,6 +5590,7 @@ fn test_batch_record_with_dimensions() {
             emotional_state: Some("focus".to_string()),
         },
         RecordInput {
+            idempotency_key: None,
             text: "batch health jog".to_string(),
             memory_type: "episodic".to_string(),
             importance: 0.4,
@@ -5596,6 +5605,7 @@ fn test_batch_record_with_dimensions() {
             emotional_state: None,
         },
         RecordInput {
+            idempotency_key: None,
             text: "batch personal diary".to_string(),
             memory_type: "semantic".to_string(),
             importance: 0.3,
@@ -7150,6 +7160,7 @@ fn flagged_committed_writes_tick_the_nudge_counter_exactly_once() {
 
     // record_batch(): two flagged inputs, one clean.
     let mk = |text: &str, meta: serde_json::Value, source: &str| RecordInput {
+        idempotency_key: None,
         text: text.into(),
         memory_type: "semantic".into(),
         importance: 0.7,
@@ -7212,6 +7223,7 @@ fn deferred_batch_leaves_importance_stats_untouched() {
 
     let err = db
         .record_batch(&[RecordInput {
+            idempotency_key: None,
             text: "deferred".into(),
             memory_type: "semantic".into(),
             importance: 0.9,
@@ -7431,6 +7443,7 @@ fn batch_append_failure_leaves_importance_stats_untouched() {
     // stats assertions below are what this test pins.
     let err = db
         .record_batch(&[RecordInput {
+            idempotency_key: None,
             text: "batch after saturation".into(),
             memory_type: "semantic".into(),
             importance: 0.9,
@@ -8242,6 +8255,7 @@ fn batch_append_failure_writes_nothing_at_all() {
     // absence assertions below are meaningful rather than vacuously true. A
     // regression test whose branch never fires is decoration (#83 lesson).
     db.record_batch(&[RecordInput {
+        idempotency_key: None,
         text: "Quarterly sync with Klaxonberg about the roadmap".into(),
         memory_type: "episodic".into(),
         importance: 0.6,
@@ -8306,6 +8320,7 @@ fn batch_append_failure_writes_nothing_at_all() {
     // The doomed batch: same text shape, a DIFFERENT unique entity.
     let err = db
         .record_batch(&[RecordInput {
+            idempotency_key: None,
             text: "Quarterly sync with Quorvexia about the roadmap".into(),
             memory_type: "episodic".into(),
             importance: 0.9,
@@ -8405,6 +8420,7 @@ fn record_batch_normalizes_blank_namespace_like_record() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
 
     let mk = |text: &str, ns: &str, emb: f32| RecordInput {
+        idempotency_key: None,
         text: text.into(),
         memory_type: "semantic".into(),
         importance: 0.7,
@@ -8483,6 +8499,282 @@ fn record_batch_normalizes_blank_namespace_like_record() {
         )
         .unwrap();
     assert_eq!(count, 2, "both observations under the normalized namespace");
+}
+
+/// 4a.6d-2b helper: a keyed batch input. Explicit embedding (batch items are
+/// always caller-supplied vectors -> PayloadVariant::Record digest).
+fn keyed_input(text: &str, ns: &str, emb: f32, key: Option<&str>) -> RecordInput {
+    RecordInput {
+        idempotency_key: key.map(|k| k.to_string()),
+        text: text.into(),
+        memory_type: "semantic".into(),
+        importance: 0.7,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: serde_json::json!({}),
+        embedding: vec_seed(emb, 8),
+        namespace: ns.into(),
+        certainty: 0.8,
+        domain: "work".into(),
+        source: "user".into(),
+        emotional_state: None,
+    }
+}
+
+/// 4a.6d-2b: retrying an identical keyed batch is a per-item idempotent HIT —
+/// the same rids come back in the same order and the store is untouched:
+/// no second rows, no stats advance, no second record ops. Repetition is not
+/// corroboration (T07), now for batches.
+#[test]
+fn keyed_batch_retry_returns_original_rids_and_writes_nothing() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let batch = vec![
+        keyed_input("kb item one", "kb_ns", 1.0, Some("kb-1")),
+        keyed_input("kb item two", "kb_ns", 2.0, Some("kb-2")),
+    ];
+
+    let rids1 = db.record_batch(&batch).unwrap();
+    assert_eq!(rids1.len(), 2);
+
+    let count = |sql: &str| -> i64 { db.conn().query_row(sql, [], |r| r.get(0)).unwrap() };
+    let rows_before = count("SELECT COUNT(*) FROM memories WHERE namespace = 'kb_ns'");
+    let ops_before = count("SELECT COUNT(*) FROM oplog WHERE op_type = 'record'");
+    let stats_before: i64 = db
+        .conn()
+        .query_row(
+            "SELECT count FROM namespace_importance_stats WHERE namespace = 'kb_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(rows_before, 2);
+    assert_eq!(stats_before, 2);
+
+    let rids2 = db.record_batch(&batch).unwrap();
+    assert_eq!(rids2, rids1, "retry returns the ORIGINAL rids, in order");
+    assert_eq!(
+        count("SELECT COUNT(*) FROM memories WHERE namespace = 'kb_ns'"),
+        rows_before,
+        "a keyed retry must write no rows"
+    );
+    assert_eq!(
+        count("SELECT COUNT(*) FROM oplog WHERE op_type = 'record'"),
+        ops_before,
+        "a keyed retry must log no ops"
+    );
+    let stats_after: i64 = db
+        .conn()
+        .query_row(
+            "SELECT count FROM namespace_importance_stats WHERE namespace = 'kb_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stats_after, stats_before,
+        "a keyed retry must not advance stats"
+    );
+}
+
+/// 4a.6d-2b: the same key appearing twice WITHIN one batch with an identical
+/// payload is one write — both positions return the same rid, one row lands.
+#[test]
+fn batch_in_batch_same_key_same_payload_aliases_to_one_write() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rids = db
+        .record_batch(&[
+            keyed_input("alias item", "ib_ns", 1.0, Some("ib-dup")),
+            keyed_input("independent item", "ib_ns", 2.0, None),
+            keyed_input("alias item", "ib_ns", 1.0, Some("ib-dup")),
+        ])
+        .unwrap();
+    assert_eq!(rids.len(), 3, "positional result for every input");
+    assert_eq!(rids[0], rids[2], "in-batch dup aliases to the first write");
+    assert_ne!(rids[0], rids[1]);
+
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'ib_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(rows, 2, "the aliased dup must not write a second row");
+}
+
+/// 4a.6d-2b: the same key WITHIN one batch with a DIFFERENT payload is a
+/// caller bug — the whole batch fails typed and writes NOTHING (batches stay
+/// all-or-nothing on failure; a partial batch would silently drop the item a
+/// retry then can never distinguish).
+#[test]
+fn batch_in_batch_same_key_divergent_payload_is_a_conflict() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let err = db
+        .record_batch(&[
+            keyed_input("first payload", "dv_ns", 1.0, Some("dv-key")),
+            keyed_input("DIFFERENT payload", "dv_ns", 2.0, Some("dv-key")),
+        ])
+        .expect_err("divergent payloads under one key must fail the batch");
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::IdempotencyConflict { .. }
+        ),
+        "expected IdempotencyConflict, got {err:?}"
+    );
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'dv_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(rows, 0, "a conflicted batch must write nothing");
+}
+
+/// 4a.6d-2b, the 4a.6c invariant on the batch surface: NOTHING may reject a
+/// duplicate that would write nothing. A fully-duplicate keyed batch resolves
+/// to its rids even when the delta is saturated — that is exactly when
+/// clients retry — because hits are excluded from the write set BEFORE any
+/// capacity is reserved.
+#[test]
+fn keyed_batch_duplicate_resolves_even_under_backpressure() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let dim = db.embedding_dim();
+    let batch = vec![
+        keyed_input("bp keyed one", "bp_ns", 1.0, Some("bp-1")),
+        keyed_input("bp keyed two", "bp_ns", 2.0, Some("bp-2")),
+    ];
+    let rids1 = db.record_batch(&batch).unwrap();
+
+    // Saturate the delta.
+    let mut saturated = false;
+    for i in 0..400 {
+        let emb: Vec<f32> = (0..dim).map(|j| ((i + j) as f32) * 0.001).collect();
+        match db.record(
+            &format!("bp-filler-{i}"),
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &emb,
+            "bp_filler_ns",
+            0.8,
+            "general",
+            "user",
+            None,
+        ) {
+            Ok(_) => {}
+            Err(crate::error::YantrikDbError::Backpressure { .. }) => {
+                saturated = true;
+                break;
+            }
+            Err(e) => panic!("unexpected: {e:?}"),
+        }
+    }
+    assert!(saturated, "delta never saturated");
+
+    // A fresh unkeyed batch must still backpressure (the saturation is real)…
+    let fresh_err = db
+        .record_batch(&[keyed_input("bp fresh", "bp_ns", 3.0, None)])
+        .expect_err("fresh batch into saturated delta must fail");
+    assert!(matches!(
+        fresh_err,
+        crate::error::YantrikDbError::Backpressure { .. }
+    ));
+
+    // …but the keyed duplicate batch resolves to its original rids.
+    let rids2 = db
+        .record_batch(&batch)
+        .expect("a fully-duplicate keyed batch must resolve, not backpressure");
+    assert_eq!(rids2, rids1);
+}
+
+/// 4a.6d-2b: record() and record_batch share the Record digest variant, so the
+/// SAME key with a byte-identical payload is a HIT across the two surfaces —
+/// they are the same write (caller-supplied embedding, identical canonical
+/// payload). Divergent payloads under the key conflict as always.
+#[test]
+fn same_key_across_record_and_record_batch_hits_on_identical_payload() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let input = keyed_input("cross surface batch text", "xb_ns", 1.5, Some("xb-key"));
+
+    let rid = db
+        .record_with_idempotency(
+            &input.text,
+            &input.memory_type,
+            input.importance,
+            input.valence,
+            input.half_life,
+            &input.metadata,
+            &input.embedding,
+            &input.namespace,
+            input.certainty,
+            &input.domain,
+            &input.source,
+            input.emotional_state.as_deref(),
+            Some("xb-key"),
+        )
+        .unwrap();
+
+    let rids = db.record_batch(&[input]).unwrap();
+    assert_eq!(
+        rids[0], rid,
+        "identical payload under the same key is the same write on either surface"
+    );
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'xb_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(rows, 1, "the batch hit must not write a second row");
+}
+
+/// 4a.6d-2b (#94): a keyed batch item's claim binds to a REAL op that
+/// committed in the same transaction — op_id in the claim exists in the oplog
+/// as an applied record op targeting the claimed rid. This is only possible
+/// because 2b moves the batch's op INSERTs INSIDE the savepoint (the 4a.6c
+/// rule: recovery never has to guess from row existence).
+#[test]
+fn keyed_batch_claim_binds_to_a_committed_op() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rids = db
+        .record_batch(&[keyed_input(
+            "claim binding probe",
+            "cb_ns",
+            1.0,
+            Some("cb-key"),
+        )])
+        .unwrap();
+
+    let (claim_rid, op_id, state): (String, String, String) = db
+        .conn()
+        .query_row(
+            "SELECT rid, op_id, state FROM idempotency_claims              WHERE idempotency_key = 'cb-key' AND namespace = 'cb_ns'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .expect("a keyed batch item must write a claim");
+    assert_eq!(claim_rid, rids[0]);
+    assert_eq!(state, "committed");
+
+    let (op_type, applied, target_rid): (String, i64, String) = db
+        .conn()
+        .query_row(
+            "SELECT op_type, applied, target_rid FROM oplog WHERE op_id = ?1",
+            rusqlite::params![op_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .expect("the claim's op_id must exist in the oplog — the claim binds to it");
+    assert_eq!(op_type, "record");
+    assert_eq!(applied, 1);
+    assert_eq!(target_rid, rids[0]);
 }
 
 // ── Relationship-Based Entity Type Tests ──
@@ -17547,6 +17839,7 @@ fn record_batch_defers_during_reembed_instead_of_writing_a_doomed_generation() {
     // its own comment claimed every append lands on one anchored generation.
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let inputs = vec![RecordInput {
+        idempotency_key: None,
         text: "written during a cutover".to_string(),
         memory_type: "semantic".to_string(),
         importance: 0.5,
@@ -17675,6 +17968,7 @@ fn record_batch_replicates_to_a_peer() {
     let follower = YantrikDB::new(":memory:", 8).unwrap();
 
     let mk = |text: &str, seed: f32| RecordInput {
+        idempotency_key: None,
         text: text.to_string(),
         memory_type: "semantic".to_string(),
         importance: 0.6,

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -8870,6 +8870,81 @@ fn partial_hit_batch_writes_only_the_fresh_items() {
     assert_eq!(ns, "ph_ns");
 }
 
+/// 4a.6d-2b sol r2 finding 1: a KEYED batch item's record op must carry the
+/// v37 idempotency fields — record()'s payload does (record.rs ~440,
+/// "a follower's keyed row must mirror its leader's"), and replication's
+/// materialize_record persists them to the follower row. The batch payload
+/// omitted both, so a keyed batch row replicated as an UNKEYED row on every
+/// peer: the memories partial-unique mirror (the claims table's
+/// defense-in-depth) silently never covered follower rows for batch writes.
+/// The pre-existing batch replication test missed it because its inputs are
+/// unkeyed — same lesson as the python wrapper in r1: bugs live where the
+/// keyed variant is untested.
+#[test]
+fn keyed_batch_record_op_replicates_the_key_to_a_peer() {
+    use crate::replication::{apply_ops, extract_ops_since};
+    let leader = YantrikDB::new(":memory:", 8).unwrap();
+    let follower = YantrikDB::new(":memory:", 8).unwrap();
+
+    let rids = leader
+        .record_batch(&[
+            keyed_input("replicated keyed item", "rk_ns", 1.0, Some("rk-key")),
+            keyed_input("replicated unkeyed item", "rk_ns", 2.0, None),
+        ])
+        .unwrap();
+
+    // Payload-level: the keyed item's op carries BOTH fields; the unkeyed
+    // item's op carries them as null (identical to record()'s shape).
+    let payload_for = |rid: &str| -> serde_json::Value {
+        let raw: String = leader
+            .conn()
+            .query_row(
+                "SELECT payload FROM oplog WHERE op_type = 'record' AND target_rid = ?1",
+                rusqlite::params![rid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        serde_json::from_str(&raw).unwrap()
+    };
+    let keyed_payload = payload_for(&rids[0]);
+    assert_eq!(
+        keyed_payload["idempotency_key"], "rk-key",
+        "keyed batch op payload must carry the key for follower mirroring"
+    );
+    assert_eq!(
+        keyed_payload["origin_actor"],
+        leader.actor_id(),
+        "keyed batch op payload must carry the origin actor"
+    );
+    let unkeyed_payload = payload_for(&rids[1]);
+    assert!(
+        unkeyed_payload["idempotency_key"].is_null(),
+        "unkeyed items carry null, matching record()'s keyless shape"
+    );
+
+    // End-to-end: the follower row mirrors the leader's v37 columns.
+    let ops = extract_ops_since(&leader.conn(), None, None, None, 100).unwrap();
+    apply_ops(&follower, &ops).unwrap();
+    let (f_key, f_actor): (Option<String>, Option<String>) = follower
+        .conn()
+        .query_row(
+            "SELECT idempotency_key, origin_actor FROM memories WHERE rid = ?1",
+            rusqlite::params![rids[0]],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        f_key.as_deref(),
+        Some("rk-key"),
+        "follower keyed row must mirror the leader's idempotency_key"
+    );
+    assert_eq!(
+        f_actor.as_deref(),
+        Some(leader.actor_id()),
+        "follower keyed row must mirror the leader's origin_actor"
+    );
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -8814,6 +8814,62 @@ fn keyed_batch_duplicate_resolves_during_reembed_cutover() {
     assert_eq!(rids2, rids1);
 }
 
+/// 4a.6d-2b: a batch mixing an idempotent HIT with fresh items writes ONLY
+/// the fresh items — hits are per-item successes (original rid at their
+/// position), failures stay all-or-nothing. The hit contributes no row, no
+/// second record op, no stats observation, and no entity re-extraction.
+#[test]
+fn partial_hit_batch_writes_only_the_fresh_items() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let keyed = keyed_input("partial hit anchor", "ph_ns", 1.0, Some("ph-key"));
+    let first = db.record_batch(std::slice::from_ref(&keyed)).unwrap();
+
+    let rids = db
+        .record_batch(&[
+            keyed.clone(),
+            keyed_input("partial fresh item", "ph_ns", 2.0, None),
+        ])
+        .unwrap();
+    assert_eq!(rids.len(), 2);
+    assert_eq!(rids[0], first[0], "hit position carries the ORIGINAL rid");
+    assert_ne!(rids[1], rids[0]);
+
+    let count = |sql: &str| -> i64 { db.conn().query_row(sql, [], |r| r.get(0)).unwrap() };
+    assert_eq!(
+        count("SELECT COUNT(*) FROM memories WHERE namespace = 'ph_ns'"),
+        2,
+        "one row from each batch — the hit wrote nothing"
+    );
+    assert_eq!(
+        count("SELECT COUNT(*) FROM oplog WHERE op_type = 'record'"),
+        2,
+        "one record op per WRITTEN item"
+    );
+    let stats_count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT count FROM namespace_importance_stats WHERE namespace = 'ph_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        stats_count, 2,
+        "two written observations, the hit added none"
+    );
+
+    // And the fresh item is durable + visible: point-read it back.
+    let ns: String = db
+        .conn()
+        .query_row(
+            "SELECT namespace FROM memories WHERE rid = ?1",
+            rusqlite::params![rids[1]],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(ns, "ph_ns");
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -8777,6 +8777,43 @@ fn keyed_batch_claim_binds_to_a_committed_op() {
     assert_eq!(target_rid, rids[0]);
 }
 
+/// 4a.6d-2b: the UNLOCKED pre-admission probe's unique contribution — it runs
+/// BEFORE the write-router, so a fully-duplicate keyed batch resolves to its
+/// rids even while a reembed cutover has the router in Queueing (a fresh batch
+/// correctly defers, since no queued-batch primitive exists). Without the
+/// pre-router probe, a dup retry during cutover could only ever see
+/// BatchDeferredDuringReembed — the retry loop that never converges, again.
+#[test]
+fn keyed_batch_duplicate_resolves_during_reembed_cutover() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let batch = vec![
+        keyed_input("cutover keyed one", "co_ns", 1.0, Some("co-1")),
+        keyed_input("cutover keyed two", "co_ns", 2.0, Some("co-2")),
+    ];
+    let rids1 = db.record_batch(&batch).unwrap();
+
+    // Simulate a reembed cutover in flight.
+    db.write_router.switch_to_queueing();
+
+    // Control: a FRESH batch must defer — the router state is real.
+    let err = db
+        .record_batch(&[keyed_input("cutover fresh", "co_ns", 3.0, None)])
+        .expect_err("fresh batch must defer during cutover");
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::BatchDeferredDuringReembed { .. }
+        ),
+        "expected BatchDeferredDuringReembed, got {err:?}"
+    );
+
+    // The fully-duplicate keyed batch resolves BEFORE the router.
+    let rids2 = db
+        .record_batch(&batch)
+        .expect("a fully-duplicate keyed batch must resolve during cutover");
+    assert_eq!(rids2, rids1);
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -1029,9 +1029,35 @@ impl PyYantrikDB {
                 .transpose()?
                 .unwrap_or(serde_json::json!({}));
 
+            // 4a.6d-2b (sol r1 finding 1): a key on a batch item requires an
+            // EXPLICIT embedding. Rust record_batch digests PayloadVariant::
+            // Record — API-byte identity, the caller-supplied vector included —
+            // so a wrapper-synthesized vector would make an honest retry a
+            // false conflict the moment the embedder drifts, and would make
+            // `record(text, key)` (which routes to record_text's
+            // embedding-EXCLUDED digest) and `record_batch([{text, key}])`
+            // resolve the same user-level write differently. No engine-side
+            // text-batch idempotency surface exists yet, so fail loud rather
+            // than subtly mis-dedup — same interim stance 4a.6c took on
+            // record() before 4a.6d-1 shipped the RecordText variant.
+            let has_key = d
+                .get_item("idempotency_key")?
+                .map(|v| !v.is_none())
+                .unwrap_or(false);
             let embedding: Vec<f32> = match d.get_item("embedding")? {
-                Some(v) => v.extract()?,
-                None => self.embed_text(py, &text)?,
+                Some(v) if !v.is_none() => v.extract()?,
+                _ if has_key => {
+                    return Err(PyValueError::new_err(
+                        "idempotency_key on a record_batch item requires an \
+                         explicit 'embedding': the batch digest includes the \
+                         caller's vector (API-byte identity), and a \
+                         wrapper-generated vector would make an honest retry \
+                         a false conflict. Pass the embedding, or use \
+                         record(text, idempotency_key=...) for an \
+                         engine-embedded keyed write.",
+                    ));
+                }
+                _ => self.embed_text(py, &text)?,
             };
 
             let namespace: String = d

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -1064,6 +1064,16 @@ impl PyYantrikDB {
                 .transpose()?
                 .flatten();
 
+            // 4a.6d-2b: optional per-item idempotency key, same contract as
+            // record(idempotency_key=...). Batch items carry explicit
+            // caller-supplied embeddings, so the Record digest variant
+            // applies and no embedder-drift guard is needed here.
+            let idempotency_key: Option<String> = d
+                .get_item("idempotency_key")?
+                .map(|v| v.extract::<Option<String>>())
+                .transpose()?
+                .flatten();
+
             record_inputs.push(yantrikdb_core::RecordInput {
                 text,
                 memory_type,
@@ -1077,6 +1087,7 @@ impl PyYantrikDB {
                 domain,
                 source,
                 emotional_state,
+                idempotency_key,
             });
         }
 

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,102 @@
+"""Wrapper-level idempotency tests (v0.10 4a.6c / 4a.6d).
+
+The engine-side semantics (claims, digests, probes) are pinned by the Rust
+suite; these tests pin the PYTHON WRAPPER's routing and refusals — the layer
+pytest alone can exercise.
+"""
+
+import math
+
+import pytest
+
+from yantrikdb import YantrikDB
+
+DIM = 8
+
+
+def _vec(seed: float) -> list[float]:
+    raw = [math.sin(seed * 1.7 + i * 2.3) + math.cos(seed * 0.3 + i * 3.1) for i in range(DIM)]
+    norm = math.sqrt(sum(x * x for x in raw))
+    if norm < 1e-9:
+        raw[0] = 1.0
+        norm = 1.0
+    return [x / norm for x in raw]
+
+
+@pytest.fixture
+def db():
+    engine = YantrikDB(db_path=":memory:", embedding_dim=DIM)
+    yield engine
+    engine.close()
+
+
+class TestRecordIdempotency:
+    def test_keyed_retry_returns_original_rid(self, db):
+        kwargs = dict(
+            text="keyed write",
+            embedding=_vec(1.0),
+            idempotency_key="k-1",
+        )
+        rid1 = db.record(**kwargs)
+        rid2 = db.record(**kwargs)
+        assert rid2 == rid1
+
+    def test_same_key_different_payload_conflicts(self, db):
+        db.record(text="first payload", embedding=_vec(1.0), idempotency_key="k-2")
+        with pytest.raises(Exception, match="[Ii]dempoten"):
+            db.record(text="DIFFERENT payload", embedding=_vec(2.0), idempotency_key="k-2")
+
+
+class TestBatchIdempotency:
+    def test_keyed_batch_retry_returns_original_rids(self, db):
+        batch = [
+            {"text": "batch one", "embedding": _vec(1.0), "idempotency_key": "b-1"},
+            {"text": "batch two", "embedding": _vec(2.0), "idempotency_key": "b-2"},
+        ]
+        rids1 = db.record_batch(batch)
+        rids2 = db.record_batch(batch)
+        assert rids2 == rids1
+
+    def test_unkeyed_items_need_no_embedding_refusal(self, db):
+        # Unkeyed items without an embedding are refused only because this
+        # fixture has NO embedder at all — the error must be about embedding
+        # generation, not about idempotency.
+        with pytest.raises(Exception) as exc_info:
+            db.record_batch([{"text": "no vector, no key"}])
+        assert "idempotency" not in str(exc_info.value).lower()
+
+    def test_keyed_batch_item_without_embedding_is_refused(self, db):
+        # sol 4a.6d-2b r1 finding 1: the batch digest is API-byte identity
+        # (PayloadVariant::Record, caller vector INCLUDED), so a
+        # wrapper-synthesized vector would make honest retries false
+        # conflicts. The wrapper must refuse loudly, pointing at the two
+        # honest options.
+        with pytest.raises(ValueError, match="idempotency_key.*embedding"):
+            db.record_batch([{"text": "keyed but no vector", "idempotency_key": "b-3"}])
+
+    def test_keyed_batch_item_with_none_embedding_is_refused(self, db):
+        # An explicit None embedding is the same hazard as an absent one.
+        with pytest.raises(ValueError, match="idempotency_key.*embedding"):
+            db.record_batch(
+                [{"text": "keyed, None vector", "embedding": None, "idempotency_key": "b-4"}]
+            )
+
+    def test_cross_surface_hit_record_then_batch(self, db):
+        # Identical payload + key via record() and then a batch item is ONE
+        # write: the batch position returns record()'s rid.
+        common = dict(
+            text="cross surface",
+            memory_type="episodic",
+            importance=0.5,
+            valence=0.0,
+            half_life=604800.0,
+            namespace="default",
+            certainty=0.8,
+            domain="general",
+            source="user",
+        )
+        rid = db.record(embedding=_vec(3.0), idempotency_key="x-1", **common)
+        rids = db.record_batch(
+            [{**common, "embedding": _vec(3.0), "idempotency_key": "x-1"}]
+        )
+        assert rids == [rid]


### PR DESCRIPTION
Closes #94. sol-ACCEPTed after 3 rounds; both r1 findings and the r2 finding were real bugs, all cleared in full.

## What

Per-item idempotency keys for `record_batch` — the batch surface of the 4a.6c durable claim (T07). `RecordInput` gains `idempotency_key: Option<String>` (all in-crate literals fixed; python dicts take an optional `idempotency_key`).

**Semantics**
- Digest: canonical RAW payload, `PayloadVariant::Record`, built from the input with two load-bearing overrides (NORMALIZED namespace, SANITIZED text) → byte-compatible with `record_with_idempotency`, so an identical payload under one key is the SAME write across record()/batch — cross-surface retries hit.
- In-batch dups: same (namespace, key) + same digest → the later item is an alias (one write; both positions return its rid). Divergent digest → whole-batch typed `IdempotencyConflict` — batches stay all-or-nothing on failure.
- Hits and aliases write NOTHING: no reserve, no row, no session bump, no entities/graph (mention_count cannot inflate on retries — the #80 class), no stats advance, no flag tick, no audit event.
- Admission mirrors 4a.6c: unlocked pre-router probe (an all-hits batch resolves during reembed cutover and under full delta saturation — exactly when clients retry) → locked probe under the continuously-held conn guard (window closed) → per-write-item reserve → claims as the FIRST statements of the savepoint, each bound to a preminted op id → rows stamp the v37 `idempotency_key`/`origin_actor` columns like record().

**#94 subsumed**: claims must bind to op ids that commit atomically, so the per-item record ops moved INSIDE the savepoint via `log_op_in_tx` (generalized `&Transaction` → `&Connection`; Transaction derefs, callers unchanged — the same generalization 4a.6b made for the stats advance). The post-commit `log_record_ops_batch` — the last Err-after-commit in this path — is deleted dead.

## sol rounds (all findings real)

- **r1.1**: python `record_batch` synthesized missing embeddings under a key → generated vector in the Record digest → embedder drift = false conflicts, and `record(text, key)` vs `record_batch([{text, key}])` resolved the same user write differently. Fixed: keyed batch items require an explicit embedding (loud ValueError; explicit None = absent). The wrapper layer had ZERO pytest coverage since 4a.6c — `tests/test_idempotency.py` now pins it, refusal tests proven to fail on the pre-fix wheel.
- **r1.2**: probe comments overstated 'NOTHING may reject a duplicate' — narrowed at all three sites to the implemented guarantee (duplicates bypass RESOURCE admission; deterministic payload-shape prevalidation still errors first, identically on any retry). sol concurred the gate-mode-change-between-retries semantic is pre-existing and out of scope.
- **r2.1**: the batch record-op payload omitted the v37 `idempotency_key`/`origin_actor` fields that record()/record_queued carry and that `materialize_record` persists — keyed batch rows replicated as UNKEYED rows on peers. Fixed + keyed replication test proven to fail on the omission (payload AND end-to-end follower-row mirror). The pre-existing replication test missed it because its inputs are unkeyed — same lesson as r1: bugs live where the keyed variant is untested.

## Evidence

- 6 behavioral tests proven to fail at 61d5bc7 (field present, engine ignoring it) + 3 property pins added with the implementation (reembed-cutover resolution, partial-hit batch, keyed replication).
- 8/8 mutants killed (fail-loud harness, compiled-and-ran verified): both-probes-removed fails LOUDLY via the defensive in-tx arm; unlocked-probe-removed is killed by the cutover test while the retry test still passes — the two probe layers are each independently pinned.
- 1753 Rust lib tests · workspace `--features testing` (kill proofs) · 240 python tests against a wheel rebuilt from this branch (+ #102 filed: a pre-existing time-flake reproduced 3/3 on a main-built wheel, deselected).

## Out of scope, tracked

- `record_with_rid`: no keys yet, own op type, last commit-then-append site → 4a.6d-3 (next).
- #100: migrate the 7 remaining manual SAVEPOINT sites to SavepointGuard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)