### PR TITLE
release: v0.11.2 — abi3 wheels

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.11.1"
+version = "0.11.2"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump only — the change landed in #122.

First release published as **abi3**: one `cp310-abi3` wheel per platform rather
than one per interpreter.

| | files | size |
|---|---|---|
| 0.11.1 | 26 | ~490 MB |
| 0.11.2 | 6 | ~101 MB |

This is what stops the PyPI 10 GB wall recurring — the wall that broke the
0.11.1 publish mid-upload and left everyone on Python 3.12+ resolving to the
build with the broken Windows fingerprint. It also means a new CPython release
no longer requires rebuilding and republishing.

Verified in #122 by running a wheel built on 3.13 against 3.13, 3.12 and 3.11,
each mounting a pack downloaded from the live marketplace.

## Post-merge

Tag `v0.11.2`, then `gh release create`. Worth watching the publish run's file
count: it should upload 6 artifacts, not 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)