### PR TITLE
fix(embedder): fingerprint changed with the build platform, not the model

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Bundled embedder assets are compiled into the binary with
+# `include_bytes!` and hashed byte-for-byte by
+# `bundled_embedder_fingerprint()`, which is the identity a pack is
+# checked against at mount time.
+#
+# Two of them are .json, so git treated them as text and normalised line
+# endings on checkout. On a Windows runner (autocrlf=true) that produced
+# CRLF, on Linux and macOS LF — same model, same weights, byte-identical
+# output vectors, and a *different* fingerprint. The published v0.11.0
+# Windows wheel therefore refused to mount every pack in the marketplace
+# with PackEmbedderMismatch, while the Linux and macOS wheels of the same
+# release accepted them.
+#
+# `-text` disables all EOL conversion for these paths, in both
+# directions, on every platform. The fingerprint is now a property of the
+# repository rather than of the machine that ran the build.
+crates/yantrikdb-core/assets/** -text
+
+# The same reasoning applies to any file whose bytes are hashed or
+# signed rather than parsed. Pack fixtures are sealed SQLite databases.
+*.ydbpack -text
+*.safetensors -text

--- a/crates/yantrikdb-core/src/embedder/default.rs
+++ b/crates/yantrikdb-core/src/embedder/default.rs
@@ -264,6 +264,42 @@ mod tests {
         assert_eq!(BUNDLED_EMBEDDER_DIM, 64);
     }
 
+    /// The fingerprint must be a property of the repository, not of the
+    /// machine that ran the build.
+    ///
+    /// v0.11.0 shipped a Windows wheel whose fingerprint differed from
+    /// its own Linux and macOS wheels. Two of the bundled assets are
+    /// `.json`, git treated them as text, and the Windows runner checked
+    /// them out with CRLF. The JSON parses identically either way — same
+    /// model, same weights, byte-identical output vectors — but
+    /// `bundled_embedder_fingerprint()` hashes raw bytes, so the Windows
+    /// build disagreed with every other build about which embedder it
+    /// had, and refused to mount every published pack with
+    /// `PackEmbedderMismatch`.
+    ///
+    /// `.gitattributes` marks the asset directory `-text` to prevent the
+    /// conversion. This asserts the invariant directly, because a
+    /// `.gitattributes` entry is easy to lose in a merge and its absence
+    /// is silent on the platform that does not convert.
+    #[test]
+    fn bundled_json_assets_have_no_crlf() {
+        for (name, bytes) in [
+            ("tokenizer.json", POTION_2M_TOKENIZER),
+            ("config.json", POTION_2M_CONFIG),
+            ("modules.json", POTION_2M_MODULES),
+        ] {
+            assert!(
+                !bytes.windows(2).any(|w| w == b"\r\n"),
+                "{name} was compiled in with CRLF line endings. The model still \
+                 works, which is what makes this dangerous: the fingerprint \
+                 changes, so packs built against a build of this crate on \
+                 another platform will be refused at mount with \
+                 PackEmbedderMismatch. Check that .gitattributes still marks \
+                 crates/yantrikdb-core/assets/** as -text, then re-checkout."
+            );
+        }
+    }
+
     #[test]
     fn embed_returns_64_dim_vector() {
         let e = BundledEmbedder::new();


### PR DESCRIPTION
**v0.11.0's Windows wheel cannot mount a single pack in the marketplace.**

```
PackEmbedderMismatch: pack was built with embedder blake3:85766a09…,
this database's vectors were built with blake3:f1524499…
(both 64-dimensional, which is why this cannot be caught later)
```

The vectors are identical. Embedding the same sentence under both builds returns
the same 64 floats to every printed digit:

```
local build   [-0.293654, -0.158944, 0.104964, -0.222695, 0.058242, 0.03325]
PyPI wheel    [-0.293654, -0.158944, 0.104964, -0.222695, 0.058242, 0.03325]
```

Same model, same weights, same output — different fingerprint.

## Cause

Two of the four bundled embedder assets are `.json`. With no `.gitattributes`,
git treats them as text and normalises line endings on checkout, so
`windows-latest` compiled CRLF while the Linux and macOS runners compiled LF.
`bundled_embedder_fingerprint()` hashes the raw `include_bytes!` blobs, so the
Windows wheel disagreed with its own sibling wheels from the same release.

Reproduced exactly, in both directions, by hashing the assets with the same
payload construction the Rust code uses:

| assets | fingerprint | which build |
|---|---|---|
| LF | `blake3:85766a09…` | local build, and **every pack in the catalog** |
| CRLF | `blake3:f1524499…` | the published PyPI **Windows** wheel |

The identity guard was working correctly on a build that was not reproducible.
It refused rather than returning plausible nonsense across mismatched embedding
spaces — which is the behaviour we want, aimed at a false mismatch.

## Fix

`.gitattributes` marks `crates/yantrikdb-core/assets/**` as `-text`, disabling
conversion in both directions on every platform. Also `*.ydbpack` and
`*.safetensors`, on the same principle: any file whose bytes are hashed or
signed rather than parsed must never be normalised.

`bundled_json_assets_have_no_crlf` asserts the invariant on the compiled-in
bytes rather than trusting the attributes file. A `.gitattributes` entry is easy
to lose in a merge, and its absence is silent on the platform that does not
convert — the failure only reaches the user on the other one.

## How it was found

Installing the published wheel into a clean venv, with no `PYTHONPATH`, and
mounting a pack downloaded from the live catalog. Nothing in the build or test
loop had ever done that: every script ran with `PYTHONPATH=src`, which shadows
site-packages with the local build. That is the same blind spot that let the
pack API go unreleased for the whole build.

Needs a 0.11.1 to reach users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)