### PR TITLE
release: v0.11.1 — Windows wheel could not mount any pack

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.11.0"
+version = "0.11.1"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump only — the fix landed in #120.

## Why this is urgent

The 0.11.0 **Windows** wheel refuses every pack in the marketplace:

```
PackEmbedderMismatch: pack was built with embedder blake3:85766a09…,
this database's vectors were built with blake3:f1524499…
```

Linux and macOS wheels from the same release are unaffected.

The vectors were never wrong — the same sentence embeds to the same 64 floats
under both builds. Two of the four bundled embedder assets are `.json` and the
repository had no `.gitattributes`, so git normalised line endings on checkout:
`windows-latest` compiled CRLF, Linux and macOS compiled LF, and the fingerprint
over those raw bytes disagreed across wheels of the same release.

| assets | fingerprint | which build |
|---|---|---|
| LF | `blake3:85766a09…` | Linux, macOS, and every published pack |
| CRLF | `blake3:f1524499…` | the 0.11.0 Windows wheel |

## For users

Upgrade and already-downloaded packs mount. No rebuild, no re-download — the
packs were always built against the LF fingerprint, which is now what every
platform produces.

## Verification

#120's `bundled_json_assets_have_no_crlf` runs on the `windows-latest` runner —
the same one that produced the broken wheel — so the fix validates itself on the
affected platform rather than on the platforms that were already fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)