### PR TITLE
release: v0.10.1 — materializer idle-scan fix

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.10.0"
+version = "0.10.1"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump for the v0.10.1 patch release. The fix itself merged as 43d5d1d (#114); this makes the version string true.

**What ships:** #113 — the materializer drain poll scanned the entire oplog on every tick, because `idx_oplog_pending` was added in a migration and never in `SCHEMA_SQL`, so every database created since v24 never had one.

**Measured by the reporting consumer** on the affected 32-logical-CPU box (6 engines, median of 3x6s after quiesce):

| records | before | after | |
|---|---|---|---|
| 500 | 1.25% of machine | 0.22% | 5.7x |
| 2,000 | 4.65% | 0.24% | 19x |
| 6,000 | **34.41%** | **0.14%** | **246x** |

Curve flat across a 12x history increase; Backpressure-at-depth events **7 to 0**.

**Schema 37 to 38**, additive. Forward-only stamping unchanged — older binaries still open v38 databases. Consumers with an exact-version assertion should relax it to `>=` (ledger already broadcast pre-tag).

Gates: `cargo fmt --check` zero drift, pylint 10.00/10, 1759 lib tests. Shipping wheel verified by content — `__version__` 0.10.1, schema stamped 38, drain plan `SCAN oplog USING INDEX idx_oplog_pending_ordered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)