### PR TITLE
feat(python): typed exception classes for actionable engine errors

### DIFF
--- a/crates/yantrikdb-python/src/lib.rs
+++ b/crates/yantrikdb-python/src/lib.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 
 pub mod py_consolidate;
 pub mod py_engine;
+pub mod py_errors;
 pub mod py_tenant;
 pub mod py_triggers;
 pub mod py_types;
@@ -11,6 +12,31 @@ fn _yantrikdb_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Engine
     m.add_class::<py_engine::PyYantrikDB>()?;
     m.add_class::<py_tenant::PyTenantManager>()?;
+
+    // Typed exceptions (v0.10) — all subclass RuntimeError, so pre-v0.10
+    // `except RuntimeError:` handlers keep working; new code branches on type.
+    m.add("Backpressure", m.py().get_type::<py_errors::Backpressure>())?;
+    m.add(
+        "CorrectionDeferredDuringReembed",
+        m.py()
+            .get_type::<py_errors::CorrectionDeferredDuringReembed>(),
+    )?;
+    m.add(
+        "BatchDeferredDuringReembed",
+        m.py().get_type::<py_errors::BatchDeferredDuringReembed>(),
+    )?;
+    m.add(
+        "IdempotencyConflict",
+        m.py().get_type::<py_errors::IdempotencyConflict>(),
+    )?;
+    m.add(
+        "InvalidIdempotencyKey",
+        m.py().get_type::<py_errors::InvalidIdempotencyKey>(),
+    )?;
+    m.add(
+        "ProvenanceInconsistent",
+        m.py().get_type::<py_errors::ProvenanceInconsistent>(),
+    )?;
 
     // Triggers
     m.add_class::<py_triggers::PyTrigger>()?;

--- a/crates/yantrikdb-python/src/lib.rs
+++ b/crates/yantrikdb-python/src/lib.rs
@@ -37,6 +37,10 @@ fn _yantrikdb_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
         "ProvenanceInconsistent",
         m.py().get_type::<py_errors::ProvenanceInconsistent>(),
     )?;
+    m.add(
+        "RecallContended",
+        m.py().get_type::<py_errors::RecallContended>(),
+    )?;
 
     // Triggers
     m.add_class::<py_triggers::PyTrigger>()?;

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -238,6 +238,7 @@ pub(crate) fn map_err(e: yantrikdb_core::YantrikDbError) -> PyErr {
         E::ProvenanceInconsistent { .. } => {
             py_errors::ProvenanceInconsistent::new_err(e.to_string())
         }
+        E::RecallContended { .. } => py_errors::RecallContended::new_err(e.to_string()),
         E::NoEmbedder => PyRuntimeError::new_err(e.to_string()),
         E::NoQuery => PyValueError::new_err(e.to_string()),
         _ => PyRuntimeError::new_err(e.to_string()),

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -218,9 +218,28 @@ pub(crate) fn py_to_sql_value(obj: &Bound<'_, PyAny>) -> PyResult<Box<dyn rusqli
 }
 
 pub(crate) fn map_err(e: yantrikdb_core::YantrikDbError) -> PyErr {
+    use crate::py_errors;
+    use yantrikdb_core::YantrikDbError as E;
+    // v0.10 (yantrikdb-mcp friction 2): actionable variants cross the pyo3
+    // boundary as TYPED exception classes so hosts branch on type, never on
+    // message text. Every class subclasses RuntimeError — pre-v0.10 handlers
+    // keep working. The message still carries the details (e.g. the existing
+    // rid on a conflict).
     match e {
-        yantrikdb_core::YantrikDbError::NoEmbedder => PyRuntimeError::new_err(e.to_string()),
-        yantrikdb_core::YantrikDbError::NoQuery => PyValueError::new_err(e.to_string()),
+        E::Backpressure { .. } => py_errors::Backpressure::new_err(e.to_string()),
+        E::CorrectionDeferredDuringReembed { .. } => {
+            py_errors::CorrectionDeferredDuringReembed::new_err(e.to_string())
+        }
+        E::BatchDeferredDuringReembed { .. } => {
+            py_errors::BatchDeferredDuringReembed::new_err(e.to_string())
+        }
+        E::IdempotencyConflict { .. } => py_errors::IdempotencyConflict::new_err(e.to_string()),
+        E::InvalidIdempotencyKey { .. } => py_errors::InvalidIdempotencyKey::new_err(e.to_string()),
+        E::ProvenanceInconsistent { .. } => {
+            py_errors::ProvenanceInconsistent::new_err(e.to_string())
+        }
+        E::NoEmbedder => PyRuntimeError::new_err(e.to_string()),
+        E::NoQuery => PyValueError::new_err(e.to_string()),
         _ => PyRuntimeError::new_err(e.to_string()),
     }
 }

--- a/crates/yantrikdb-python/src/py_errors.rs
+++ b/crates/yantrikdb-python/src/py_errors.rs
@@ -1,0 +1,73 @@
+//! Typed Python exceptions for the engine's actionable error variants
+//! (v0.10, yantrikdb-mcp validation friction 2).
+//!
+//! Before this module, every engine error crossed the pyo3 boundary as a bare
+//! `RuntimeError`, so a host implementing the documented retry semantics had
+//! to string-match on message text — the brittle thing that silently breaks
+//! on a rewording. These classes let hosts branch on TYPE:
+//!
+//! - retryable-later: `Backpressure`, `CorrectionDeferredDuringReembed`,
+//!   `BatchDeferredDuringReembed`
+//! - caller-decision: `IdempotencyConflict` (the message carries the existing
+//!   rid — the first write's content stands), `InvalidIdempotencyKey`,
+//!   `ProvenanceInconsistent`
+//!
+//! Every class SUBCLASSES `RuntimeError`, so pre-v0.10 handlers written as
+//! `except RuntimeError:` keep working unchanged — this is additive, not a
+//! break. Unmatched variants still map to bare `RuntimeError` in `map_err`.
+
+use pyo3::create_exception;
+use pyo3::exceptions::PyRuntimeError;
+
+create_exception!(
+    yantrikdb,
+    Backpressure,
+    PyRuntimeError,
+    "The engine is saturated (pending-op queue or delta capacity); nothing \
+     was written. Retryable: back off and reissue the identical call. Keyed \
+     duplicate retries resolve even under saturation."
+);
+
+create_exception!(
+    yantrikdb,
+    CorrectionDeferredDuringReembed,
+    PyRuntimeError,
+    "A re-embedding cutover is in flight; the correction was not applied. \
+     Retryable: reissue verbatim after the cutover completes."
+);
+
+create_exception!(
+    yantrikdb,
+    BatchDeferredDuringReembed,
+    PyRuntimeError,
+    "A re-embedding cutover is in flight; the WHOLE batch was deferred and \
+     nothing was written. Retryable: reissue the identical batch. Fully \
+     keyed duplicate batches resolve without deferring."
+);
+
+create_exception!(
+    yantrikdb,
+    IdempotencyConflict,
+    PyRuntimeError,
+    "The same idempotency key was already committed with a DIFFERENT \
+     payload. The first write's content stands; the message carries the \
+     existing rid. Not retryable as-is: change the key or the payload."
+);
+
+create_exception!(
+    yantrikdb,
+    InvalidIdempotencyKey,
+    PyRuntimeError,
+    "The idempotency key is empty, whitespace-only, or longer than 512 \
+     bytes. Not retryable as-is: fix the key."
+);
+
+create_exception!(
+    yantrikdb,
+    ProvenanceInconsistent,
+    PyRuntimeError,
+    "The write's declared provenance is internally inconsistent (e.g. \
+     source=inference claiming kind=fact without confirmation/verification) \
+     and the anti-laundering gate refused it. Not retryable as-is: fix the \
+     declaration or raise the confidence basis."
+);

--- a/crates/yantrikdb-python/src/py_errors.rs
+++ b/crates/yantrikdb-python/src/py_errors.rs
@@ -49,9 +49,14 @@ create_exception!(
     yantrikdb,
     IdempotencyConflict,
     PyRuntimeError,
-    "The same idempotency key was already committed with a DIFFERENT \
-     payload. The first write's content stands; the message carries the \
-     existing rid. Not retryable as-is: change the key or the payload."
+    "An idempotency claim could not resolve to a hit. USUALLY: the same key \
+     was already committed with a DIFFERENT payload — the first write's \
+     content stands, the message carries the existing rid, and the fix is to \
+     change the key or the payload (not retryable as-is). The variant also \
+     covers anomalous claim states (a crashed prior attempt, an \
+     engine-invariant violation), some of which the message marks as \
+     retryable — read it before deciding, but branch on this TYPE to know \
+     you are in claim-resolution territory at all."
 );
 
 create_exception!(
@@ -60,6 +65,15 @@ create_exception!(
     PyRuntimeError,
     "The idempotency key is empty, whitespace-only, or longer than 512 \
      bytes. Not retryable as-is: fix the key."
+);
+
+create_exception!(
+    yantrikdb,
+    RecallContended,
+    PyRuntimeError,
+    "A recall lost a bounded read-contention race (writer-priority lock \
+     tuning). Nothing is wrong with the query. Retryable: back off briefly \
+     and reissue the identical recall."
 );
 
 create_exception!(

--- a/src/yantrikdb/__init__.py
+++ b/src/yantrikdb/__init__.py
@@ -7,6 +7,7 @@ from yantrikdb._yantrikdb_rust import (
     IdempotencyConflict,
     InvalidIdempotencyKey,
     ProvenanceInconsistent,
+    RecallContended,
     TenantManager,
     YantrikDB,
 )
@@ -39,4 +40,5 @@ __all__ = [
     "IdempotencyConflict",
     "InvalidIdempotencyKey",
     "ProvenanceInconsistent",
+    "RecallContended",
 ]

--- a/src/yantrikdb/__init__.py
+++ b/src/yantrikdb/__init__.py
@@ -1,11 +1,42 @@
 """YantrikDB — A Cognitive Memory Engine for Persistent AI Systems."""
 
-from yantrikdb._yantrikdb_rust import YantrikDB, TenantManager
+from yantrikdb._yantrikdb_rust import (
+    BatchDeferredDuringReembed,
+    Backpressure,
+    CorrectionDeferredDuringReembed,
+    IdempotencyConflict,
+    InvalidIdempotencyKey,
+    ProvenanceInconsistent,
+    TenantManager,
+    YantrikDB,
+)
 from yantrikdb.consolidate import consolidate
 from yantrikdb.triggers import check_all_triggers
 
 # Backward-compat alias
 AIDB = YantrikDB
 
-__version__ = "0.2.4"
-__all__ = ["YantrikDB", "AIDB", "TenantManager", "consolidate", "check_all_triggers"]
+# The single source of the version is the installed distribution metadata
+# (pyproject.toml). A hardcoded string here drifted to "0.2.4" while the
+# wheel shipped 0.9.4 — the exact version-string lie the v0.10 release
+# coordination flagged (yantrikdb-mcp friction 1).
+try:
+    from importlib.metadata import version as _dist_version
+
+    __version__ = _dist_version("yantrikdb")
+except Exception:  # pragma: no cover - source tree without installed dist
+    __version__ = "0.0.0+unknown"
+
+__all__ = [
+    "YantrikDB",
+    "AIDB",
+    "TenantManager",
+    "consolidate",
+    "check_all_triggers",
+    "Backpressure",
+    "BatchDeferredDuringReembed",
+    "CorrectionDeferredDuringReembed",
+    "IdempotencyConflict",
+    "InvalidIdempotencyKey",
+    "ProvenanceInconsistent",
+]

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -100,3 +100,59 @@ class TestBatchIdempotency:
             [{**common, "embedding": _vec(3.0), "idempotency_key": "x-1"}]
         )
         assert rids == [rid]
+
+class TestTypedExceptions:
+    """v0.10 (yantrikdb-mcp friction 2): actionable errors cross the pyo3
+    boundary as typed exception classes — hosts branch on type, never on
+    message text. Each subclasses RuntimeError, so pre-v0.10 handlers keep
+    working unchanged."""
+
+    def test_idempotency_conflict_is_typed(self, db):
+        import yantrikdb as y
+
+        db.record(text="first", embedding=_vec(1.0), idempotency_key="te-1")
+        with pytest.raises(y.IdempotencyConflict) as exc_info:
+            db.record(text="DIFFERENT", embedding=_vec(2.0), idempotency_key="te-1")
+        # Back-compat: still a RuntimeError.
+        assert isinstance(exc_info.value, RuntimeError)
+        # The message carries the existing rid for the caller's fetch-and-decide.
+        assert "existing rid" in str(exc_info.value)
+
+    def test_invalid_key_is_typed(self, db):
+        import yantrikdb as y
+
+        with pytest.raises(y.InvalidIdempotencyKey):
+            db.record(text="x", embedding=_vec(3.0), idempotency_key="   ")
+
+    def test_provenance_refusal_is_typed(self, db):
+        import yantrikdb as y
+
+        with pytest.raises(y.ProvenanceInconsistent):
+            db.record(
+                text="laundered",
+                embedding=_vec(4.0),
+                source="inference",
+                metadata={"kind": "fact"},
+            )
+
+    def test_typed_classes_are_exported(self):
+        import yantrikdb as y
+
+        for name in (
+            "Backpressure",
+            "BatchDeferredDuringReembed",
+            "CorrectionDeferredDuringReembed",
+            "IdempotencyConflict",
+            "InvalidIdempotencyKey",
+            "ProvenanceInconsistent",
+        ):
+            cls = getattr(y, name)
+            assert issubclass(cls, RuntimeError), name
+
+    def test_version_is_not_the_stale_hardcode(self):
+        import yantrikdb as y
+
+        # The old hardcoded "0.2.4" drifted from the real wheel version —
+        # the version-string lie. It must now come from dist metadata.
+        assert y.__version__ != "0.2.4"
+

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -145,6 +145,7 @@ class TestTypedExceptions:
             "IdempotencyConflict",
             "InvalidIdempotencyKey",
             "ProvenanceInconsistent",
+            "RecallContended",
         ):
             cls = getattr(y, name)
             assert issubclass(cls, RuntimeError), name


### PR DESCRIPTION
Requested by yantrikdb-mcp during v0.10 release validation (their friction 2): every engine error crossed the pyo3 boundary as a bare RuntimeError, so any host implementing the documented retry semantics had to string-match message text — brittle by construction.

sol-ACCEPTed after 2 rounds (r1 found RecallContended missing — it was in the MCP's original ask — and a docstring overstating IdempotencyConflict's semantics).

## What
- New `py_errors` module: **Backpressure, CorrectionDeferredDuringReembed, BatchDeferredDuringReembed, IdempotencyConflict, InvalidIdempotencyKey, ProvenanceInconsistent, RecallContended** — each SUBCLASSES RuntimeError (pre-v0.10 `except RuntimeError:` handlers keep working; purely additive), each with a docstring stating whether and how it is retryable.
- `map_err` routes the matching engine variants to the typed classes; everything else stays RuntimeError.
- Exported from the package root (`yantrikdb.IdempotencyConflict` …).
- `__version__` now reads distribution metadata — the hardcoded '0.2.4' had drifted from the 0.9.4 wheel (the version-string-lie class, instance two from the same validation round).

## Evidence
5 new pytest cases proven to fail on the pre-fix wheel (bare RuntimeError, missing exports, stale __version__); full python suite **245 green** against the rebuilt wheel; core crate untouched.

Rides the v0.10 train pre-tag so hosts implement against the final error surface instead of shipping regex-matchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)