### PR TITLE
feat(v0.10-4a.6d-3a): record_with_rid reserve-before-savepoint port — the last commit-then-append site

### DIFF
--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -1357,15 +1357,32 @@ impl YantrikDB {
             // remove it; (b) a reader on a separate connection could see the
             // new vector paired with the not-yet-committed old text. While
             // reserved, search still returns the old durable vector.
-            if let Err(e) = state_for_commit.vec_index.append_reserved(
+            // `false` = an identical (rid, seq_new) already exists. seq_new is
+            // freshly minted for this correction, so that is an invariant
+            // violation — and constructing the guard below over an entry this
+            // call does not own would let a failure path remove another
+            // write's published vector (4a.6d-3, sol r1 finding 1).
+            match state_for_commit.vec_index.append_reserved(
                 rid.to_string(),
                 new_embedding.clone(),
                 seq_new,
             ) {
-                drop(_epoch);
-                drop(conn);
-                drop(sync_guard);
-                return Err(e);
+                Ok(crate::vector::delta_index::ReservedAppend::Inserted) => {}
+                Ok(crate::vector::delta_index::ReservedAppend::AlreadyPresent) => {
+                    drop(_epoch);
+                    drop(conn);
+                    drop(sync_guard);
+                    return Err(crate::error::YantrikDbError::InvalidInput(format!(
+                        "freshly minted seq {seq_new} for rid {rid} already \
+                         present in the delta — engine invariant violation"
+                    )));
+                }
+                Err(e) => {
+                    drop(_epoch);
+                    drop(conn);
+                    drop(sync_guard);
+                    return Err(e);
+                }
             }
 
             // From here the reservation is owed back on EVERY exit — including an
@@ -1835,14 +1852,25 @@ impl YantrikDB {
             });
 
             // Reserve-append BEFORE commit; propagate failure (op retried).
+            // `false` = the freshly minted seq collided with an existing
+            // (rid, seq) entry — an invariant violation; constructing the
+            // guard over an entry this call does not own would let a failure
+            // path remove another write's published vector (4a.6d-3).
             let seq_new = if let Some(v) = &new_vec {
                 let s = self
                     .vec_seq
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                     + 1;
-                state
+                if state
                     .vec_index
-                    .append_reserved(rid.to_string(), v.clone(), s)?;
+                    .append_reserved(rid.to_string(), v.clone(), s)?
+                    == crate::vector::delta_index::ReservedAppend::AlreadyPresent
+                {
+                    return Err(crate::error::YantrikDbError::InvalidInput(format!(
+                        "freshly minted seq {s} for rid {rid} already present \
+                         in the delta — engine invariant violation"
+                    )));
+                }
                 Some(s)
             } else {
                 None

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -499,10 +499,18 @@ impl YantrikDB {
 
         // RESERVE: consumes delta capacity and validates dim, but stays invisible
         // to search until published. This is where Backpressure surfaces — before
-        // a single durable byte has been written.
-        state
+        // a single durable byte has been written. `false` (entry already
+        // present) is impossible here — the rid is freshly minted — so it is
+        // an invariant violation, never a replay.
+        if !state
             .vec_index
-            .append_reserved(rid.clone(), embedding.to_vec(), seq)?;
+            .append_reserved(rid.clone(), embedding.to_vec(), seq)?
+        {
+            return Err(crate::error::YantrikDbError::InvalidInput(format!(
+                "freshly minted rid {rid} already present in the delta at seq \
+                 {seq} — engine invariant violation"
+            )));
+        }
 
         // From here until commit, ANY exit — including an unwinding panic —
         // must drop the reservation, or its capacity is held forever
@@ -1621,111 +1629,196 @@ impl YantrikDB {
 
         let session_id = self.active_sessions.read().get(namespace).cloned();
 
-        // Single conn block: INSERT OR IGNORE on memories (idempotent on rid),
-        // session links, entity persistence. SAVEPOINT for atomicity within
-        // the call.
-        let was_new_row: bool = {
-            let conn = self.conn();
-            conn.execute_batch("SAVEPOINT record_with_rid")?;
+        // ── 4a.6d-3: reserve → one savepoint → publish ──────────────────
+        // The pre-port shape was record()'s pre-4a.6a disease, worse: the row
+        // committed alone; the vector appended AFTER (with a partial
+        // compensating DELETE on failure — the #92 class); and the op and the
+        // materialization enqueue ran as separate post-commit autocommits. A
+        // failure or kill between the commit and the op was UNREPAIRABLE:
+        // the retry takes the was_new_row=false arm, which skips log_op by
+        // design, so the row existed forever with no oplog provenance and the
+        // write never replicated (kill_record_with_rid_boundary.rs). Now the
+        // row, the session link, the op, and the enqueue commit in ONE
+        // savepoint, with the vector reserved before it opens and published
+        // after RELEASE.
+        let emb_hash = embedding_hash(embedding);
+        let conn = self.conn();
 
-            let result: Result<bool> = (|| {
-                // **Issue #41 brainstorm-4 §6.** v28 embedding_generation
-                // stamp from the SearchState snapshot loaded above.
-                let embedding_generation: i64 = state.generation as i64;
-                let inserted = conn.execute(
-                    "INSERT OR IGNORE INTO memories \
-                     (rid, type, text, embedding, created_at, updated_at, importance, \
-                      half_life, last_access, valence, metadata, namespace, \
-                      certainty, domain, source, emotional_state, \
-                      created_at_unix_micros, embedding_model, embedding_generation) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6, ?7, ?5, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
-                    params![
-                        rid, memory_type, stored_text, stored_emb,
-                        ts_secs,
-                        importance, half_life, valence, stored_meta, namespace,
-                        certainty, domain, source, emotional_state,
-                        created_at_unix_micros, embedding_model,
-                        embedding_generation,
-                    ],
-                )?;
-                let was_new_row = inserted == 1;
-
-                if was_new_row {
-                    // Auto-link only on first insert. Replay should not
-                    // re-bump session memory_count.
-                    if let Some(session_id) = &session_id {
-                        conn.execute(
-                            "UPDATE memories SET session_id = ?1 WHERE rid = ?2",
-                            params![session_id, rid],
-                        )?;
-                        conn.execute(
-                            "UPDATE sessions SET memory_count = memory_count + 1 WHERE session_id = ?1",
-                            params![session_id],
-                        )?;
-                    }
-                }
-
-                // **Phase 4.3 Commit C (saga task 19, 2026-05-08).** The
-                // entity / memory_entities INSERT loop was previously here
-                // inside the SAVEPOINT, holding `db.conn().lock()` for
-                // O(extracted_entities.len()) statements. Now enqueued as
-                // OP_MATERIALIZE_RECORD_WITH_RID_POST after the SAVEPOINT
-                // releases. See docs/phase_4_3_design.md for the contract.
-
-                Ok(was_new_row)
-            })();
-
-            match result {
-                Ok(b) => {
-                    conn.execute_batch("RELEASE record_with_rid")?;
-                    b
-                }
-                Err(e) => {
-                    let _ = conn.execute_batch("ROLLBACK TO record_with_rid");
-                    let _ = conn.execute_batch("RELEASE record_with_rid");
-                    return Err(e);
-                }
-            }
-        };
-        // conn dropped
-
-        // DeltaIndex append. The seq is either caller-supplied (cluster
-        // mode: openraft commit-log index for byte-deterministic replay)
-        // or engine-allocated (single-node). On idempotent replay the rid
-        // is the same and the seq is identical (cluster) or fresh
-        // (single-node retry); the compactor's highest-seq-wins rule
-        // converges state identically on both paths.
+        // Seq minted under the conn lock (search resolves a rid to its
+        // HIGHEST seq; minting in the serialized region keeps seq order and
+        // commit order aligned — record()'s rationale). Cluster callers pass
+        // their commit-log index; fetch_max ratchets either way.
         let seq = self.assign_seq(seq);
-        // **v0.7.19 orphan-on-Backpressure fix.** The trader's
-        // `trader_ledger` DB shows `record_with_rid` pinned at
-        // exactly 256 (the v0.7.17 delta_max wedge ceiling) — every
-        // additional call after that left a memories row from the
-        // INSERT OR IGNORE above with no oplog provenance because
-        // the vec_index.append Err short-circuited the log_op below.
-        // Compensating DELETE on failure. Skip the delete when
-        // was_new_row=false (replay path: the row pre-existed; we
-        // shouldn't yank it).
-        if let Err(e) = state
+
+        // RESERVE before any SQL — Backpressure and dim surface here, before
+        // a single durable byte. `inserted == false` is the deterministic-
+        // replay case: an identical (rid, seq) is already in the delta
+        // (cluster re-delivery; the prior apply published it), and this call
+        // then owes the delta NOTHING — publishing is done, and a removal on
+        // failure would delete the prior write's PUBLISHED vector — so no
+        // guard is constructed at all. `inserted == true` with an EXISTING
+        // row (was_new_row=false below) is the repair case the old
+        // post-commit append also served: a row whose vector was lost gets
+        // it re-published.
+        let inserted = state
             .vec_index
-            .append(rid.to_string(), embedding.to_vec(), seq)
-        {
-            if was_new_row {
-                let conn = self.conn();
-                let _ = conn.execute("DELETE FROM memories WHERE rid = ?1", params![rid]);
-                // **v0.7.23 residual fix.** The session `memory_count`
-                // bumped inside the (already-RELEASEd) SAVEPOINT survives
-                // the compensating DELETE. Reverse it so the stat matches
-                // the surviving rows. Mirrors the was_new_row guard on the
-                // original bump — replay (was_new_row=false) never bumped.
-                if let Some(session_id) = &session_id {
-                    let _ = conn.execute(
-                        "UPDATE sessions SET memory_count = memory_count - 1 WHERE session_id = ?1",
-                        params![session_id],
-                    );
+            .append_reserved(rid.to_string(), embedding.to_vec(), seq)?;
+        let mut reservation = if inserted {
+            Some(ReservationGuard::publish_only(&state, rid, seq))
+        } else {
+            None
+        };
+
+        // #91's class: RAII — every `?` below and any unwinding panic rolls
+        // the whole write back AND releases the frame.
+        let savepoint = super::savepoint::SavepointGuard::new(&conn, "record_with_rid")?;
+
+        // **Issue #41 brainstorm-4 §6.** v28 embedding_generation
+        // stamp from the SearchState snapshot loaded above.
+        let embedding_generation: i64 = state.generation as i64;
+        let inserted_row = conn.execute(
+            "INSERT OR IGNORE INTO memories \
+             (rid, type, text, embedding, created_at, updated_at, importance, \
+              half_life, last_access, valence, metadata, namespace, \
+              certainty, domain, source, emotional_state, \
+              created_at_unix_micros, embedding_model, embedding_generation) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6, ?7, ?5, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+            params![
+                rid, memory_type, stored_text, stored_emb,
+                ts_secs,
+                importance, half_life, valence, stored_meta, namespace,
+                certainty, domain, source, emotional_state,
+                created_at_unix_micros, embedding_model,
+                embedding_generation,
+            ],
+        )?;
+        let was_new_row = inserted_row == 1;
+        debug_assert!(
+            inserted || !was_new_row,
+            "row {rid} is NEW but its (rid, seq {seq}) vector entry pre-exists — \
+             a fresh row cannot have a prior published vector"
+        );
+
+        if was_new_row {
+            // Auto-link only on first insert. Replay should not
+            // re-bump session memory_count.
+            if let Some(session_id) = &session_id {
+                conn.execute(
+                    "UPDATE memories SET session_id = ?1 WHERE rid = ?2",
+                    params![session_id, rid],
+                )?;
+                conn.execute(
+                    "UPDATE sessions SET memory_count = memory_count + 1 WHERE session_id = ?1",
+                    params![session_id],
+                )?;
+            }
+
+            // Kill boundary (4a.6d-3): pre-port the process could die between
+            // the RELEASEd row and the op's autocommit — the unrepairable
+            // orphan. Inside the savepoint, dying here rolls back BOTH.
+            crate::testing::fail_point("record_with_rid.between_row_and_oplog");
+
+            // The op commits WITH the row — applied=1, generation pinned to
+            // the same snapshot the reserved delta entry was written against.
+            // Payload unchanged (peers' record_with_rid materialization
+            // contract).
+            self.log_op_in_tx(
+                &conn,
+                "record_with_rid",
+                Some(rid),
+                &serde_json::json!({
+                    "rid": rid,
+                    "type": memory_type,
+                    "text": text,
+                    "importance": importance,
+                    "valence": valence,
+                    "half_life": half_life,
+                    "metadata": metadata,
+                    "created_at_unix_micros": created_at_unix_micros,
+                    "namespace": namespace,
+                    "certainty": certainty,
+                    "domain": domain,
+                    "source": source,
+                    "emotional_state": emotional_state,
+                    "embedding_model": embedding_model,
+                    "extracted_entities": extracted_entities,
+                }),
+                Some(&emb_hash),
+                None,
+                embedding_generation,
+                None,
+            )?;
+
+            // **Phase 4.3 Commit C**, moved IN-TX (4a.6a's record() fix,
+            // ported): the entity-materialization enqueue commits with the
+            // row, so a crash can no longer keep the row while losing the
+            // enqueue. Gated on was_new_row — the pre-port unconditional
+            // re-enqueue on replay was repair for exactly the crash window
+            // this savepoint closes; with atomicity it is pure duplicate
+            // work inflating the pending queue on every re-delivery.
+            if !extracted_entities.is_empty() {
+                // Pending-queue admission BEFORE the enqueue, inside the tx:
+                // an Err here rolls the whole write back. Pre-port this check
+                // lived inside the post-commit log_op_pending — it reported
+                // Err for a write that was already durable AND visible, and
+                // the retry could never log the skipped op.
+                self.check_pending_backpressure_locked()?;
+                let post_payload = serde_json::json!({
+                    "rid": rid,
+                    "namespace": namespace,
+                    "ts_secs": ts_secs,
+                    "extracted_entities": extracted_entities.to_vec(),
+                    "was_new_row": true,
+                });
+                self.log_op_pending_in_tx(
+                    &conn,
+                    crate::engine::op_types::OP_MATERIALIZE_RECORD_WITH_RID_POST,
+                    Some(rid),
+                    &post_payload,
+                    None,
+                    None,
+                )?;
+                // The tx now holds a pending row: the guard owes its count
+                // post-commit (log_op_pending_in_tx deliberately never
+                // touches the counter — counting inside the tx would strand
+                // the increment on rollback, the v0.7.1 drift).
+                if let Some(r) = reservation.as_mut() {
+                    r.count_pending_op_on_completion(&self.pending_op_count);
                 }
             }
-            return Err(e);
         }
+
+        savepoint.release()?;
+        // The obligation inverts HERE: the write is durable, so the
+        // reservation owes publish (+count if it enqueued), not removal.
+        // Nothing fallible may sit between the RELEASE and this call.
+        if let Some(r) = reservation.as_mut() {
+            r.mark_committed();
+        }
+        let published = match reservation.as_mut() {
+            Some(r) => r.complete(),
+            // Replay whose vector already exists: nothing was reserved,
+            // nothing publishes — the existing entry is the truth.
+            None => false,
+        };
+        debug_assert!(
+            published || !inserted,
+            "record_with_rid reservation for {rid} seq {seq} vanished before publish"
+        );
+        if inserted && !published {
+            tracing::error!(
+                rid = %rid,
+                seq,
+                "reserved vector entry missing at publish — row is durable but \
+                 unsearchable until the index is rebuilt from SQL"
+            );
+        }
+        drop(reservation);
+
+        // LAST: a read-your-write waiter must not wake against a
+        // half-applied record (CONCURRENCY.md: bump visible_seq AFTER the
+        // delta publish). Idempotent fetch_max, so the no-reservation replay
+        // arm bumps harmlessly.
         self.bump_visible_seq(namespace, seq);
 
         // Scoring cache (engine-internal; replay safe since insert is
@@ -1751,71 +1844,6 @@ impl YantrikDB {
             );
         }
 
-        // Op log entry — applied=1 since leader has materialized inline.
-        // Followers will receive a separate replicated entry via the
-        // cluster sync path; this path never logs applied=0.
-        //
-        // Logged BEFORE the post-record materialization enqueue so
-        // extract_ops_since reports the user-data op in causal order
-        // (record_with_rid arrived, then its entity-link materialization
-        // was queued).
-        crate::testing::fail_point("record_with_rid.between_row_and_oplog");
-        let emb_hash = embedding_hash(embedding);
-        if was_new_row {
-            self.log_op(
-                "record_with_rid",
-                Some(rid),
-                &serde_json::json!({
-                    "rid": rid,
-                    "type": memory_type,
-                    "text": text,
-                    "importance": importance,
-                    "valence": valence,
-                    "half_life": half_life,
-                    "metadata": metadata,
-                    "created_at_unix_micros": created_at_unix_micros,
-                    "namespace": namespace,
-                    "certainty": certainty,
-                    "domain": domain,
-                    "source": source,
-                    "emotional_state": emotional_state,
-                    "embedding_model": embedding_model,
-                    "extracted_entities": extracted_entities,
-                }),
-                Some(&emb_hash),
-            )?;
-        }
-
-        // **Phase 4.3 Commit C (saga task 19, 2026-05-08).** Enqueue the
-        // entity / memory_entities / graph_index materialization for the
-        // worker thread. Skip when there are no entities to apply — the
-        // dispatch arm short-circuits the same way, but skipping avoids
-        // a wasteful oplog row in the common no-entity case.
-        //
-        // Cluster determinism: the leader and each follower will both
-        // enqueue + apply this op against their local state. Convergence
-        // on entities + memory_entities is guaranteed by the same
-        // INSERT OR IGNORE / ON CONFLICT idempotency the inline path
-        // had. The convergence *time* differs by the materializer-lag
-        // window (ms-scale), but the converged final state is identical.
-        if !extracted_entities.is_empty() {
-            let entities_json: Vec<&str> = extracted_entities.to_vec();
-            let post_payload = serde_json::json!({
-                "rid": rid,
-                "namespace": namespace,
-                "ts_secs": ts_secs,
-                "extracted_entities": entities_json,
-                "was_new_row": was_new_row,
-            });
-            self.log_op_pending(
-                crate::engine::op_types::OP_MATERIALIZE_RECORD_WITH_RID_POST,
-                Some(rid),
-                &post_payload,
-                None,
-                None,
-            )?;
-        }
-
         // 4a.6b: an ORIGIN write that was warn-flagged and actually WROTE A ROW is
         // durable — count it now. Gated on `was_new_row` (sol r3 finding 2): this
         // path is `INSERT OR IGNORE`, so a replay of an existing rid persists
@@ -1824,6 +1852,7 @@ impl YantrikDB {
         if was_new_row {
             self.note_flagged_write_committed(gate_verdict);
         }
+        drop(conn);
         Ok(())
     }
 

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1759,6 +1759,7 @@ impl YantrikDB {
         // extract_ops_since reports the user-data op in causal order
         // (record_with_rid arrived, then its entity-link materialization
         // was queued).
+        crate::testing::fail_point("record_with_rid.between_row_and_oplog");
         let emb_hash = embedding_hash(embedding);
         if was_new_row {
             self.log_op(

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -499,12 +499,13 @@ impl YantrikDB {
 
         // RESERVE: consumes delta capacity and validates dim, but stays invisible
         // to search until published. This is where Backpressure surfaces — before
-        // a single durable byte has been written. `false` (entry already
-        // present) is impossible here — the rid is freshly minted — so it is
-        // an invariant violation, never a replay.
-        if !state
+        // a single durable byte has been written. `AlreadyPresent` is
+        // impossible here — the rid is freshly minted — so it is an invariant
+        // violation, never a replay.
+        if state
             .vec_index
             .append_reserved(rid.clone(), embedding.to_vec(), seq)?
+            == crate::vector::delta_index::ReservedAppend::AlreadyPresent
         {
             return Err(crate::error::YantrikDbError::InvalidInput(format!(
                 "freshly minted rid {rid} already present in the delta at seq \
@@ -1662,7 +1663,8 @@ impl YantrikDB {
         // it re-published.
         let inserted = state
             .vec_index
-            .append_reserved(rid.to_string(), embedding.to_vec(), seq)?;
+            .append_reserved(rid.to_string(), embedding.to_vec(), seq)?
+            == crate::vector::delta_index::ReservedAppend::Inserted;
         let mut reservation = if inserted {
             Some(ReservationGuard::publish_only(&state, rid, seq))
         } else {

--- a/crates/yantrikdb-core/src/engine/reservation.rs
+++ b/crates/yantrikdb-core/src/engine/reservation.rs
@@ -205,10 +205,11 @@ impl<'a> BatchReservationGuard<'a> {
         // Batch rids are freshly minted, so an already-present (rid, seq)
         // is an invariant violation — and it must NOT be pushed as an entry
         // (this guard would then publish/remove a vector it doesn't own).
-        if !self
+        if self
             .state
             .vec_index
             .append_reserved(rid.clone(), embedding, seq)?
+            == crate::vector::delta_index::ReservedAppend::AlreadyPresent
         {
             return Err(crate::error::YantrikDbError::InvalidInput(format!(
                 "freshly minted rid {rid} already present in the delta at seq \
@@ -279,7 +280,7 @@ mod tests {
     fn drop_before_commit_removes_the_reservation() {
         let db = db();
         let state = db.search_state.load_full();
-        state
+        let _ = state
             .vec_index
             .append_reserved("r1".into(), vec![0.1; 8], 7)
             .unwrap();
@@ -299,7 +300,7 @@ mod tests {
     fn unwind_before_commit_removes_the_reservation() {
         let db = db();
         let state = db.search_state.load_full();
-        state
+        let _ = state
             .vec_index
             .append_reserved("r2".into(), vec![0.1; 8], 8)
             .unwrap();
@@ -323,7 +324,7 @@ mod tests {
     fn unwind_after_commit_publishes_rather_than_stranding() {
         let db = db();
         let state = db.search_state.load_full();
-        state
+        let _ = state
             .vec_index
             .append_reserved("r3".into(), vec![0.1; 8], 9)
             .unwrap();
@@ -352,7 +353,7 @@ mod tests {
     fn complete_then_drop_discharges_exactly_once() {
         let db = db();
         let state = db.search_state.load_full();
-        state
+        let _ = state
             .vec_index
             .append_reserved("r4".into(), vec![0.1; 8], 10)
             .unwrap();
@@ -386,7 +387,7 @@ mod tests {
         let before = db.pending_op_count.load(Ordering::Relaxed);
 
         // committed-and-completed
-        state
+        let _ = state
             .vec_index
             .append_reserved("r5".into(), vec![0.1; 8], 11)
             .unwrap();
@@ -396,7 +397,7 @@ mod tests {
             g.complete();
         }
         // committed-and-unwound (Drop discharges)
-        state
+        let _ = state
             .vec_index
             .append_reserved("r6".into(), vec![0.1; 8], 12)
             .unwrap();

--- a/crates/yantrikdb-core/src/engine/reservation.rs
+++ b/crates/yantrikdb-core/src/engine/reservation.rs
@@ -106,6 +106,18 @@ impl<'a> ReservationGuard<'a> {
         self.phase = ResPhase::Committed;
     }
 
+    /// Upgrade a `publish_only` guard to ALSO owe the pending-op count —
+    /// called at the moment the surrounding transaction actually ENQUEUES a
+    /// pending row (4a.6d-3: `record_with_rid` only learns whether it will
+    /// enqueue after `was_new_row` resolves INSIDE the transaction, so the
+    /// obligation cannot be chosen at construction). Safe at any pre-commit
+    /// point: an unwind before `mark_committed` still takes the Reserved arm
+    /// (removal, no count — the rollback removed the pending row too), and
+    /// after commit both discharge paths publish AND count.
+    pub(crate) fn count_pending_op_on_completion(&mut self, counter: &'a AtomicI64) {
+        self.pending_op_count = Some(counter);
+    }
+
     /// Discharge the post-commit obligations exactly once. Returns whether
     /// `publish` found the reservation.
     pub(crate) fn complete(&mut self) -> bool {
@@ -190,9 +202,19 @@ impl<'a> BatchReservationGuard<'a> {
         embedding: Vec<f32>,
         seq: u64,
     ) -> crate::error::Result<()> {
-        self.state
+        // Batch rids are freshly minted, so an already-present (rid, seq)
+        // is an invariant violation — and it must NOT be pushed as an entry
+        // (this guard would then publish/remove a vector it doesn't own).
+        if !self
+            .state
             .vec_index
-            .append_reserved(rid.clone(), embedding, seq)?;
+            .append_reserved(rid.clone(), embedding, seq)?
+        {
+            return Err(crate::error::YantrikDbError::InvalidInput(format!(
+                "freshly minted rid {rid} already present in the delta at seq \
+                 {seq} — engine invariant violation"
+            )));
+        }
         self.entries.push((rid, seq));
         Ok(())
     }

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -280,7 +280,11 @@ impl YantrikDB {
     /// SQL. That is the v0.7.1 counter-leak class.
     pub(crate) fn log_op_pending_in_tx(
         &self,
-        tx: &rusqlite::Transaction<'_>,
+        // &Connection, not &Transaction — same generalization as
+        // `log_op_in_tx` (4a.6d-2b): Transaction derefs, so tx callers are
+        // unchanged, and SAVEPOINT-guarded callers (record_with_rid,
+        // 4a.6d-3) have no Transaction to offer.
+        tx: &rusqlite::Connection,
         op_type: &str,
         target_rid: Option<&str>,
         payload: &serde_json::Value,

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -8945,6 +8945,135 @@ fn keyed_batch_record_op_replicates_the_key_to_a_peer() {
     );
 }
 
+/// 4a.6d-3 helper: a record_with_rid call with every knob defaulted.
+#[allow(clippy::too_many_arguments)]
+fn rwr(
+    db: &YantrikDB,
+    rid: &str,
+    text: &str,
+    ns: &str,
+    entities: &[&str],
+    seq: Option<u64>,
+) -> crate::error::Result<()> {
+    db.record_with_rid(
+        rid,
+        text,
+        "semantic",
+        0.6,
+        0.0,
+        604800.0,
+        &serde_json::json!({}),
+        &vec_seed(4.0, 8),
+        ns,
+        0.8,
+        "general",
+        "user",
+        None,
+        1_750_000_000_000_000,
+        entities,
+        "test-embedder",
+        seq,
+        crate::provenance::WriteAdmission::Origin,
+    )
+}
+
+/// 4a.6d-3 (#94's class on this path): the pending-queue admission check ran
+/// INSIDE `log_op_pending`, AFTER the row and vector were durable — so a
+/// saturated pending queue returned Err for a write that had already
+/// committed, and a retrying caller (the cluster applier!) then hit the
+/// was_new_row=false arm which never logs the op: the row exists forever
+/// without provenance. Post-port the locked check runs BEFORE any durable
+/// byte: Err means nothing was written.
+#[test]
+fn record_with_rid_pending_saturation_rejects_before_writing() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    db.pending_op_count
+        .swap(1_000_000, std::sync::atomic::Ordering::SeqCst);
+
+    let err = rwr(
+        &db,
+        "0198c1c2-0000-7000-8000-0000000000aa",
+        "saturated pending write",
+        "sat_ns",
+        &["SaturatedEntity"],
+        None,
+    )
+    .expect_err("pending saturation must reject the write");
+    assert!(
+        matches!(err, crate::error::YantrikDbError::Backpressure { .. }),
+        "expected Backpressure, got {err:?}"
+    );
+
+    let rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE namespace = 'sat_ns'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        rows, 0,
+        "a write rejected for pending saturation must write NOTHING —          pre-port the row and vector were already durable when the check ran"
+    );
+    let ops: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE op_type = 'record_with_rid'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(ops, 0, "no op for a rejected write");
+    assert!(db.conn().is_autocommit(), "no savepoint left open");
+}
+
+/// 4a.6d-3: replaying an EXISTING rid must not re-enqueue its entity
+/// materialization. Pre-port the enqueue ran post-commit unconditionally
+/// (its rationale: repair a crash between the row and the enqueue) — but the
+/// port commits row + op + enqueue in ONE savepoint, so the repair case
+/// cannot exist and a replay re-enqueue is pure duplicate work inflating the
+/// pending queue on every cluster re-delivery.
+#[test]
+fn record_with_rid_replay_does_not_reenqueue_materialization() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rid = "0198c1c2-0000-7000-8000-0000000000bb";
+
+    rwr(&db, rid, "replayed write", "rp_ns", &["ReplayEntity"], None).unwrap();
+    rwr(&db, rid, "replayed write", "rp_ns", &["ReplayEntity"], None).unwrap();
+
+    let enqueues: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE op_type = ?1 AND target_rid = ?2",
+            rusqlite::params![
+                crate::engine::op_types::OP_MATERIALIZE_RECORD_WITH_RID_POST,
+                rid
+            ],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        enqueues, 1,
+        "replay of an existing rid re-enqueued its materialization"
+    );
+
+    // And the replay logged no second record_with_rid op (pre-existing
+    // was_new_row gate — pinned here so the port cannot regress it).
+    let ops: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE op_type = 'record_with_rid' AND target_rid = ?1",
+            rusqlite::params![rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        ops, 1,
+        "exactly one record_with_rid op for one logical write"
+    );
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/engine/tests.rs
+++ b/crates/yantrikdb-core/src/engine/tests.rs
@@ -9074,6 +9074,65 @@ fn record_with_rid_replay_does_not_reenqueue_materialization() {
     );
 }
 
+/// 4a.6d-3: the in-tx materialization enqueue owes pending_op_count exactly
+/// +1, discharged post-commit by the reservation guard's upgrade
+/// (`count_pending_op_on_completion`). Counting is what the backpressure
+/// ceiling reads — a skipped increment drifts the counter low and the
+/// ceiling stops engaging (the inverse of the v0.7.1 wedge).
+#[test]
+fn record_with_rid_enqueue_counts_exactly_one_pending_op() {
+    use std::sync::atomic::Ordering;
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+
+    let before = db.pending_op_count.load(Ordering::SeqCst);
+    rwr(
+        &db,
+        "0198c1c2-0000-7000-8000-0000000000cc",
+        "counted enqueue",
+        "cnt_ns",
+        &["CountedEntity"],
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        db.pending_op_count.load(Ordering::SeqCst),
+        before + 1,
+        "one enqueued materialization op = exactly one count"
+    );
+
+    // No entities -> no enqueue -> no count.
+    rwr(
+        &db,
+        "0198c1c2-0000-7000-8000-0000000000cd",
+        "uncounted write",
+        "cnt_ns",
+        &[],
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        db.pending_op_count.load(Ordering::SeqCst),
+        before + 1,
+        "an entity-less write enqueues nothing and must not count"
+    );
+
+    // Replay -> no enqueue -> no count.
+    rwr(
+        &db,
+        "0198c1c2-0000-7000-8000-0000000000cc",
+        "counted enqueue",
+        "cnt_ns",
+        &["CountedEntity"],
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        db.pending_op_count.load(Ordering::SeqCst),
+        before + 1,
+        "a replay enqueues nothing and must not count"
+    );
+}
+
 // ── Relationship-Based Entity Type Tests ──
 
 #[test]

--- a/crates/yantrikdb-core/src/vector/delta_index.rs
+++ b/crates/yantrikdb-core/src/vector/delta_index.rs
@@ -155,6 +155,23 @@ pub struct DeltaIndex {
     compactor_wake_mu: parking_lot::Mutex<()>,
 }
 
+/// Outcome of [`DeltaIndex::append_reserved`]. `#[must_use]` is the
+/// load-bearing part: it makes `append_reserved(...)?;` — the statement
+/// shape that silently discarded the old bool return (sol 4a.6d-3 r1
+/// finding 1: two correction sites did exactly that) — a compiler warning,
+/// so every caller must decide which arm it is on.
+#[must_use = "AlreadyPresent means the caller owns NO reservation — \
+              publishing or removing the existing entry corrupts a prior \
+              write's vector"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReservedAppend {
+    /// A new unpublished entry was inserted; the caller owes
+    /// publish-on-commit / remove-on-failure (the ReservationGuard rule).
+    Inserted,
+    /// An identical (rid, seq) already exists; the caller owes NOTHING.
+    AlreadyPresent,
+}
+
 impl DeltaIndex {
     /// Create a new empty `DeltaIndex` with the given embedding dimension.
     /// Cold starts as a fresh empty `HnswIndex(dim)`. Delta is empty.
@@ -253,16 +270,32 @@ impl DeltaIndex {
     /// so a correction's vector never becomes visible (or gets sealed into
     /// cold) unless its text change is durable.
     ///
-    /// Returns whether an entry was INSERTED (4a.6d-3). `false` means an
-    /// identical `(rid, seq)` already exists — the idempotent-replay no-op —
+    /// Returns whether an entry was INSERTED (4a.6d-3). `AlreadyPresent`
+    /// means an identical `(rid, seq)` exists — the idempotent-replay no-op —
     /// and the caller owns NO obligation for it: it must neither publish it
     /// (the existing entry's published flag belongs to the write that made
     /// it) nor remove it on failure (that would delete a prior write's
     /// possibly-PUBLISHED vector). Writers minting fresh rids/seqs treat
-    /// `false` as an invariant violation; the deterministic-replay path
-    /// (`record_with_rid` with a caller seq) treats it as "already applied".
-    pub fn append_reserved(&self, rid: String, embedding: Vec<f32>, seq: u64) -> Result<bool> {
+    /// `AlreadyPresent` as an invariant violation; the deterministic-replay
+    /// path (`record_with_rid` with a caller seq) treats it as "already
+    /// applied". The outcome is a `#[must_use]` ENUM, not a bool, precisely
+    /// so `append_reserved(...)?;` cannot silently discard it (sol 4a.6d-3
+    /// r1 finding 1: two correction sites did exactly that — `?` consumes
+    /// the Result, and a bare bool then drops without a whisper).
+    pub fn append_reserved(
+        &self,
+        rid: String,
+        embedding: Vec<f32>,
+        seq: u64,
+    ) -> Result<ReservedAppend> {
         self.append_inner(rid, embedding, seq, false)
+            .map(|inserted| {
+                if inserted {
+                    ReservedAppend::Inserted
+                } else {
+                    ReservedAppend::AlreadyPresent
+                }
+            })
     }
 
     fn append_inner(
@@ -772,7 +805,8 @@ mod tests {
         idx.append("rid".to_string(), old.clone(), 1).unwrap();
 
         // Reserve the new vector at a higher seq — still invisible.
-        idx.append_reserved("rid".to_string(), new.clone(), 2)
+        let _ = idx
+            .append_reserved("rid".to_string(), new.clone(), 2)
             .unwrap();
         let hit_old = idx.search(&old, 1).unwrap();
         assert_eq!(hit_old[0].0, "rid");
@@ -804,7 +838,8 @@ mod tests {
         let mut new = vec![0.0f32; 8];
         new[4] = 1.0;
         idx.append("rid".to_string(), old.clone(), 1).unwrap();
-        idx.append_reserved("rid".to_string(), new.clone(), 2)
+        let _ = idx
+            .append_reserved("rid".to_string(), new.clone(), 2)
             .unwrap();
 
         // Compact: the published old entry seals into cold; the reserved

--- a/crates/yantrikdb-core/src/vector/delta_index.rs
+++ b/crates/yantrikdb-core/src/vector/delta_index.rs
@@ -241,7 +241,7 @@ impl DeltaIndex {
     /// the second append is silently a no-op (recovery may replay the
     /// same op multiple times).
     pub fn append(&self, rid: String, embedding: Vec<f32>, seq: u64) -> Result<()> {
-        self.append_inner(rid, embedding, seq, true)
+        self.append_inner(rid, embedding, seq, true).map(|_| ())
     }
 
     /// **v0.10 Item 3 — reserved append.** Append the new vector as an
@@ -252,7 +252,16 @@ impl DeltaIndex {
     /// then publishes on commit / [`Self::remove_appended`]s on failure —
     /// so a correction's vector never becomes visible (or gets sealed into
     /// cold) unless its text change is durable.
-    pub fn append_reserved(&self, rid: String, embedding: Vec<f32>, seq: u64) -> Result<()> {
+    ///
+    /// Returns whether an entry was INSERTED (4a.6d-3). `false` means an
+    /// identical `(rid, seq)` already exists — the idempotent-replay no-op —
+    /// and the caller owns NO obligation for it: it must neither publish it
+    /// (the existing entry's published flag belongs to the write that made
+    /// it) nor remove it on failure (that would delete a prior write's
+    /// possibly-PUBLISHED vector). Writers minting fresh rids/seqs treat
+    /// `false` as an invariant violation; the deterministic-replay path
+    /// (`record_with_rid` with a caller seq) treats it as "already applied".
+    pub fn append_reserved(&self, rid: String, embedding: Vec<f32>, seq: u64) -> Result<bool> {
         self.append_inner(rid, embedding, seq, false)
     }
 
@@ -262,7 +271,7 @@ impl DeltaIndex {
         embedding: Vec<f32>,
         seq: u64,
         published: bool,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if embedding.len() != self.dim {
             return Err(YantrikDbError::InvalidInput(format!(
                 "embedding dimension mismatch: expected {}, got {}",
@@ -273,9 +282,10 @@ impl DeltaIndex {
 
         let mut delta = self.delta.write();
 
-        // Idempotent on rid+seq.
+        // Idempotent on rid+seq: the existing entry stands, whatever its
+        // published state — the second arrival owns nothing (4a.6d-3).
         if delta.iter().any(|e| e.rid == rid && e.seq == seq) {
-            return Ok(());
+            return Ok(false);
         }
 
         if delta.len() >= self.delta_max {
@@ -317,7 +327,7 @@ impl DeltaIndex {
         if new_len >= self.delta_max * 80 / 100 {
             self.compactor_wake_cv.notify_one();
         }
-        Ok(())
+        Ok(true)
     }
 
     /// Append a tombstone for `rid` to the delta tier.

--- a/crates/yantrikdb-core/tests/kill_record_with_rid_boundary.rs
+++ b/crates/yantrikdb-core/tests/kill_record_with_rid_boundary.rs
@@ -1,0 +1,174 @@
+//! v0.10 Item 4a.6d-3 — the record_with_rid-boundary kill proof.
+//!
+//! `record_with_rid` is the cluster apply primitive AND a public origin API,
+//! and until 4a.6d-3 it had the exact pre-4a.6a shape `record()` was cured of:
+//! the memories row committed in its own savepoint, and the
+//! `"record_with_rid"` oplog op was written AFTERWARDS on a separate
+//! autocommit. A process death between the two left a durable row with no
+//! oplog provenance — and on THIS path the orphan is unrepairable by retry:
+//! the row exists, so the retry takes the `was_new_row = false` arm, which
+//! deliberately skips `log_op`. The op is not late; it is lost FOREVER, and
+//! with it the write's replication to every peer.
+//!
+//! After 4a.6d-3: the row, the session updates, the `record_with_rid` op and
+//! the entity-materialization enqueue share one savepoint, so a kill at this
+//! boundary rolls back all of it. Neither half survives; the retry then takes
+//! the fresh-row path and writes everything.
+//!
+//! Mechanics mirror `kill_record_boundary.rs`: re-invoke this test binary to
+//! run the ignored child helper with the failpoint armed, wait for the
+//! handshake line with a bounded timeout, kill the child, reopen, assert.
+#![cfg(feature = "testing")]
+
+use std::io::BufRead;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use yantrikdb::YantrikDB;
+
+fn test_vec(seed: f32, dim: usize) -> Vec<f32> {
+    let raw: Vec<f32> = (0..dim).map(|i| ((seed + i as f32) * 0.7).sin()).collect();
+    let norm: f32 = raw.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-9);
+    raw.iter().map(|x| x / norm).collect()
+}
+
+/// CHILD half — ignored in normal runs; the parent invokes it explicitly.
+#[test]
+#[ignore]
+fn child_parks_at_record_with_rid_boundary() {
+    let db_path = std::env::var("YANTRIKDB_KILL_DB").expect("child needs YANTRIKDB_KILL_DB");
+    let db = YantrikDB::new(&db_path, 8).unwrap();
+
+    println!("CHILD_READY:opened");
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    // Parks at the row/oplog boundary. The parent kills us here.
+    let _ = db.record_with_rid(
+        "0198c1c2-0000-7000-8000-00000000feed",
+        "the replicated write that must not survive",
+        "semantic",
+        0.5,
+        0.0,
+        604800.0,
+        &serde_json::json!({}),
+        &test_vec(3.0, 8),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+        1_750_000_000_000_000,
+        &["KillProofEntity"],
+        "test-embedder",
+        None,
+        yantrikdb::provenance::WriteAdmission::Origin,
+    );
+    unreachable!("parent must kill us at the failpoint");
+}
+
+/// PARENT half — the actual proof.
+#[test]
+fn kill_between_record_with_rid_row_and_oplog_leaves_neither() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("kill_rwr.db");
+    let db_path_str = db_path.to_str().unwrap().to_string();
+
+    let exe = std::env::current_exe().unwrap();
+    let mut child = Command::new(exe)
+        .args([
+            "child_parks_at_record_with_rid_boundary",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("YANTRIKDB_KILL_DB", &db_path_str)
+        .env(
+            "YANTRIKDB_FAILPOINTS",
+            "record_with_rid.between_row_and_oplog",
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn child");
+
+    let stdout = child.stdout.take().unwrap();
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stdout)
+            .lines()
+            .map_while(|l| l.ok())
+        {
+            let _ = tx.send(line);
+        }
+    });
+
+    let deadline = Duration::from_secs(60);
+    let mut saw_ready = false;
+    let mut saw_failpoint = false;
+    let start = std::time::Instant::now();
+    while start.elapsed() < deadline {
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(line) if line.starts_with("CHILD_READY:") => saw_ready = true,
+            Ok(line) if line == "FAILPOINT:record_with_rid.between_row_and_oplog" => {
+                saw_failpoint = true;
+                break;
+            }
+            Ok(_) => {}
+            Err(_) => {
+                if let Ok(Some(_)) = child.try_wait() {
+                    break;
+                }
+            }
+        }
+    }
+    assert!(saw_ready, "child never opened the engine");
+    assert!(saw_failpoint, "child never hit the armed failpoint");
+
+    child.kill().expect("kill child");
+    let _ = child.wait();
+
+    let db = YantrikDB::new(&db_path_str, 8).unwrap();
+    let conn = db.conn();
+
+    let qc: String = conn
+        .query_row("PRAGMA quick_check", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(qc, "ok", "quick_check after kill");
+
+    // THE assertion. On the pre-4a.6d-3 code the row exists (its savepoint
+    // RELEASEd before the kill) with no record_with_rid op — an orphan no
+    // retry can repair, because was_new_row=false skips log_op forever.
+    let memories: i64 = conn
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        memories, 0,
+        "the killed record_with_rid's row survived without oplog provenance — \
+         unrepairable by retry (was_new_row=false skips log_op)"
+    );
+
+    let ops: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM oplog WHERE op_type = 'record_with_rid'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(ops, 0, "the killed write logged an op");
+
+    // Both-or-neither, stated as the standing invariant.
+    let rows_without_ops: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories m WHERE NOT EXISTS \
+             (SELECT 1 FROM oplog o WHERE o.op_type = 'record_with_rid' \
+              AND o.target_rid = m.rid)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        rows_without_ops, 0,
+        "a memories row exists with no record_with_rid op"
+    );
+}


### PR DESCRIPTION
sol-ACCEPTed after 2 rounds (the r1 finding was real; instance + category fixed).

## The defects, each with a proof that failed pre-port

`record_with_rid` — the cluster apply primitive AND public origin API — had the exact pre-4a.6a shape record() was cured of, with a sharper edge:

1. **The unrepairable orphan**: the row committed in its own savepoint; the op was logged AFTERWARDS by autocommit. A kill between them left a durable row with no op — and the retry takes the `was_new_row=false` arm, which skips `log_op` by design, so the op is lost FOREVER and the write never replicates. New kill proof `kill_record_with_rid_boundary.rs` failed pre-port with row=1/ops=0.
2. **Err-after-commit on pending saturation**: the queue admission check lived inside post-commit `log_op_pending` — Err for a write already durable and visible. Proven-to-fail test.
3. **Replay re-enqueue**: every re-delivery of an existing rid re-enqueued its entity materialization. Its rationale (repairing a crash between row and enqueue) dies with the one-savepoint port. Proven-to-fail test: 2 enqueues for 1 write.

## The port

- **Reserve before the savepoint**; `append_reserved` now returns `ReservedAppend::{Inserted, AlreadyPresent}` — a `#[must_use]` ENUM. `AlreadyPresent` (cluster re-delivery: the prior apply's published vector holds the slot) means this call owes the delta NOTHING: no guard, no publish, no removal — a guard there would let a failure path remove a PUBLISHED vector it doesn't own. Fresh-rid/seq sites (record, batch, both lifecycle corrections) treat it as a loud invariant error. `Inserted` + existing row is the vector-repair arm (kept from the old append semantics).
- **One savepoint** (SavepointGuard): row → session link → failpoint → `log_op_in_tx` (generation pinned to the snapshot) → in-tx pending-queue check → `log_op_pending_in_tx` (generalized `&Transaction`→`&Connection`, like 2b's `log_op_in_tx`) — the op/enqueue gated on `was_new_row`.
- **`ReservationGuard::count_pending_op_on_completion`**: whether this write enqueues is only known after `was_new_row` resolves inside the tx, so the guard upgrades from publish_only at the enqueue site; pre-commit unwinds still take the removal arm (the rollback removed the pending row).
- Seq minted under the conn lock; compensating DELETE + session reversal deleted; `bump_visible_seq` after publish.
- Op payload byte-identical (peers' materialization contract).

## sol r1 finding (real, cleared in full)

Both lifecycle correction sites still discarded `append_reserved`'s outcome via bare `?;` and constructed guards unconditionally — the exact ownership confusion the return change existed to prevent, in the sites I wasn't looking at. Fixed both, and closed the CATEGORY: the outcome is a `#[must_use]` enum because fn-level `#[must_use]` would have been decorative (`?` consumes the Result; only a must-use TYPE makes the `f(...)?;` discard warn).

## Evidence

- 3 defect proofs flipped + pending-count property pin; **6/6 mutants killed** (reserve-skipped, op-not-logged, was_new_row-gate-removed, pending-check-removed, count-upgrade-removed, guard-never-constructed).
- 1757 lib tests · workspace `--features testing` (all 4 kill proofs) · 240 python tests against a wheel rebuilt from this branch.

## Out of scope, tracked

- **#104** (filed): record_with_rid bypasses the write_router — pre-existing #41 layer-3 gap; needs yantrikdb-server coordination.
- **4a.6d-3b**: Origin idempotency keys for this path (return-type change: a key hit resolves to the ORIGINAL rid, which `Ok(())` would misrepresent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)