### PR TITLE
build: abi3 wheels — one per platform instead of one per interpreter

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -73,7 +73,15 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist -i python3.10 python3.11 python3.12 python3.13 python3.14
+          # **abi3.** One wheel per platform, not one per interpreter.
+          # `pyo3/abi3-py310` links against CPython's stable ABI, so a
+          # single `cp310-abi3` wheel runs on 3.10 through 3.14 and every
+          # future 3.x — which is also why no `-i` list appears here any
+          # more. Building five interpreters produced 25 wheels at ~20 MB
+          # a release, and v0.11.1 hit PyPI's 10 GB project limit
+          # mid-upload and published a half-release (cp310/cp311 only)
+          # that left most users on the previous, broken build.
+          args: --release --out dist
           sccache: "true"
 
       - name: Upload wheels

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 yantrikdb-core = { path = "../yantrikdb-core", package = "yantrikdb" }
-pyo3 = { version = "0.28.3", features = ["extension-module", "multiple-pymethods"] }
+pyo3 = { version = "0.28.3", features = ["extension-module", "multiple-pymethods", "abi3-py310"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde_json = "1"
 


### PR DESCRIPTION
## Why

v0.11.1 hit PyPI's 10 GB project limit **mid-upload** and published a
half-release — cp310 and cp311 only, 10 of 26 files. Everyone on Python 3.12+
kept resolving to 0.11.0, which was the build with the broken Windows embedder
fingerprint. The fix for a release-blocking bug did not reach the people it was
for.

Recovery required deleting 23 old releases through the PyPI **web UI**, because
Warehouse has no delete API. That is not a process anyone should have to repeat.

## What was consuming it

Redundancy. The matrix built five interpreters across five platforms, so every
release published 25 wheels at ~20 MB that differ only in which CPython they
link against.

`pyo3/abi3-py310` links CPython's stable ABI instead. A single `cp310-abi3`
wheel per platform runs on 3.10 through 3.14 — and on every future 3.x, so new
Python releases stop requiring a rebuild.

| | files | size |
|---|---|---|
| before | 26 | ~490 MB |
| after | 6 | ~101 MB |

At 8.60 GB used, that turns ~3 remaining releases of headroom into ~14.

## Verification

The claim abi3 makes is that one binary runs on many interpreters, so that is
what I tested — not that it builds.

Built a wheel on **3.13**, then ran it on **3.13, 3.12 and 3.11**, each time
mounting `yantrik/wordpress-expert@0.2.0` downloaded from the live marketplace
and recalling from it:

```
runs on Python 3.13: v0.11.1  mounted yantrik/wordpress-expert@0.2.0
runs on Python 3.12: v0.11.1  mounted yantrik/wordpress-expert@0.2.0
runs on Python 3.11: v0.11.1  mounted yantrik/wordpress-expert@0.2.0
```

`multiple-pymethods` turned out to be compatible with abi3, so the feature set
is unchanged.

- 1,767 rust tests, 22 pack tests, 246 python tests — all pass against the abi3 build
- Wheel is `yantrikdb-0.11.1-cp310-abi3-win_amd64.whl`, 20.2 MB

## Cost

Real but small: stable-ABI calls forgo some version-specific fast paths. Worth
it against a release process that has already failed once on storage and gets
more expensive with every Python version added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)