### PR TITLE
release: v0.10.0

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.9.4"
+version = "0.10.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.9.4"
+version = "0.10.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.9.4"
+version = "0.10.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
The v0.10.0 release bump — the coordinated train's core leg. Everything in v0.10 is already merged and validated; this PR only makes the version string true.

## The release
- **Item 4 (Reliability): COMPLETE.** All 13 trace contracts implemented (T06 anti-laundering-chokepoint and T07 repetition-not-corroboration flipped in #106 with dedicated contract-anchor tests).
- **Durable idempotency (T07)**: record/record_text/record_batch keys, claim-first transactions, cross-surface digests, typed conflicts.
- **The write-path hardening campaign**: reserve→commit→publish on every writer (#101 batch, #105 record_with_rid), RAII savepoints, ops atomic with rows (#103 closed #94), the unrepairable-orphan crash window killed (kill-proven).
- **Typed python exceptions** (#107): branch on type, not regex.
- **BEHAVIORAL, flag for consumers**: recall excludes superseded results by default (`include_superseded` opt-in); record_text/record_batch now normalize blank namespaces like record() always did.

## Cross-workspace validation (the train)
- yantrikdb-server: PASS, 2,118 tests against the RC rev; wire-format v2 (their #52) merged as the Item-3 determinism precondition.
- yantrikdb-mcp: PASS twice (144/144 + typed-error surface re-validation); consumer-simulation gate green.
- Post-tag legs contracted: server widens pin + populates wire embedding + include_superseded wiring; MCP widens pin + remember(idempotency_key=) + six contract cases. CT128 dogfood deploys last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)