### PR TITLE
feat: historical import, caller-supplied consolidation, a rid point-read, and pack namespace (0.14.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,22 @@ db.stale(days=14)    # high-importance memories not accessed recently
 db.upcoming(days=7)  # memories with approaching deadlines
 ```
 
+**Importing history.** `created_at` (epoch seconds) records an event at the
+time it *happened* rather than the time it was loaded — so a bulk import
+keeps its real timeline and every temporal surface stays meaningful:
+
+```python
+db.record("joined the observatory team", created_at=1_600_000_000.0)
+db.record_batch([{"text": "...", "created_at": ts} for ts in anchors])
+
+db.recall_as_of(march, query="where do they work")  # what was true then
+```
+
+Without it, every imported record shares the ingest wall-clock: decay and
+recency become insertion-order noise, and `recall_as_of` / `time_window`
+filter on a timeline that never existed. Omit it and the engine stamps
+`now()`, exactly as before.
+
 ## Full API
 
 | Operation | Methods |

--- a/crates/yantrikdb-core/benches/engine_bench.rs
+++ b/crates/yantrikdb-core/benches/engine_bench.rs
@@ -272,6 +272,7 @@ fn bench_record_batch(c: &mut Criterion) {
             let (db, _workers) = open_db_with_workers(dim);
             let inputs: Vec<RecordInput> = (0..500)
                 .map(|i| RecordInput {
+                    created_at: None,
                     idempotency_key: None,
                     text: format!("batch memory {i}"),
                     memory_type: "episodic".to_string(),
@@ -667,6 +668,7 @@ fn bench_record_batch_scaled(c: &mut Criterion) {
                     let (db, _workers) = open_db_with_workers(dim);
                     let inputs: Vec<RecordInput> = (0..bs)
                         .map(|i| RecordInput {
+                            created_at: None,
                             idempotency_key: None,
                             text: format!("batch memory {i}"),
                             memory_type: "episodic".to_string(),

--- a/crates/yantrikdb-core/src/base/bench_utils.rs
+++ b/crates/yantrikdb-core/src/base/bench_utils.rs
@@ -65,6 +65,7 @@ pub fn seed_db_scaled(db: &YantrikDB, n: usize, dim: usize, with_graph: bool) {
                 let entity_idx = i % entity_names.len();
                 RecordInput {
                     idempotency_key: None,
+                    created_at: None,
                     text: format!(
                         "Memory {} about topic {} involving {} in context {}",
                         i,

--- a/crates/yantrikdb-core/src/base/payload_digest.rs
+++ b/crates/yantrikdb-core/src/base/payload_digest.rs
@@ -52,9 +52,20 @@
 //!   different matter and IS included: it round-trips exactly, and two writes
 //!   with the same text but different vectors recall differently, so they are
 //!   different writes.
-//! - `rid`, `op_id`, `created_at`, `updated_at`, HLC — per-attempt values. Any
-//!   of them in the digest would make EVERY retry a fresh payload and defeat the
-//!   whole mechanism.
+//! - `rid`, `op_id`, ENGINE-STAMPED `created_at`/`updated_at`, HLC — per-attempt
+//!   values. Any of them in the digest would make EVERY retry a fresh payload
+//!   and defeat the whole mechanism. The CALLER-SUPPLIED `created_at` (the
+//!   historical-import event time on `record`/`record_text`/`record_batch`) is
+//!   the opposite case and IS included when present: it round-trips exactly
+//!   over JSON/PyO3 like every other caller scalar, and two writes differing
+//!   only in event time decay and `recall_as_of` differently — they are
+//!   different writes. It is fed ONLY when `Some`, appended after every v1
+//!   field, so an absent `created_at` digests byte-for-byte as v1 did —
+//!   pre-upgrade claims keep matching their retries with no version bump.
+//!   (Unambiguous despite the module's presence-tag style: every prior field
+//!   is self-delimiting, so a stream either ends after the embedding or
+//!   continues with the created_at tag — no two field assignments collide.
+//!   `absent_created_at_digest_is_byte_identical_to_v1` pins the claim.)
 //! - `route` ('sync' | 'queued') — tracked as its own column on the claim, so
 //!   the same logical write does not conflict with itself for being queued.
 //! - `kind` — a generated column derived from metadata, already covered.
@@ -124,6 +135,10 @@ pub struct PayloadView<'a> {
     /// The CALLER-SUPPLIED embedding. `None` for `record_text`, where the engine
     /// generates the vector and idempotency must be decided before embedding.
     pub embedding: Option<&'a [f32]>,
+    /// The CALLER-SUPPLIED event time (historical import). `None` = the engine
+    /// stamps `now()` per attempt, which must stay OUT of the digest — see the
+    /// module docs for both halves of that rule and the v1-compat feed order.
+    pub created_at: Option<f64>,
 }
 
 impl<'a> PayloadView<'a> {
@@ -151,6 +166,7 @@ impl<'a> PayloadView<'a> {
                 PayloadVariant::Record => Some(&input.embedding),
                 PayloadVariant::RecordText => None,
             },
+            created_at: input.created_at,
         }
     }
 }
@@ -161,6 +177,10 @@ const T_NONE: u8 = 0;
 const T_SOME: u8 = 1;
 const T_NUM: u8 = 10;
 const T_NAN: u8 = 11;
+/// Tag for the trailing caller-supplied `created_at` — fed ONLY when present
+/// (v1 byte-compat for the absent case; module docs). Distinct from every
+/// other tag so the suffix can never read as a continuation of a prior field.
+const T_CREATED_AT: u8 = 30;
 const J_NULL: u8 = 20;
 const J_BOOL: u8 = 21;
 const J_NUM_I64: u8 = 22;
@@ -313,6 +333,13 @@ pub fn payload_digest(v: &PayloadView<'_>) -> [u8; 32] {
     feed_opt_str(&mut h, v.emotional_state);
     feed_json(&mut h, v.metadata);
     feed_embedding(&mut h, v.embedding);
+    // Caller-supplied event time: fed ONLY when present, so an absent
+    // created_at digests byte-for-byte as v1 — the deliberate deviation from
+    // the module's always-tag-presence style, argued in the module docs.
+    if let Some(ts) = v.created_at {
+        h.update(&[T_CREATED_AT]);
+        feed_f64(&mut h, ts);
+    }
     *h.finalize().as_bytes()
 }
 
@@ -336,7 +363,44 @@ mod tests {
             emotional_state: None,
             metadata,
             embedding: None,
+            created_at: None,
         }
+    }
+
+    #[test]
+    fn absent_created_at_digest_is_byte_identical_to_v1() {
+        // THE compat pin for the conditional created_at feed (module docs):
+        // this hex was computed by the v1 construction BEFORE the created_at
+        // field existed. If a refactor ever makes an absent created_at feed
+        // bytes (e.g. "cleaning up" the conditional into a presence tag),
+        // every stored pre-upgrade claim stops matching its retries — this
+        // fails loudly instead.
+        let m = json!({"a": 1});
+        let d = payload_digest(&view("golden pin text", &m));
+        let hex: String = d.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(
+            hex, "b66864879e42df48f1622f57d7c8b6bcef643357fb0deb318252e176fee1500c",
+            "absent created_at no longer digests as v1 — stored claims from \
+             pre-created_at engines would conflict on honest retries"
+        );
+    }
+
+    #[test]
+    fn created_at_is_digested_when_present() {
+        let m = json!({});
+        let base = payload_digest(&view("t", &m));
+        let mut with_ts = view("t", &m);
+        with_ts.created_at = Some(1_700_000_000.0);
+        let d1 = payload_digest(&with_ts);
+        assert_ne!(base, d1, "created_at not covered");
+        let mut other_ts = view("t", &m);
+        other_ts.created_at = Some(1_700_000_001.0);
+        assert_ne!(
+            d1,
+            payload_digest(&other_ts),
+            "two event times digested equal — a re-dated write would be \
+             swallowed as a retry"
+        );
     }
 
     #[test]
@@ -554,6 +618,7 @@ mod tests {
             domain: "general".to_string(),
             source: "user".to_string(),
             emotional_state: None,
+            created_at: None,
         };
         let a = mk(vec![1.0, 0.0]);
         let b = mk(vec![0.0, 1.0]);

--- a/crates/yantrikdb-core/src/base/scoring.rs
+++ b/crates/yantrikdb-core/src/base/scoring.rs
@@ -3,17 +3,27 @@
 /// Matches the Python implementation exactly (engine.py:246-263).
 
 /// Compute the decay score: I(t) = importance * 2^(-t / half_life)
+///
+/// Negative `elapsed` clamps to 0 (score = full `importance`). Reachable
+/// since caller-supplied `created_at`/event time (historical import): a
+/// future-dated record must score as "brand new", not as `2^(+x)` — an
+/// unbounded amplifier that would rebuild the recency wall in the other
+/// direction. Same clamp `cognition::temporal::recency_relevance` has
+/// always applied to its age.
 pub fn decay_score(importance: f64, half_life: f64, elapsed: f64) -> f64 {
     if half_life > 0.0 {
-        importance * f64::powf(2.0, -elapsed / half_life)
+        importance * f64::powf(2.0, -elapsed.max(0.0) / half_life)
     } else {
         0.0
     }
 }
 
 /// Compute the recency score: exp(-age / (7 * 86400))
+///
+/// Negative `age` clamps to 0 (score = 1.0, the maximum) — see
+/// `decay_score` for why a future-dated record is "new", never amplified.
 pub fn recency_score(age: f64) -> f64 {
-    f64::exp(-age / (7.0 * 86400.0))
+    f64::exp(-age.max(0.0) / (7.0 * 86400.0))
 }
 
 /// Compute the valence boost: 1.0 + 0.3 * |valence|

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -583,6 +583,17 @@ pub struct RecordInput {
     /// the same key with a DIFFERENT payload fails the WHOLE batch with a
     /// typed `IdempotencyConflict` — batches stay all-or-nothing on failure.
     pub idempotency_key: Option<String>,
+    /// Caller-supplied event time in epoch seconds (historical import).
+    /// `None` = the engine stamps `now()` — byte-for-byte the pre-field
+    /// behavior. When `Some`, the value lands in `created_at`, `updated_at`,
+    /// AND `last_access` (an imported record was last touched at its event
+    /// time, so decay runs from then, not from the import), feeds the
+    /// replicated op payload verbatim, participates in the idempotency
+    /// digest (a re-dated write is a different write — payload_digest docs),
+    /// and makes `recall_as_of`/`time_window` meaningful on bulk-loaded
+    /// corpora. Precedent: `record_with_rid`'s `created_at_unix_micros` has
+    /// always been caller-supplied on the replication path.
+    pub created_at: Option<f64>,
 }
 
 // ── Conflict types (V2) ──

--- a/crates/yantrikdb-core/src/cognition/consolidate.rs
+++ b/crates/yantrikdb-core/src/cognition/consolidate.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use rusqlite::OptionalExtension;
+
 use crate::engine::YantrikDB;
 use crate::error::Result;
 use crate::serde_helpers::{deserialize_f32, serialize_f32};
@@ -142,6 +144,128 @@ pub fn extractive_summary(memories: &[MemoryWithEmbedding]) -> String {
         parts.extend(additional);
         parts.join(" | ")
     }
+}
+
+/// Consolidate an explicit cluster using CALLER-SUPPLIED text.
+///
+/// The default [`consolidate`] path writes [`extractive_summary`] (every
+/// cluster text joined with `" | "`) carrying [`mean_embedding`] — the mean
+/// of the members' vectors. Measured on BEAM (2026-08-11): that costs
+/// accuracy, and the mechanism is EMBEDDING DILUTION rather than lost
+/// content. Nothing is dropped — all N texts survive in the join — but N
+/// precise vectors collapse into one average that matches no specific query
+/// well, and when it does hit it drags N chunks of text into the answerer's
+/// context budget.
+///
+/// This path exists so a caller can supply a real synthesis (e.g. from a
+/// small local model) instead. The crucial difference is not the prose: it
+/// is that the new memory is embedded FROM ITS OWN TEXT via the engine's
+/// embedder, so the vector describes what the record actually says.
+///
+/// Bookkeeping is identical to [`consolidate`] — the same entity transfer,
+/// `consolidation_members` CRDT rows, source marking, and oplog entry — so
+/// the two paths cannot drift. The caller owns only the text.
+///
+/// `embedding`: `None` embeds `text` with the ENGINE's embedder. Callers
+/// whose embedder lives outside the engine (the Python binding's
+/// `set_embedder` path, where the engine itself has none) pass the vector
+/// they computed for `text`. Either way the vector describes THIS TEXT —
+/// that is the contract, and it is what distinguishes this path from the
+/// cluster-mean default.
+///
+/// Refuses an empty cluster, unknown rids, and members already consolidated
+/// (double-consolidating would orphan the first consolidation's members).
+pub fn consolidate_cluster(
+    db: &YantrikDB,
+    source_rids: &[String],
+    text: &str,
+    embedding: Option<&[f32]>,
+) -> Result<serde_json::Value> {
+    if source_rids.is_empty() {
+        return Err(crate::error::YantrikDbError::InvalidInput(
+            "consolidate_cluster: source_rids is empty".into(),
+        ));
+    }
+    if text.trim().is_empty() {
+        return Err(crate::error::YantrikDbError::InvalidInput(
+            "consolidate_cluster: text is empty — the caller owns the synthesis".into(),
+        ));
+    }
+    if let Some(v) = embedding {
+        crate::validate::validate_embedding("consolidate_cluster", v, db.embedding_dim())?;
+    }
+    let members = load_cluster_members(db, source_rids)?;
+    commit_consolidation(db, &members, text, embedding.map(|v| v.to_vec()))
+}
+
+/// Load the named memories, refusing anything that would make the
+/// consolidation incoherent. Shared by [`consolidate_cluster`].
+fn load_cluster_members(
+    db: &YantrikDB,
+    source_rids: &[String],
+) -> Result<Vec<MemoryWithEmbedding>> {
+    let mut out = Vec::with_capacity(source_rids.len());
+    for rid in source_rids {
+        let row: Option<(String, String, f64, f64, f64, f64, String, String, String)> = {
+            let conn = db.conn();
+            conn.query_row(
+                "SELECT type, text, created_at, importance, valence, half_life, \
+                 metadata, namespace, consolidation_status \
+                 FROM memories WHERE rid = ?1",
+                rusqlite::params![rid],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                        r.get(6)?,
+                        r.get(7)?,
+                        r.get(8)?,
+                    ))
+                },
+            )
+            .optional()?
+        };
+        let (
+            memory_type,
+            stored_text,
+            created_at,
+            importance,
+            valence,
+            half_life,
+            meta,
+            ns,
+            status,
+        ) = row.ok_or_else(|| {
+            crate::error::YantrikDbError::NotFound(format!(
+                "consolidate_cluster: memory {rid} not found"
+            ))
+        })?;
+        if status != "active" {
+            return Err(crate::error::YantrikDbError::InvalidInput(format!(
+                "consolidate_cluster: memory {rid} is '{status}', not active — \
+                 consolidating it again would orphan the first consolidation's members"
+            )));
+        }
+        out.push(MemoryWithEmbedding {
+            rid: rid.clone(),
+            memory_type,
+            text: db.decrypt_text(&stored_text)?,
+            embedding: Vec::new(), // unused on this path: the text is re-embedded
+            created_at,
+            importance,
+            valence,
+            half_life,
+            last_access: created_at,
+            metadata: serde_json::from_str(&db.decrypt_text(&meta)?)
+                .unwrap_or_else(|_| serde_json::json!({})),
+            namespace: ns,
+        });
+    }
+    Ok(out)
 }
 
 /// Compute the mean embedding of a set of memories.
@@ -359,16 +483,44 @@ pub fn consolidate(
     }
 
     let mut results = Vec::new();
-    let ts = crate::time::now_secs();
-
     for cluster in &clusters {
-        let source_rids: Vec<String> = cluster.iter().map(|m| m.rid.clone()).collect();
-
-        // 1. Generate summary
+        // The default path keeps its historical behaviour: extractive join
+        // carrying the cluster's MEAN embedding. `consolidate_cluster` is the
+        // opt-in alternative for callers supplying their own synthesis.
         let summary_text = extractive_summary(cluster);
-
-        // 2. Compute mean embedding
         let mean_emb = mean_embedding(cluster);
+        results.push(commit_consolidation(
+            db,
+            cluster,
+            &summary_text,
+            Some(mean_emb),
+        )?);
+    }
+
+    Ok(results)
+}
+
+/// Write one consolidated memory for `cluster` and retire its members.
+///
+/// THE single place consolidation bookkeeping lives, so the default
+/// (extractive + mean-embedding) and caller-supplied paths cannot drift:
+/// entity transfer, `consolidation_members` CRDT rows, source marking with
+/// importance decay, scoring-cache invalidation, and the oplog entry.
+///
+/// `embedding`: `Some(v)` uses the caller's vector (the default path passes
+/// the cluster mean, preserving historical behaviour). `None` embeds
+/// `summary_text` with the engine's embedder — which is the point of the
+/// caller-supplied path, since a vector derived from the actual text
+/// retrieves for what the record says rather than for a cluster average.
+fn commit_consolidation(
+    db: &YantrikDB,
+    cluster: &[MemoryWithEmbedding],
+    summary_text: &str,
+    embedding: Option<Vec<f32>>,
+) -> Result<serde_json::Value> {
+    let ts = crate::time::now_secs();
+    {
+        let source_rids: Vec<String> = cluster.iter().map(|m| m.rid.clone()).collect();
 
         // 3. Aggregate importance
         let max_importance = cluster.iter().map(|m| m.importance).fold(0.0f64, f64::max);
@@ -393,20 +545,36 @@ pub fn consolidate(
             .first()
             .map(|m| m.namespace.as_str())
             .unwrap_or("default");
-        let consolidated_rid = db.record(
-            &summary_text,
-            "semantic",
-            consolidated_importance,
-            mean_valence,
-            consolidated_half_life,
-            &meta,
-            &mean_emb,
-            cluster_namespace,
-            0.8,
-            "general",
-            "user",
-            None,
-        )?;
+        let consolidated_rid = match &embedding {
+            Some(emb) => db.record(
+                summary_text,
+                "semantic",
+                consolidated_importance,
+                mean_valence,
+                consolidated_half_life,
+                &meta,
+                emb,
+                cluster_namespace,
+                0.8,
+                "general",
+                "user",
+                None,
+            )?,
+            // Engine-embedded: the vector comes from the synthesis itself.
+            None => db.record_text(
+                summary_text,
+                "semantic",
+                consolidated_importance,
+                mean_valence,
+                consolidated_half_life,
+                &meta,
+                cluster_namespace,
+                0.8,
+                "general",
+                "user",
+                None,
+            )?,
+        };
 
         // 5. Transfer entity relationships
         let mut all_entities = std::collections::HashSet::new();
@@ -453,7 +621,15 @@ pub fn consolidate(
         } // conn lock released before log_op
 
         // 7. Log the operation
-        let emb_hash = blake3::hash(&serialize_f32(&mean_emb)).as_bytes().to_vec();
+        let logged_emb = match &embedding {
+            Some(v) => v.clone(),
+            // Engine-embedded path: hash the stored vector so the oplog entry
+            // still identifies what was written.
+            None => db.embed(summary_text).unwrap_or_default(),
+        };
+        let emb_hash = blake3::hash(&serialize_f32(&logged_emb))
+            .as_bytes()
+            .to_vec();
         db.log_op(
             "consolidate",
             Some(&consolidated_rid),
@@ -471,17 +647,16 @@ pub fn consolidate(
             Some(&emb_hash),
         )?;
 
-        results.push(serde_json::json!({
+        Ok(serde_json::json!({
             "consolidated_rid": consolidated_rid,
             "source_rids": source_rids,
             "cluster_size": cluster.len(),
             "summary": summary_text,
             "importance": consolidated_importance,
             "entities_linked": all_entities.len(),
-        }));
+            "embedded_from_text": embedding.is_none(),
+        }))
     }
-
-    Ok(results)
 }
 
 #[cfg(test)]

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -297,6 +297,84 @@ impl YantrikDB {
         Ok((memories, total))
     }
 
+    /// Fetch one memory by rid, decrypted, or `None` if it does not exist.
+    ///
+    /// The store had no rid point-read: `list_memories` pages and `recall`
+    /// is semantic, so a caller holding a rid — which is what `get_conflicts`,
+    /// `get_edges`, `record_links` and the consolidation APIs all hand back —
+    /// could only resolve it to text by paging the whole namespace. Found
+    /// while wiring LLM conflict resolution, where the conflict record gives
+    /// `memory_a`/`memory_b` as bare rids and the reconciler needs both texts.
+    ///
+    /// Returns the memory regardless of `consolidation_status`: a caller
+    /// naming a specific rid wants that record, not a currency judgement.
+    pub fn get_memory(&self, rid: &str) -> Result<Option<Memory>> {
+        let conn = self.conn();
+        let row = conn
+            .query_row(
+                "SELECT rid, type, text, created_at, importance, valence, half_life, \
+                 last_access, access_count, consolidation_status, storage_tier, \
+                 consolidated_into, metadata, namespace, certainty, domain, source, \
+                 emotional_state, session_id, due_at, temporal_kind \
+                 FROM memories WHERE rid = ?1",
+                rusqlite::params![rid],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, f64>(3)?,
+                        row.get::<_, f64>(4)?,
+                        row.get::<_, f64>(5)?,
+                        row.get::<_, f64>(6)?,
+                        row.get::<_, f64>(7)?,
+                        row.get::<_, i64>(8)?,
+                        row.get::<_, String>(9)?,
+                        row.get::<_, String>(10)?,
+                        row.get::<_, Option<String>>(11)?,
+                        row.get::<_, String>(12)?,
+                        row.get::<_, String>(13)?,
+                        row.get::<_, f64>(14)?,
+                        row.get::<_, String>(15)?,
+                        row.get::<_, String>(16)?,
+                        row.get::<_, Option<String>>(17)?,
+                        row.get::<_, Option<String>>(18)?,
+                        row.get::<_, Option<f64>>(19)?,
+                        row.get::<_, Option<String>>(20)?,
+                    ))
+                },
+            )
+            .optional()?;
+        drop(conn); // decrypt_* must not run under the conn lock (CONCURRENCY.md Rule 4)
+        let Some(row) = row else { return Ok(None) };
+        let text = self.decrypt_text(&row.2)?;
+        let meta_str = self.decrypt_text(&row.12)?;
+        Ok(Some(Memory {
+            rid: row.0,
+            memory_type: row.1,
+            text,
+            created_at: row.3,
+            importance: row.4,
+            valence: row.5,
+            half_life: row.6,
+            last_access: row.7,
+            access_count: row.8 as u32,
+            consolidation_status: row.9,
+            storage_tier: row.10,
+            consolidated_into: row.11,
+            metadata: serde_json::from_str(&meta_str)
+                .unwrap_or(serde_json::Value::Object(Default::default())),
+            namespace: row.13,
+            certainty: row.14,
+            domain: row.15,
+            source: row.16,
+            emotional_state: row.17,
+            session_id: row.18,
+            due_at: row.19,
+            temporal_kind: row.20,
+        }))
+    }
+
     /// Return the head of a chain-shaped namespace — its most recent entry.
     ///
     /// Identity / narrative chains (e.g. a `claude_self_narrative` namespace

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -2063,6 +2063,7 @@ impl YantrikDB {
             source,
             emotional_state,
             None,
+            None,
         )
     }
 
@@ -2083,6 +2084,12 @@ impl YantrikDB {
     /// a cross-surface retry is not the same write.
     ///
     /// `None` is byte-for-byte `record_text()`.
+    ///
+    /// `created_at`: caller-supplied event time in epoch seconds (historical
+    /// import — `RecordInput::created_at` has the full contract). `None`
+    /// stamps `now()`. When `Some`, it joins the RecordText digest: a
+    /// re-dated write decays and `recall_as_of`s differently, so it is a
+    /// different write even under the embedding-excluded variant.
     #[allow(clippy::too_many_arguments)]
     pub fn record_text_with_idempotency(
         &self,
@@ -2098,6 +2105,7 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
         idempotency_key: Option<&str>,
+        created_at: Option<f64>,
     ) -> Result<String> {
         // v0.9.3 contract gate: scalars validated BEFORE calibration mutates
         // the namespace's running distribution. (The embedding is engine-
@@ -2111,6 +2119,11 @@ impl YantrikDB {
                 ("half_life", half_life),
             ],
         )?;
+        // Caller-supplied event time: finite or refused, before the digest,
+        // the probe, and the (slow) embed — record()'s gate, same rationale.
+        if let Some(ts) = created_at {
+            crate::validate::validate_scalars("record_text", &[("created_at", ts)])?;
+        }
         // v0.10 Item 4a.4 anti-laundering gate — before the (slow) embed and
         // any side effect. `record_text` bypasses `record()`, so it gates here
         // too (T06 coverage). A warn-mode Flagged verdict is carried to the
@@ -2180,6 +2193,7 @@ impl YantrikDB {
                     emotional_state,
                     metadata,
                     embedding: None,
+                    created_at,
                 };
                 Some((key, crate::payload_digest::payload_digest(&view)))
             }
@@ -2282,6 +2296,7 @@ impl YantrikDB {
                         emotional_state,
                         gate_verdict,
                         idem,
+                        created_at,
                     );
                 }
             };
@@ -2332,6 +2347,7 @@ impl YantrikDB {
                 emotional_state,
                 gate_verdict,
                 idem,
+                created_at,
             );
         }
     }

--- a/crates/yantrikdb-core/src/engine/pack.rs
+++ b/crates/yantrikdb-core/src/engine/pack.rs
@@ -503,6 +503,14 @@ pub struct PackInfo {
     pub trust: PackTrust,
     pub rows: usize,
     pub tier_multiplier: f64,
+    /// The namespace the pack's rows live under, from its manifest.
+    ///
+    /// Exposed because a consumer whose recall is namespace-scoped CANNOT REACH a mounted pack's
+    /// knowledge without it — it gets the constitution and none of the corpus, while every surface
+    /// (mount returns an id, the pack lists as mounted, rows is non-zero) looks healthy. The Python
+    /// binding hit exactly this and had to work around it via `read_pack_manifest(path)`; a Rust
+    /// embedder had no equivalent escape hatch.
+    pub namespace: Option<String>,
 }
 
 /// The subset of recall's filters that applies to pack candidates.
@@ -1377,6 +1385,7 @@ impl YantrikDB {
                 trust: p.trust,
                 rows: p.index.len(),
                 tier_multiplier: p.trust.tier_multiplier(),
+                namespace: p.manifest.namespace.clone(),
             })
             .collect()
     }

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -81,6 +81,7 @@ impl YantrikDB {
             source,
             emotional_state,
             None,
+            None,
         )
     }
 
@@ -110,6 +111,13 @@ impl YantrikDB {
     /// false conflict.
     ///
     /// `None` is byte-for-byte `record()`.
+    ///
+    /// `created_at`: caller-supplied event time in epoch seconds (historical
+    /// import — see `RecordInput::created_at` for the full contract). `None`
+    /// stamps `now()`, byte-for-byte the prior behavior. When `Some`, it
+    /// participates in the idempotency digest: a re-dated write decays and
+    /// `recall_as_of`s differently, so it is a different write, exactly like
+    /// a re-vectored one (payload_digest module docs).
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip(self, metadata, embedding), fields(memory_type, namespace))]
     pub fn record_with_idempotency(
@@ -127,6 +135,7 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
         idempotency_key: Option<&str>,
+        created_at: Option<f64>,
     ) -> Result<String> {
         // v0.9.3 contract gate: validate before anything else. (Historically
         // "before any side effect" because importance calibration used to
@@ -142,6 +151,13 @@ impl YantrikDB {
                 ("half_life", half_life),
             ],
         )?;
+        // Caller-supplied event time must be finite before it reaches the
+        // digest, the row, or the replicated payload. Any finite value is
+        // legal — pre-1970 history and future-dated plans both exist; scoring
+        // clamps negative elapsed rather than validation refusing it.
+        if let Some(ts) = created_at {
+            crate::validate::validate_scalars("record", &[("created_at", ts)])?;
+        }
         // v0.10 Item 4a.4 anti-laundering gate: refuse (enforce) / flag (warn)
         // a record whose declared provenance is internally inconsistent (e.g.
         // source=inference claiming metadata.kind=fact), BEFORE any side effect.
@@ -211,6 +227,7 @@ impl YantrikDB {
                     emotional_state,
                     metadata,
                     embedding: Some(embedding),
+                    created_at,
                 };
                 Some((key, crate::payload_digest::payload_digest(&view)))
             }
@@ -263,6 +280,7 @@ impl YantrikDB {
                 emotional_state,
                 gate_verdict,
                 idem,
+                created_at,
             );
         }
         // guard is held; RAII Drop at function exit decrements inflight.
@@ -302,6 +320,7 @@ impl YantrikDB {
             emotional_state,
             gate_verdict,
             idem,
+            created_at,
         )
     }
 
@@ -342,9 +361,16 @@ impl YantrikDB {
         emotional_state: Option<&str>,
         gate_verdict: crate::provenance::GateVerdict,
         idem: Option<(&str, [u8; 32])>,
+        created_at: Option<f64>,
     ) -> Result<String> {
         let rid = crate::id::new_id();
-        let ts = now();
+        // Caller-supplied event time (validated finite at entry) or the
+        // engine's clock. `ts` feeds created_at, updated_at, AND last_access
+        // below — an imported record was last touched at its event time, so
+        // decay runs from then (RecordInput::created_at contract) — plus the
+        // replicated op payload, whose created_at both replication's
+        // materialize_record and its scoring-cache arm already read.
+        let ts = created_at.unwrap_or_else(now);
         let emb_blob = serialize_f32(embedding);
         let meta_str = serde_json::to_string(metadata)?;
         // Chunked embeddings: encrypt the window vectors up front (CPU
@@ -847,6 +873,13 @@ impl YantrikDB {
                     ("half_life", input.half_life),
                 ],
             )?;
+            // Caller-supplied event time: finite or refused, in the batch
+            // prevalidation loop like every other scalar, so a bad element
+            // late in the batch rejects the whole batch before any side
+            // effect (`record_with_idempotency` has the same gate).
+            if let Some(ts) = input.created_at {
+                crate::validate::validate_scalars("record_batch", &[("created_at", ts)])?;
+            }
             // v0.10 Item 4a.4b — anti-laundering gate (T06 fan-out). Runs in
             // the batch PREVALIDATION loop, so an inconsistent element late in
             // the batch rejects the whole batch before any side effect rather
@@ -1240,7 +1273,11 @@ impl YantrikDB {
                     continue;
                 }
                 let rid = rid_slots[idx].as_ref().expect("write items have rids");
-                let ts = now();
+                // Caller-supplied event time (prevalidated finite above) or
+                // the engine's clock — the same `ts` feeds the row's
+                // created_at/updated_at/last_access and the replicated op
+                // payload, exactly as record() routes it.
+                let ts = input.created_at.unwrap_or_else(now);
                 let emb_blob = serialize_f32(&input.embedding);
                 let meta_str = serde_json::to_string(&input.metadata)?;
 
@@ -1509,7 +1546,13 @@ impl YantrikDB {
                 let Some(rid) = rid_slots[idx].as_ref() else {
                     continue;
                 };
-                let ts = now();
+                // The ITEM's event time, not now() — recall scores from this
+                // cache, not from the memories row, so a now() here makes an
+                // imported record's row say 2020 while every decay/recency/
+                // as-of computation sees today. `record_with_rid` (the older
+                // caller-supplied-timestamp path) has always used its
+                // `ts_secs` here for exactly this reason.
+                let ts = input.created_at.unwrap_or_else(now);
                 cache.insert(
                     rid.clone(),
                     ScoringRow {
@@ -1951,9 +1994,15 @@ impl YantrikDB {
         emotional_state: Option<&str>,
         gate_verdict: crate::provenance::GateVerdict,
         idem: Option<(&str, [u8; 32])>,
+        created_at: Option<f64>,
     ) -> Result<String> {
         let rid = crate::id::new_id();
-        let ts = now();
+        // Caller-supplied event time or the engine's clock — the payload's
+        // created_at is what the post-swap materializer
+        // (apply_queued_reembed_record) stamps on the row, so the queued
+        // route preserves an imported record's event time exactly as the
+        // sync route does.
+        let ts = created_at.unwrap_or_else(now);
 
         // Capture the current runtime embedder name (the one active
         // before reembed flipped the router). The post-swap materializer

--- a/crates/yantrikdb-core/src/engine/tests/basics.rs
+++ b/crates/yantrikdb-core/src/engine/tests/basics.rs
@@ -89,6 +89,7 @@ fn test_record_batch_auto_extracts_entities() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let inputs = vec![
         RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "Alice Chen is the CEO of Acme Corp".to_string(),
             memory_type: "semantic".to_string(),
@@ -104,6 +105,7 @@ fn test_record_batch_auto_extracts_entities() {
             emotional_state: None,
         },
         RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "Sarah Kim is the CTO of Acme Corp".to_string(),
             memory_type: "semantic".to_string(),
@@ -708,6 +710,7 @@ fn contract_gate_rejects_invalid_writes() {
     // (no earlier element half-committed), and the error names the position.
     let batch = vec![
         crate::types::RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "good".into(),
             memory_type: "episodic".into(),
@@ -723,6 +726,7 @@ fn contract_gate_rejects_invalid_writes() {
             emotional_state: None,
         },
         crate::types::RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "bad".into(),
             memory_type: "episodic".into(),

--- a/crates/yantrikdb-core/src/engine/tests/cognition_gates.rs
+++ b/crates/yantrikdb-core/src/engine/tests/cognition_gates.rs
@@ -304,6 +304,7 @@ fn gate_batch_rejects_inconsistent_element_atomically() {
     // side effect — earlier elements must not be half-committed.
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let mk = |text: &str, source: &str, meta: serde_json::Value| RecordInput {
+        created_at: None,
         idempotency_key: None,
         text: text.to_string(),
         memory_type: "semantic".to_string(),

--- a/crates/yantrikdb-core/src/engine/tests/consolidate_cluster.rs
+++ b/crates/yantrikdb-core/src/engine/tests/consolidate_cluster.rs
@@ -1,0 +1,211 @@
+//! Caller-supplied consolidation (`consolidate_cluster`).
+//!
+//! The default `consolidate()` writes an extractive join carrying the
+//! cluster's MEAN embedding. Measured on BEAM (2026-08-11) that costs
+//! accuracy through EMBEDDING DILUTION: no content is lost (all texts are
+//! joined), but N precise vectors become one average that matches no
+//! specific query well. This path lets a caller supply a real synthesis and
+//! — the load-bearing part — embeds it FROM ITS OWN TEXT.
+
+use super::*;
+
+fn seed(db: &YantrikDB, texts: &[&str]) -> Vec<String> {
+    texts
+        .iter()
+        .enumerate()
+        .map(|(i, t)| {
+            db.record(
+                t,
+                "episodic",
+                0.5,
+                0.0,
+                604800.0,
+                &empty_meta(),
+                &vec_seed(1.0 + i as f32 * 0.01, 8),
+                "default",
+                0.8,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap()
+        })
+        .collect()
+}
+
+/// The point of the feature: the consolidated record's vector must describe
+/// the SYNTHESIS, not the average of the members it replaced.
+#[test]
+fn caller_text_is_embedded_from_itself_not_the_cluster_mean() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rids = seed(&db, &["alpha one", "alpha two", "alpha three"]);
+    let members: Vec<String> = rids.clone();
+
+    let out = crate::consolidate::consolidate_cluster(
+        &db,
+        &members,
+        "the alpha project shipped",
+        Some(&vec_seed(9.0, 8)),
+    )
+    .unwrap();
+    assert_eq!(out["cluster_size"], 3);
+    assert_eq!(
+        out["embedded_from_text"], false,
+        "flag reports engine-side embedding; this call supplied its own vector"
+    );
+
+    let new_rid = out["consolidated_rid"].as_str().unwrap();
+    let stored: String = db
+        .conn()
+        .query_row(
+            "SELECT text FROM memories WHERE rid = ?1",
+            params![new_rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        db.decrypt_text(&stored).unwrap(),
+        "the alpha project shipped",
+        "the caller owns the text; the engine must not rewrite it"
+    );
+}
+
+/// Bookkeeping must match the default path exactly — sources retired,
+/// membership recorded — or the two paths drift and replication diverges.
+#[test]
+fn sources_are_retired_and_membership_recorded() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rids = seed(&db, &["beta one", "beta two"]);
+    let out = crate::consolidate::consolidate_cluster(
+        &db,
+        &rids,
+        "beta summary",
+        Some(&vec_seed(9.0, 8)),
+    )
+    .unwrap();
+    let new_rid = out["consolidated_rid"].as_str().unwrap();
+
+    for rid in &rids {
+        let (status, into): (String, Option<String>) = db
+            .conn()
+            .query_row(
+                "SELECT consolidation_status, consolidated_into FROM memories WHERE rid = ?1",
+                params![rid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "consolidated", "source {rid} not retired");
+        assert_eq!(into.as_deref(), Some(new_rid));
+    }
+    let members: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM consolidation_members WHERE consolidation_rid = ?1",
+            params![new_rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(members, 2, "consolidation_members CRDT rows missing");
+}
+
+/// Double-consolidating a member would orphan the first consolidation's
+/// membership rows, so it is refused rather than silently accepted.
+#[test]
+fn already_consolidated_members_are_refused() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rids = seed(&db, &["gamma one", "gamma two"]);
+    crate::consolidate::consolidate_cluster(&db, &rids, "gamma summary", Some(&vec_seed(9.0, 8)))
+        .unwrap();
+    let err =
+        crate::consolidate::consolidate_cluster(&db, &rids, "gamma again", Some(&vec_seed(9.0, 8)))
+            .unwrap_err();
+    assert!(
+        format!("{err}").contains("not active"),
+        "expected an active-status refusal, got: {err}"
+    );
+}
+
+#[test]
+fn empty_cluster_and_empty_text_are_refused() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    assert!(
+        crate::consolidate::consolidate_cluster(&db, &[], "x", Some(&vec_seed(9.0, 8))).is_err()
+    );
+    let rids = seed(&db, &["delta one"]);
+    let err = crate::consolidate::consolidate_cluster(&db, &rids, "   ", Some(&vec_seed(9.0, 8)))
+        .unwrap_err();
+    assert!(format!("{err}").contains("text is empty"), "{err}");
+}
+
+#[test]
+fn unknown_rid_is_refused_before_anything_is_written() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rids = seed(&db, &["eps one"]);
+    let mut with_bogus = rids.clone();
+    with_bogus.push("does-not-exist".to_string());
+    assert!(crate::consolidate::consolidate_cluster(
+        &db,
+        &with_bogus,
+        "s",
+        Some(&vec_seed(9.0, 8))
+    )
+    .is_err());
+    let status: String = db
+        .conn()
+        .query_row(
+            "SELECT consolidation_status FROM memories WHERE rid = ?1",
+            params![rids[0]],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "active", "a refused call must write nothing");
+}
+
+/// A caller-supplied vector of the wrong dimension must be refused before
+/// anything is written — a diverged dim is undetectable until a query
+/// silently misses.
+#[test]
+fn wrong_dimension_embedding_is_refused() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rids = seed(&db, &["zeta one"]);
+    let err = crate::consolidate::consolidate_cluster(
+        &db,
+        &rids,
+        "zeta summary",
+        Some(&vec_seed(1.0, 4)),
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("consolidate_cluster"), "{err}");
+    let status: String = db
+        .conn()
+        .query_row(
+            "SELECT consolidation_status FROM memories WHERE rid = ?1",
+            params![rids[0]],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "active", "a refused call must write nothing");
+}
+
+/// `get_memory` — the rid point-read the binding lacked entirely.
+/// Found while wiring LLM conflict resolution: `get_conflicts` hands back
+/// `memory_a`/`memory_b` as bare rids and there was no way to resolve them
+/// to text short of paging the namespace.
+#[test]
+fn get_memory_reads_by_rid_including_consolidated() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rids = seed(&db, &["theta one", "theta two"]);
+
+    let m = db.get_memory(&rids[0]).unwrap().expect("memory must exist");
+    assert_eq!(m.text, "theta one");
+    assert_eq!(m.consolidation_status, "active");
+    assert!(db.get_memory("no-such-rid").unwrap().is_none());
+
+    // Naming a rid asks for THAT record — currency is not the caller's
+    // question here, so a consolidated source must still be readable.
+    crate::consolidate::consolidate_cluster(&db, &rids, "theta summary", Some(&vec_seed(9.0, 8)))
+        .unwrap();
+    let after = db.get_memory(&rids[0]).unwrap().expect("still readable");
+    assert_eq!(after.text, "theta one");
+    assert_eq!(after.consolidation_status, "consolidated");
+}

--- a/crates/yantrikdb-core/src/engine/tests/corrections.rs
+++ b/crates/yantrikdb-core/src/engine/tests/corrections.rs
@@ -627,6 +627,7 @@ fn record_batch_defers_during_reembed_instead_of_writing_a_doomed_generation() {
     // its own comment claimed every append lands on one anchored generation.
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let inputs = vec![RecordInput {
+        created_at: None,
         idempotency_key: None,
         text: "written during a cutover".to_string(),
         memory_type: "semantic".to_string(),
@@ -756,6 +757,7 @@ fn record_batch_replicates_to_a_peer() {
     let follower = YantrikDB::new(":memory:", 8).unwrap();
 
     let mk = |text: &str, seed: f32| RecordInput {
+        created_at: None,
         idempotency_key: None,
         text: text.to_string(),
         memory_type: "semantic".to_string(),

--- a/crates/yantrikdb-core/src/engine/tests/created_at.rs
+++ b/crates/yantrikdb-core/src/engine/tests/created_at.rs
@@ -1,0 +1,515 @@
+//! Caller-supplied `created_at` (historical import, 0.14).
+//!
+//! The contract under test is `RecordInput::created_at`'s: `Some(ts)` lands
+//! the event time in `created_at`, `updated_at`, AND `last_access` (decay
+//! runs from the event, not the import), flows into the replicated op
+//! payload, joins the idempotency digest (a re-dated write is a different
+//! write), and makes `recall_as_of`/`time_window` meaningful on bulk-loaded
+//! corpora. `None` is byte-for-byte the pre-field behavior. Motivated by the
+//! BEAM/AMB finding that on a bulk-loaded conversation corpus every temporal
+//! surface collapsed onto the ingest wall-clock — `recall_as_of` was inert,
+//! `time_window` was inert, and decay/recency were pure insertion-order
+//! noise (the 2026-06-08 benchmark diagnosis, this time fixed at the write
+//! path instead of worked around with pinned weights).
+
+use super::*;
+
+/// The row triple: `Some(ts)` stamps created_at, updated_at AND last_access
+/// with the event time — an imported record was last touched when it
+/// happened, so decay runs from then.
+#[test]
+fn record_with_created_at_stamps_the_full_row_triple() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let event_time = 1_600_000_000.0; // 2020-09-13, unambiguously "the past"
+    let rid = db
+        .record_with_idempotency(
+            "joined the observatory team",
+            "episodic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "work",
+            "user",
+            None,
+            None,
+            Some(event_time),
+        )
+        .unwrap();
+
+    let (created, updated, last_access): (f64, f64, f64) = db
+        .conn()
+        .query_row(
+            "SELECT created_at, updated_at, last_access FROM memories WHERE rid = ?1",
+            params![rid],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(created, event_time);
+    assert_eq!(updated, event_time);
+    assert_eq!(
+        last_access, event_time,
+        "last_access must be the event time — decay from the import instant \
+         would give every imported record a fresh-memory decay curve"
+    );
+}
+
+/// `None` still stamps now() — the pre-field behavior, byte-for-byte.
+#[test]
+fn record_without_created_at_still_stamps_now() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let before = crate::engine::now();
+    let rid = db
+        .record(
+            "an ordinary present-day write",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(2.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    let after = crate::engine::now();
+    let created: f64 = db
+        .conn()
+        .query_row(
+            "SELECT created_at FROM memories WHERE rid = ?1",
+            params![rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        created >= before && created <= after,
+        "None must stamp the engine clock: {created} outside [{before}, {after}]"
+    );
+}
+
+/// The point of the feature: on a bulk-loaded corpus with real event times,
+/// `recall_as_of(t)` distinguishes what existed at `t` — instead of every
+/// record sharing the ingest wall-clock and the filter being inert.
+#[test]
+fn recall_as_of_respects_imported_event_times() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let january = 1_735_700_000.0;
+    let march = 1_740_800_000.0;
+    let april = 1_743_500_000.0;
+
+    let rid_old = db
+        .record_with_idempotency(
+            "works at the observatory",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "work",
+            "user",
+            None,
+            None,
+            Some(january),
+        )
+        .unwrap();
+    let rid_new = db
+        .record_with_idempotency(
+            "moved to the planetarium",
+            "semantic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.05, 8),
+            "default",
+            0.8,
+            "work",
+            "user",
+            None,
+            None,
+            Some(april),
+        )
+        .unwrap();
+
+    // As of March, only the January record existed.
+    let hits = db
+        .recall_as_of(&vec_seed(1.0, 8), 10, march, None, None)
+        .unwrap();
+    let rids: Vec<&str> = hits.iter().map(|r| r.rid.as_str()).collect();
+    assert!(
+        rids.contains(&rid_old.as_str()),
+        "January record missing at t=March"
+    );
+    assert!(
+        !rids.contains(&rid_new.as_str()),
+        "April record visible at t=March — created_at did not reach the as-of filter"
+    );
+
+    // Today, both exist.
+    let now_hits = db
+        .recall_as_of(&vec_seed(1.0, 8), 10, crate::engine::now(), None, None)
+        .unwrap();
+    let now_rids: Vec<&str> = now_hits.iter().map(|r| r.rid.as_str()).collect();
+    assert!(now_rids.contains(&rid_old.as_str()));
+    assert!(now_rids.contains(&rid_new.as_str()));
+}
+
+/// record_batch: per-item event times land per-row, mixed with None items
+/// that stamp now().
+#[test]
+fn record_batch_carries_per_item_created_at() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let event_time = 1_650_000_000.0;
+    let mk = |text: &str, seed: f32, created_at: Option<f64>| RecordInput {
+        text: text.into(),
+        memory_type: "episodic".into(),
+        importance: 0.5,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: empty_meta(),
+        embedding: vec_seed(seed, 8),
+        namespace: "default".into(),
+        certainty: 0.8,
+        domain: "general".into(),
+        source: "user".into(),
+        emotional_state: None,
+        idempotency_key: None,
+        created_at,
+    };
+    let before = crate::engine::now();
+    let rids = db
+        .record_batch(&[
+            mk("historical item", 1.0, Some(event_time)),
+            mk("present item", 2.0, None),
+        ])
+        .unwrap();
+
+    let created_hist: f64 = db
+        .conn()
+        .query_row(
+            "SELECT created_at FROM memories WHERE rid = ?1",
+            params![rids[0]],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let created_now: f64 = db
+        .conn()
+        .query_row(
+            "SELECT created_at FROM memories WHERE rid = ?1",
+            params![rids[1]],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(created_hist, event_time);
+    assert!(
+        created_now >= before,
+        "None item must stamp the engine clock"
+    );
+}
+
+/// The event time must reach the RECALL path, not just the SQL row.
+///
+/// Recall scores from the in-memory `scoring_cache`, not from `memories`, so
+/// the two can disagree: `record_batch` shipped the correct `created_at` to
+/// SQL while its cache insert still stamped `now()`, and every through-recall
+/// consumer (decay, recency, `recall_as_of`, `order="recency"`) saw today for
+/// a record whose row said 2020. The SQL-reading tests above all passed —
+/// only a through-recall assertion catches it. `record_with_rid` had this
+/// right from the start; the batch path was the copied-without-the-rationale
+/// sibling.
+#[test]
+fn imported_event_time_reaches_recall_not_just_the_row() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let event_time = 1_600_000_000.0;
+    let mk = |text: &str, seed: f32, created_at: Option<f64>| RecordInput {
+        text: text.into(),
+        memory_type: "episodic".into(),
+        importance: 0.5,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: empty_meta(),
+        embedding: vec_seed(seed, 8),
+        namespace: "default".into(),
+        certainty: 0.8,
+        domain: "general".into(),
+        source: "user".into(),
+        emotional_state: None,
+        idempotency_key: None,
+        created_at,
+    };
+    let rids = db
+        .record_batch(&[mk("batch historical record", 1.0, Some(event_time))])
+        .unwrap();
+
+    let hits = db
+        .recall(
+            &vec_seed(1.0, 8),
+            5,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+    let hit = hits
+        .iter()
+        .find(|h| h.rid == rids[0])
+        .expect("batch record must be recallable");
+    assert_eq!(
+        hit.created_at, event_time,
+        "recall reported {} for a record imported at {event_time} — the \
+         scoring cache disagrees with the row",
+        hit.created_at
+    );
+}
+
+/// A non-finite event time is refused in prevalidation — before any side
+/// effect, failing the WHOLE batch like every other scalar gate.
+#[test]
+fn non_finite_created_at_is_refused_before_any_side_effect() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let mk = |created_at: Option<f64>| RecordInput {
+        text: "t".into(),
+        memory_type: "episodic".into(),
+        importance: 0.5,
+        valence: 0.0,
+        half_life: 604800.0,
+        metadata: empty_meta(),
+        embedding: vec_seed(1.0, 8),
+        namespace: "default".into(),
+        certainty: 0.8,
+        domain: "general".into(),
+        source: "user".into(),
+        emotional_state: None,
+        idempotency_key: None,
+        created_at,
+    };
+    // Batch: a bad element late in the batch rejects the whole batch.
+    let err = db
+        .record_batch(&[mk(None), mk(Some(f64::NAN))])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::InvalidScalar {
+                field: "created_at",
+                ..
+            }
+        ),
+        "expected InvalidScalar on created_at, got {err:?}"
+    );
+    let count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0, "refused batch left rows behind");
+
+    // Single-record surface, same gate.
+    let err = db
+        .record_with_idempotency(
+            "t",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+            None,
+            Some(f64::INFINITY),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::error::YantrikDbError::InvalidScalar {
+            field: "created_at",
+            ..
+        }
+    ));
+}
+
+/// The digest half of the contract: same key + same payload + same
+/// created_at is a retry (original rid, nothing written); same key with a
+/// DIFFERENT created_at is a different write — typed conflict, first write
+/// stands. A re-dated record decays and recall_as_ofs differently, exactly
+/// like a re-vectored one.
+#[test]
+fn idempotency_treats_a_redated_write_as_a_different_write() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let write = |ts: f64| {
+        db.record_with_idempotency(
+            "the launch happened",
+            "episodic",
+            0.7,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "work",
+            "user",
+            None,
+            Some("launch-evt-1"),
+            Some(ts),
+        )
+    };
+    let rid1 = write(1_600_000_000.0).unwrap();
+
+    // Honest retry: same everything → original rid, one row.
+    let rid2 = write(1_600_000_000.0).unwrap();
+    assert_eq!(rid1, rid2);
+    let count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 1);
+
+    // Re-dated: different write reusing the key → typed conflict.
+    let err = write(1_600_000_001.0).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::IdempotencyConflict { .. }
+        ),
+        "a re-dated keyed write must conflict, got {err:?}"
+    );
+}
+
+/// Scoring safety: a FUTURE event time scores as "brand new" (clamped), not
+/// as an unbounded amplifier. Before the clamp, decay = importance·2^(+x)
+/// and recency = e^(+x) grew without bound for future-dated records — the
+/// recency wall rebuilt in the other direction, reachable the moment
+/// created_at became caller-supplied.
+#[test]
+fn future_created_at_scores_as_new_not_amplified() {
+    use crate::base::scoring::{decay_score, recency_score};
+    // Direct unit contract on the clamp:
+    assert_eq!(decay_score(0.5, 604800.0, -3_000_000.0), 0.5);
+    assert!(recency_score(-3_000_000.0) <= 1.0);
+    assert_eq!(recency_score(-3_000_000.0), 1.0);
+
+    // End-to-end: a future-dated decoy must not leapfrog a more similar
+    // present-day record purely on its timestamp.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let target = db
+        .record(
+            "the target memory about the launch",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    let one_year_ahead = crate::engine::now() + 365.0 * 86400.0;
+    db.record_with_idempotency(
+        "an unrelated future-dated decoy",
+        "episodic",
+        0.5,
+        0.0,
+        604800.0,
+        &empty_meta(),
+        &vec_seed(4.0, 8),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+        None,
+        Some(one_year_ahead),
+    )
+    .unwrap();
+
+    let hits = db
+        .recall(
+            &vec_seed(1.0, 8),
+            1,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+    assert_eq!(
+        hits[0].rid, target,
+        "future-dated decoy outranked the similar record — the clamp is not \
+         holding at the recall path"
+    );
+}
+
+/// The replicated op payload carries the caller's event time, so followers
+/// and the queued-route materializer stamp the same row the origin did.
+#[test]
+fn record_op_payload_carries_the_imported_event_time() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let event_time = 1_600_000_000.0;
+    let rid = db
+        .record_with_idempotency(
+            "replicated historical record",
+            "episodic",
+            0.5,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+            None,
+            Some(event_time),
+        )
+        .unwrap();
+    let payload: String = db
+        .conn()
+        .query_row(
+            "SELECT payload FROM oplog WHERE op_type = 'record' AND target_rid = ?1",
+            params![rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&payload).unwrap();
+    assert_eq!(
+        v["created_at"].as_f64(),
+        Some(event_time),
+        "op payload must carry the event time — a follower would otherwise \
+         materialize a different row than the origin's"
+    );
+}

--- a/crates/yantrikdb-core/src/engine/tests/dimensions.rs
+++ b/crates/yantrikdb-core/src/engine/tests/dimensions.rs
@@ -376,6 +376,7 @@ fn test_batch_record_with_dimensions() {
 
     let inputs: Vec<RecordInput> = vec![
         RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "batch work meeting".to_string(),
             memory_type: "episodic".to_string(),
@@ -391,6 +392,7 @@ fn test_batch_record_with_dimensions() {
             emotional_state: Some("focus".to_string()),
         },
         RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "batch health jog".to_string(),
             memory_type: "episodic".to_string(),
@@ -406,6 +408,7 @@ fn test_batch_record_with_dimensions() {
             emotional_state: None,
         },
         RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "batch personal diary".to_string(),
             memory_type: "semantic".to_string(),

--- a/crates/yantrikdb-core/src/engine/tests/encryption.rs
+++ b/crates/yantrikdb-core/src/engine/tests/encryption.rs
@@ -172,6 +172,7 @@ fn test_encrypted_record_batch() {
 
     let inputs: Vec<RecordInput> = (0..5)
         .map(|i| RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: format!("encrypted batch {i}"),
             memory_type: "episodic".to_string(),

--- a/crates/yantrikdb-core/src/engine/tests/idempotency.rs
+++ b/crates/yantrikdb-core/src/engine/tests/idempotency.rs
@@ -21,6 +21,7 @@ fn idempotent_retry_returns_original_rid_and_writes_nothing() {
             "user",
             None,
             Some("client-req-001"),
+            None,
         )
     };
     let rid1 = write(&db).unwrap();
@@ -115,6 +116,7 @@ fn idempotency_conflict_on_different_payload() {
             "user",
             None,
             Some("key-x"),
+            None,
         )
     };
     let rid1 = write(&db, 0.7).unwrap();
@@ -169,6 +171,7 @@ fn idempotency_holds_on_and_across_the_queued_route() {
             "user",
             None,
             Some(key),
+            None,
         )
     };
 
@@ -249,6 +252,7 @@ fn idempotency_digest_uses_raw_importance_not_calibrated() {
             "user",
             None,
             Some("sat-key"),
+            None,
         )
     };
     let rid1 = write(&db).unwrap();
@@ -291,6 +295,7 @@ fn invalid_idempotency_keys_are_rejected() {
                 "user",
                 None,
                 Some(bad),
+                None,
             )
             .expect_err("bad key must be refused");
         assert!(
@@ -335,6 +340,7 @@ fn keyed_duplicate_resolves_even_under_backpressure() {
             "user",
             None,
             Some("bp-key"),
+            None,
         )
     };
     let rid = keyed(&db).unwrap();
@@ -391,6 +397,7 @@ fn keyed_duplicate_resolves_even_under_backpressure() {
             "user",
             None,
             Some("bp-key-new"),
+            None,
         )
         .expect_err("a NEW keyed write under saturation must still backpressure");
     assert!(
@@ -436,6 +443,7 @@ fn keyed_duplicate_resolves_under_pending_queue_saturation() {
             "user",
             None,
             Some(key),
+            None,
         )
     };
     // The keyed write lands while there is capacity.
@@ -525,6 +533,7 @@ fn record_text_keyed_retry_hits_without_embedding_again() {
             "user",
             None,
             Some("rt-key"),
+            None,
         )
     };
     let rid = write(&db).unwrap();
@@ -589,6 +598,7 @@ fn same_key_across_record_and_record_text_is_a_conflict() {
         "user",
         None,
         Some("xs-key"),
+        None,
     )
     .unwrap();
 
@@ -608,6 +618,7 @@ fn same_key_across_record_and_record_text_is_a_conflict() {
             "user",
             None,
             Some("xs-key"),
+            None,
         )
         .expect_err("cross-surface same-key must conflict");
     assert!(
@@ -658,6 +669,7 @@ fn record_text_normalizes_blank_namespace_like_record() {
             "user",
             None,
             Some("ns-key"),
+            None,
         )
         .unwrap();
 
@@ -699,6 +711,7 @@ fn record_text_normalizes_blank_namespace_like_record() {
             "user",
             None,
             Some("ns-key"),
+            None,
         )
         .unwrap();
     assert_eq!(
@@ -726,6 +739,7 @@ fn batch_append_failure_writes_nothing_at_all() {
     // absence assertions below are meaningful rather than vacuously true. A
     // regression test whose branch never fires is decoration (#83 lesson).
     db.record_batch(&[RecordInput {
+        created_at: None,
         idempotency_key: None,
         text: "Quarterly sync with Klaxonberg about the roadmap".into(),
         memory_type: "episodic".into(),
@@ -791,6 +805,7 @@ fn batch_append_failure_writes_nothing_at_all() {
     // The doomed batch: same text shape, a DIFFERENT unique entity.
     let err = db
         .record_batch(&[RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "Quarterly sync with Quorvexia about the roadmap".into(),
             memory_type: "episodic".into(),
@@ -891,6 +906,7 @@ fn record_batch_normalizes_blank_namespace_like_record() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
 
     let mk = |text: &str, ns: &str, emb: f32| RecordInput {
+        created_at: None,
         idempotency_key: None,
         text: text.into(),
         memory_type: "semantic".into(),
@@ -976,6 +992,7 @@ fn record_batch_normalizes_blank_namespace_like_record() {
 /// always caller-supplied vectors -> PayloadVariant::Record digest).
 fn keyed_input(text: &str, ns: &str, emb: f32, key: Option<&str>) -> RecordInput {
     RecordInput {
+        created_at: None,
         idempotency_key: key.map(|k| k.to_string()),
         text: text.into(),
         memory_type: "semantic".into(),
@@ -1188,6 +1205,7 @@ fn same_key_across_record_and_record_batch_hits_on_identical_payload() {
             &input.source,
             input.emotional_state.as_deref(),
             Some("xb-key"),
+            None,
         )
         .unwrap();
 

--- a/crates/yantrikdb-core/src/engine/tests/mod.rs
+++ b/crates/yantrikdb-core/src/engine/tests/mod.rs
@@ -14,7 +14,9 @@ mod basics;
 mod bundled_embedder;
 mod chunking;
 mod cognition_gates;
+mod consolidate_cluster;
 mod corrections;
+mod created_at;
 mod dimensions;
 mod encryption;
 // 0.13.2: 'encrypted means encrypted', verified against the raw file

--- a/crates/yantrikdb-core/src/engine/tests/storage_fts.rs
+++ b/crates/yantrikdb-core/src/engine/tests/storage_fts.rs
@@ -298,6 +298,7 @@ fn test_record_batch() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
     let inputs: Vec<RecordInput> = (0..10)
         .map(|i| RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: format!("batch memory {i}"),
             memory_type: "episodic".to_string(),

--- a/crates/yantrikdb-core/src/engine/tests/trace_entities.rs
+++ b/crates/yantrikdb-core/src/engine/tests/trace_entities.rs
@@ -98,6 +98,7 @@ fn t06_anti_laundering_chokepoint() {
     // 4) Bypass path: batch. One inconsistent element refuses the WHOLE
     //    batch before any side effect.
     let mk = |source: &str, meta: serde_json::Value, seed: f32| RecordInput {
+        created_at: None,
         idempotency_key: None,
         text: "t06 batch probe".into(),
         memory_type: "semantic".into(),
@@ -252,6 +253,7 @@ fn t07_repetition_is_not_corroboration() {
             "user",
             None,
             key,
+            None,
         )
     };
 

--- a/crates/yantrikdb-core/src/engine/tests/write_stats.rs
+++ b/crates/yantrikdb-core/src/engine/tests/write_stats.rs
@@ -297,6 +297,7 @@ fn flagged_committed_writes_tick_the_nudge_counter_exactly_once() {
 
     // record_batch(): two flagged inputs, one clean.
     let mk = |text: &str, meta: serde_json::Value, source: &str| RecordInput {
+        created_at: None,
         idempotency_key: None,
         text: text.into(),
         memory_type: "semantic".into(),
@@ -360,6 +361,7 @@ fn deferred_batch_leaves_importance_stats_untouched() {
 
     let err = db
         .record_batch(&[RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "deferred".into(),
             memory_type: "semantic".into(),
@@ -580,6 +582,7 @@ fn batch_append_failure_leaves_importance_stats_untouched() {
     // stats assertions below are what this test pins.
     let err = db
         .record_batch(&[RecordInput {
+            created_at: None,
             idempotency_key: None,
             text: "batch after saturation".into(),
             memory_type: "semantic".into(),

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -98,10 +98,86 @@ const ENTITY_STOPWORDS: &[&str] = &[
     "With", "From", "By", "As", "Than", "Then", "Also", "Just", "Only", "Very", "Much",
 ];
 
+/// Strip fenced code blocks and inline code spans before entity extraction.
+///
+/// The capitalized-chunk heuristic below cannot tell `String`, `User` or
+/// `GET` in a code sample from `Alice`, `Anthropic` or `NASA` in prose — both
+/// are capitalized or all-caps tokens. Measured on a code-bearing
+/// conversation corpus (BEAM, 2026-08-11): ~360 records produced **5,550
+/// entities**, roughly 15 per record, and every conflict the detector then
+/// raised was a false positive keyed on the entity `GET` — pairing two
+/// adjacent chunks of the same turn because both quoted a Flask route.
+/// Garbage entities do not merely add noise: they invent `entity`-scoped
+/// conflicts, inflate `mention_count`, and give graph expansion spurious
+/// bridges between unrelated records.
+///
+/// Prose is the right domain for a proper-noun heuristic; code is not. This
+/// removes ``` fences and `inline spans` (keeping a space so word chunks do
+/// not weld across the removal) and leaves everything else untouched, so
+/// entities named in the surrounding narrative are still captured.
+///
+/// KNOWN LIMITS, deliberate rather than overlooked (adversarial review,
+/// 2026-08-11). This is a heuristic guard on a heuristic extractor; the
+/// failure it prevents (fabricated entities) is worse than the failure it
+/// allows (a missed entity), so every ambiguous case resolves toward
+/// dropping:
+/// - An UNTERMINATED fence drops the remaining text. This case is COMMON,
+///   not exotic: callers chunk long documents, and a chunk routinely begins
+///   inside a fenced block or ends with one open — so the tail genuinely is
+///   code more often than it is prose. Keeping it would readmit exactly the
+///   identifiers this function exists to remove.
+/// - Escaped backticks (``\` ``) are treated as delimiters, so a span
+///   between two of them is dropped. Costs a missed entity, never a false
+///   one.
+/// - Tilde fences and 4-space indented blocks are NOT recognised; code in
+///   those forms still reaches the extractor. Fixing that needs a markdown
+///   parser, which this deliberately is not.
+fn strip_code(text: &str) -> std::borrow::Cow<'_, str> {
+    if !text.contains('`') {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    // Always act on the EARLIEST marker. Checking for a fence first is wrong:
+    // in "`GET` text ```block```" the fence is found at 11 and the inline tick
+    // at 0, so a fence-first branch emits "`GET` text " verbatim as prose and
+    // the identifier this function exists to remove survives.
+    while let Some(t) = rest.find('`') {
+        out.push_str(&rest[..t]);
+        out.push(' ');
+        let after = &rest[t..];
+        if let Some(body) = after.strip_prefix("```") {
+            // A fenced region may contain single backticks; consume it whole
+            // so they cannot be mis-paired as inline spans.
+            match body.find("```") {
+                Some(end) => rest = &body[end + 3..],
+                None => return std::borrow::Cow::Owned(out), // unterminated: drop the tail
+            }
+        } else {
+            let body = &after[1..];
+            match body.find('`') {
+                Some(end) => rest = &body[end + 1..],
+                None => {
+                    // Unterminated single backtick: keep the remainder as
+                    // prose rather than discarding real text.
+                    out.push_str(body);
+                    return std::borrow::Cow::Owned(out);
+                }
+            }
+        }
+    }
+    out.push_str(rest);
+    std::borrow::Cow::Owned(out)
+}
+
 /// Extract candidate proper-noun entities from free-form text using a
 /// capitalized-chunk heuristic. Groups consecutive capitalized words into
 /// multi-word entities ("Alice Chen", "San Francisco", "Acme Corp") and
 /// strips leading/trailing English stopwords.
+///
+/// Code spans and fenced blocks are removed first (see [`strip_code`]) —
+/// identifiers are not proper nouns, and treating them as entities poisons
+/// conflict detection and graph expansion.
 ///
 /// This is intentionally not a full NER — it captures the common case of
 /// people, companies, places, and products well enough that conflict
@@ -109,6 +185,11 @@ const ENTITY_STOPWORDS: &[&str] = &[
 /// entity. Acronyms, lowercase entities, and ambiguous mentions still need
 /// explicit `relate()` calls to enter the graph.
 pub fn extract_heuristic_entities(text: &str) -> Vec<String> {
+    let stripped = strip_code(text);
+    extract_heuristic_entities_inner(stripped.as_ref())
+}
+
+fn extract_heuristic_entities_inner(text: &str) -> Vec<String> {
     let mut entities: Vec<String> = Vec::new();
     let mut chunk: Vec<String> = Vec::new();
 
@@ -1467,5 +1548,91 @@ mod tests {
         let (s, d) = classify_with_relationship("FAISS", "data pipeline", "related_to");
         assert_eq!(s, "tech");
         assert_eq!(d, "unknown");
+    }
+}
+
+#[cfg(test)]
+mod code_stripping_tests {
+    use super::*;
+
+    #[test]
+    fn code_identifiers_do_not_become_entities() {
+        // The BEAM failure, reduced: a Flask route in a fenced block made
+        // GET/POST/String entities, and the conflict detector then paired
+        // unrelated chunks that merely both quoted a route.
+        let text = "Alice deployed the service.\n\n```python\n\
+                    @app.route('/login', methods=['GET', 'POST'])\n\
+                    def login():\n    data = LoginSchema(String)\n```\n\
+                    She reported it to Acme Corp.";
+        let got = extract_heuristic_entities(text);
+        for bad in ["GET", "POST", "String", "LoginSchema"] {
+            assert!(
+                !got.iter().any(|e| e.contains(bad)),
+                "code identifier {bad:?} leaked into entities: {got:?}"
+            );
+        }
+        // Prose entities on both sides of the block survive.
+        assert!(
+            got.iter().any(|e| e == "Alice"),
+            "lost prose entity: {got:?}"
+        );
+        assert!(
+            got.iter().any(|e| e.contains("Acme")),
+            "lost prose entity after the block: {got:?}"
+        );
+    }
+
+    #[test]
+    fn inline_spans_are_stripped_without_welding_neighbours() {
+        let got = extract_heuristic_entities("Bob set `MAX_RETRIES` Carol reviewed it");
+        assert!(!got.iter().any(|e| e.contains("MAX_RETRIES")), "{got:?}");
+        // The space substituted for the span must keep Bob and Carol apart
+        // rather than producing a single "Bob Carol" chunk.
+        assert!(got.iter().any(|e| e == "Bob"), "{got:?}");
+        assert!(got.iter().any(|e| e == "Carol"), "{got:?}");
+        assert!(!got.iter().any(|e| e == "Bob Carol"), "welded: {got:?}");
+    }
+
+    #[test]
+    fn inline_span_before_a_fence_is_still_stripped() {
+        // Regression: a fence-first branch emitted everything preceding the
+        // fence verbatim, so an inline `GET` earlier in the same text
+        // survived — the exact identifier this function exists to remove.
+        let text = "`GET` Alice then
+```python
+class User: pass
+```
+done";
+        let got = extract_heuristic_entities(text);
+        assert!(
+            !got.iter().any(|e| e.contains("GET")),
+            "inline span leaked: {got:?}"
+        );
+        assert!(
+            !got.iter().any(|e| e.contains("User")),
+            "fence leaked: {got:?}"
+        );
+        assert!(got.iter().any(|e| e == "Alice"), "prose lost: {got:?}");
+    }
+
+    #[test]
+    fn text_without_backticks_is_unchanged() {
+        let plain = "Alice Chen is the CEO of Acme Corp";
+        assert_eq!(
+            extract_heuristic_entities(plain),
+            extract_heuristic_entities_inner(plain),
+            "no-backtick path must be byte-identical to the pre-change behavior"
+        );
+        assert!(matches!(strip_code(plain), std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn unterminated_markers_do_not_drop_prose() {
+        // A stray single backtick must not swallow the rest of the memory.
+        let got = extract_heuristic_entities("Dave noted ` then Erin shipped it");
+        assert!(
+            got.iter().any(|e| e == "Erin"),
+            "prose lost after stray tick: {got:?}"
+        );
     }
 }

--- a/crates/yantrikdb-core/tests/pack_mount.rs
+++ b/crates/yantrikdb-core/tests/pack_mount.rs
@@ -1170,3 +1170,59 @@ fn signing_payload_is_unchanged_when_retrieval_settings_are_absent() {
         "changing the floor must change the signed bytes"
     );
 }
+
+/// `PackInfo.namespace` — without it a namespace-scoped consumer cannot
+/// reach a mounted pack's corpus.
+///
+/// The failure this prevents is silent: every surface looks healthy —
+/// `mount_pack` returns an id, the pack lists as mounted, `rows` is
+/// non-zero — while a caller whose recall is namespace-scoped gets the
+/// constitution and none of the corpus, because it has no way to learn
+/// which namespace to scope to. The Python binding worked around it by
+/// re-reading the manifest off disk; a Rust embedder had no escape hatch.
+#[test]
+fn mounted_pack_reports_its_namespace() {
+    let dir = tempfile::tempdir().unwrap();
+    let digest = "sha256:namespace-probe";
+    let pack = dir.path().join("physics.ydbpack");
+    build_pack(
+        dir.path(),
+        pack.to_str().unwrap(),
+        digest,
+        &[("quarks bind via gluons", 1)],
+    );
+
+    let db = host(dir.path(), digest);
+    db.mount_pack(pack.to_str().unwrap()).unwrap();
+
+    let info = &db.mounted_packs()[0];
+    assert_eq!(
+        info.namespace.as_deref(),
+        Some("physics"),
+        "mounted pack must report the namespace its rows live under"
+    );
+    // The value must be usable as a recall scope, not merely present.
+    let scoped = db
+        .recall(
+            &vec_on(1, 0.05),
+            5,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            info.namespace.as_deref(),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+    assert!(
+        scoped.iter().any(|r| r.text.contains("gluons")),
+        "namespace from PackInfo did not scope to the pack's corpus: {:?}",
+        scoped.iter().map(|r| &r.text).collect::<Vec<_>>()
+    );
+}

--- a/crates/yantrikdb-python/src/lib.rs
+++ b/crates/yantrikdb-python/src/lib.rs
@@ -69,6 +69,7 @@ fn _yantrikdb_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
         py_consolidate::find_consolidation_candidates,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(py_consolidate::py_consolidate_cluster, m)?)?;
     m.add_function(wrap_pyfunction!(py_consolidate::py_cosine_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(py_consolidate::py_extractive_summary, m)?)?;
     m.add_function(wrap_pyfunction!(py_consolidate::py_find_clusters, m)?)?;

--- a/crates/yantrikdb-python/src/py_consolidate.rs
+++ b/crates/yantrikdb-python/src/py_consolidate.rs
@@ -197,3 +197,40 @@ fn mem_with_emb_to_dict(py: Python<'_>, m: &MemoryWithEmbedding) -> PyResult<PyO
     dict.set_item("metadata", json_to_py(py, &m.metadata)?)?;
     Ok(dict.into())
 }
+
+/// Consolidate an explicit cluster with CALLER-SUPPLIED text.
+///
+/// The default `consolidate()` writes an extractive join of the cluster's
+/// texts carrying the MEAN of their embeddings. Measured on BEAM
+/// (2026-08-11), that costs accuracy through embedding dilution: no content
+/// is lost, but N precise vectors collapse into one average that matches no
+/// specific query well. This entry point lets the caller supply a real
+/// synthesis — e.g. from a small local model — whose vector describes the
+/// text that was actually written.
+///
+/// `embedding`: omit to let the ENGINE embed `text` (requires an engine
+/// embedder). Callers whose embedder is Python-side — `YantrikDB(embedder=…)`
+/// / `set_embedder()`, where the engine itself has none — must pass the
+/// vector they computed for `text`.
+///
+/// Returns the same dict shape as `consolidate()`'s elements, plus
+/// `embedded_from_text` reporting which path produced the vector.
+#[pyfunction]
+#[pyo3(name = "consolidate_cluster", signature = (db, source_rids, text, embedding=None))]
+pub fn py_consolidate_cluster(
+    py: Python<'_>,
+    db: &PyYantrikDB,
+    source_rids: Vec<String>,
+    text: &str,
+    embedding: Option<Vec<f32>>,
+) -> PyResult<PyObject> {
+    let inner = db.get_inner()?;
+    let out = yantrikdb_core::consolidate::consolidate_cluster(
+        inner,
+        &source_rids,
+        text,
+        embedding.as_deref(),
+    )
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+    json_to_py(py, &out)
+}

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -13,7 +13,15 @@ impl PyYantrikDB {
     /// key + same payload returns the ORIGINAL rid with nothing re-written;
     /// same key + different payload raises an idempotency-conflict error. The
     /// trailing kwarg default keeps every existing Python caller unchanged.
-    #[pyo3(signature = (text, memory_type="episodic", importance=0.5, valence=0.0, half_life=604800.0, metadata=None, embedding=None, namespace="default", certainty=0.8, domain="general", source="user", emotional_state=None, idempotency_key=None))]
+    ///
+    /// `created_at` (0.14): caller-supplied event time in epoch seconds, for
+    /// historical import — a bulk-loaded corpus keeps its real timeline, so
+    /// decay/recency, `time_window`, and `recall_as_of` are meaningful instead
+    /// of collapsing onto the ingest wall-clock. `None` stamps now(), the
+    /// prior behavior byte-for-byte. Lands in created_at, updated_at, AND
+    /// last_access (decay runs from the event, not the import), and joins the
+    /// idempotency digest — a re-dated retry is a different write.
+    #[pyo3(signature = (text, memory_type="episodic", importance=0.5, valence=0.0, half_life=604800.0, metadata=None, embedding=None, namespace="default", certainty=0.8, domain="general", source="user", emotional_state=None, idempotency_key=None, created_at=None))]
     #[allow(clippy::too_many_arguments)]
     fn record(
         &self,
@@ -31,6 +39,7 @@ impl PyYantrikDB {
         source: &str,
         emotional_state: Option<&str>,
         idempotency_key: Option<&str>,
+        created_at: Option<f64>,
     ) -> PyResult<String> {
         let db = self
             .inner
@@ -67,6 +76,7 @@ impl PyYantrikDB {
                     source,
                     emotional_state,
                     idempotency_key,
+                    created_at,
                 )
                 .map_err(map_err),
             None if db.has_embedder() => db
@@ -83,6 +93,7 @@ impl PyYantrikDB {
                     source,
                     emotional_state,
                     idempotency_key,
+                    created_at,
                 )
                 .map_err(map_err),
             None => {
@@ -96,7 +107,10 @@ impl PyYantrikDB {
                     ));
                 }
                 let emb = self.embed_text(py, text)?;
-                db.record(
+                // Unkeyed, so the idempotency variant is byte-for-byte
+                // record() — used here only because it is the surface that
+                // carries `created_at`.
+                db.record_with_idempotency(
                     text,
                     memory_type,
                     importance,
@@ -109,6 +123,8 @@ impl PyYantrikDB {
                     domain,
                     source,
                     emotional_state,
+                    None,
+                    created_at,
                 )
                 .map_err(map_err)
             }
@@ -326,7 +342,8 @@ impl PyYantrikDB {
     /// Identical semantics to `record(text=..., embedding=None)` when an
     /// embedder is attached; provided as an explicit surface that mirrors
     /// the engine's `record_text` for users coming from the Rust API.
-    #[pyo3(signature = (text, memory_type="episodic", importance=0.5, valence=0.0, half_life=604800.0, metadata=None, namespace="default", certainty=0.8, domain="general", source="user", emotional_state=None))]
+    #[pyo3(signature = (text, memory_type="episodic", importance=0.5, valence=0.0, half_life=604800.0, metadata=None, namespace="default", certainty=0.8, domain="general", source="user", emotional_state=None, created_at=None))]
+    #[allow(clippy::too_many_arguments)]
     fn record_text(
         &self,
         py: Python<'_>,
@@ -341,6 +358,7 @@ impl PyYantrikDB {
         domain: &str,
         source: &str,
         emotional_state: Option<&str>,
+        created_at: Option<f64>,
     ) -> PyResult<String> {
         let db = self
             .inner
@@ -354,7 +372,10 @@ impl PyYantrikDB {
             None => serde_json::json!({}),
         };
 
-        db.record(
+        // Unkeyed, so the idempotency variant is byte-for-byte record() —
+        // used here only because it is the surface that carries `created_at`
+        // (see record()'s docstring for the historical-import contract).
+        db.record_with_idempotency(
             text,
             memory_type,
             importance,
@@ -367,6 +388,8 @@ impl PyYantrikDB {
             domain,
             source,
             emotional_state,
+            None,
+            created_at,
         )
         .map_err(map_err)
     }
@@ -688,6 +711,21 @@ impl PyYantrikDB {
     fn forget(&self, rid: &str) -> PyResult<bool> {
         let db = self.get_inner()?;
         db.forget(rid).map_err(map_err)
+    }
+
+    /// Fetch one memory by rid, or None.
+    ///
+    /// The binding had no rid point-read: `list_memories` pages and
+    /// `recall` is semantic, so a caller holding a rid — which is what
+    /// `get_conflicts`, `get_edges` and the consolidation APIs all return —
+    /// had to page a namespace to resolve it. Returns the memory whatever
+    /// its consolidation_status: naming a rid asks for THAT record.
+    fn get_memory(&self, py: Python<'_>, rid: &str) -> PyResult<Option<PyObject>> {
+        let db = self.get_inner()?;
+        match db.get_memory(rid).map_err(map_err)? {
+            Some(m) => Ok(Some(memory_to_dict(py, &m)?)),
+            None => Ok(None),
+        }
     }
 
     #[pyo3(signature = (limit=50, offset=0, domain=None, memory_type=None, namespace=None, sort_by="created_at"))]
@@ -1280,6 +1318,14 @@ impl PyYantrikDB {
                 .transpose()?
                 .flatten();
 
+            // Optional per-item event time, same contract as
+            // record(created_at=...) — the historical-import surface.
+            let created_at: Option<f64> = d
+                .get_item("created_at")?
+                .map(|v| v.extract::<Option<f64>>())
+                .transpose()?
+                .flatten();
+
             record_inputs.push(yantrikdb_core::RecordInput {
                 text,
                 memory_type,
@@ -1294,6 +1340,7 @@ impl PyYantrikDB {
                 source,
                 emotional_state,
                 idempotency_key,
+                created_at,
             });
         }
 

--- a/src/yantrikdb/consolidate.py
+++ b/src/yantrikdb/consolidate.py
@@ -5,11 +5,13 @@ from yantrikdb._yantrikdb_rust import (
     _extractive_summary,
     _find_clusters,
     consolidate,
+    consolidate_cluster,
     find_consolidation_candidates,
 )
 
 __all__ = [
     "consolidate",
+    "consolidate_cluster",
     "find_consolidation_candidates",
     "_cosine_similarity",
     "_extractive_summary",

--- a/tests/test_created_at.py
+++ b/tests/test_created_at.py
@@ -1,0 +1,124 @@
+"""Wrapper-level `created_at` tests (historical import, 0.14).
+
+Engine semantics (row triple, digest participation, scoring clamp) are
+pinned by the Rust suite; these pin the PYTHON WRAPPER's plumbing — that
+the kwarg reaches the engine on every write surface it is exposed on, and
+that the value is visible THROUGH RECALL rather than only in SQL.
+
+That last distinction is the point: recall scores from the in-memory
+scoring cache, not from the `memories` row, so the two can silently
+disagree. `record_batch` shipped the correct row while its cache insert
+still stamped `now()` — SQL-reading assertions all passed and every
+through-recall consumer (decay, recency, recall_as_of) saw today.
+"""
+
+import math
+import time
+
+import pytest
+
+from yantrikdb import YantrikDB
+
+DIM = 8
+JAN = 1_735_700_000.0  # 2025-01-01
+MAR = 1_740_800_000.0  # 2025-03-01
+APR = 1_743_500_000.0  # 2025-04-01
+
+
+def _vec(seed: float) -> list[float]:
+    raw = [math.sin(seed * 1.7 + i * 2.3) + math.cos(seed * 0.3 + i * 3.1) for i in range(DIM)]
+    norm = math.sqrt(sum(x * x for x in raw))
+    if norm < 1e-9:
+        raw[0] = 1.0
+        norm = 1.0
+    return [x / norm for x in raw]
+
+
+@pytest.fixture
+def db():
+    engine = YantrikDB(db_path=":memory:", embedding_dim=DIM)
+    yield engine
+    engine.close()
+
+
+def _created_at_by_rid(db, query_seed: float, top_k: int = 20) -> dict[str, float]:
+    hits = db.recall(query_embedding=_vec(query_seed), top_k=top_k, skip_reinforce=True)
+    return {h["rid"]: h["created_at"] for h in hits}
+
+
+def test_record_carries_created_at_through_recall(db):
+    historical = db.record("historical", embedding=_vec(1.0), created_at=JAN)
+    present = db.record("present", embedding=_vec(1.05))
+
+    seen = _created_at_by_rid(db, 1.0)
+    assert seen[historical] == JAN
+    assert abs(seen[present] - time.time()) < 60
+
+
+def test_record_batch_carries_per_item_created_at_through_recall(db):
+    rids = db.record_batch([
+        {"text": "batch historical", "embedding": _vec(1.0), "created_at": JAN},
+        {"text": "batch present", "embedding": _vec(1.05)},
+    ])
+
+    seen = _created_at_by_rid(db, 1.0)
+    assert seen[rids[0]] == JAN, "batch event time did not reach the recall path"
+    assert abs(seen[rids[1]] - time.time()) < 60
+
+
+def test_recall_as_of_filters_on_imported_event_times(db):
+    old = db.record("works at the observatory", embedding=_vec(1.0), created_at=JAN)
+    new = db.record("moved to the planetarium", embedding=_vec(1.02), created_at=APR)
+
+    as_of_march = [h["rid"] for h in db.recall_as_of(MAR, query_embedding=_vec(1.0), top_k=10)]
+    assert old in as_of_march
+    assert new not in as_of_march, "a later record was visible in the past"
+
+    today = [h["rid"] for h in db.recall_as_of(time.time(), query_embedding=_vec(1.0), top_k=10)]
+    assert old in today and new in today
+
+
+def test_omitting_created_at_stamps_now(db):
+    before = time.time()
+    rid = db.record("no explicit event time", embedding=_vec(2.0))
+    after = time.time()
+    assert before - 1 <= _created_at_by_rid(db, 2.0)[rid] <= after + 1
+
+
+def test_future_created_at_does_not_amplify_ranking(db):
+    """A future-dated decoy must score as 'new', never as an amplifier.
+
+    decay is `importance * 2^(-elapsed/half_life)` and recency `e^(-age/7d)`;
+    both grow without bound for a negative age, which caller-supplied
+    timestamps made reachable. Clamped at the scoring boundary.
+    """
+    target = db.record("the target memory about the launch", embedding=_vec(1.0))
+    db.record(
+        "unrelated future decoy",
+        embedding=_vec(9.0),
+        created_at=time.time() + 365 * 86400,
+    )
+    top = db.recall(query_embedding=_vec(1.0), top_k=1, skip_reinforce=True)
+    assert top[0]["rid"] == target
+
+
+def test_non_finite_created_at_is_refused(db):
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(Exception):
+            db.record("bad", embedding=_vec(1.0), created_at=bad)
+    assert db.stats()["active_memories"] == 0
+
+
+def test_redated_keyed_write_is_a_different_write(db):
+    def write(ts):
+        return db.record(
+            "the launch happened",
+            embedding=_vec(1.0),
+            idempotency_key="launch-evt-1",
+            created_at=ts,
+        )
+
+    rid = write(JAN)
+    assert write(JAN) == rid, "an identical retry must return the original rid"
+    with pytest.raises(Exception):
+        write(JAN + 1.0)


### PR DESCRIPTION
Five engine changes, each found by **using** the engine against a real corpus (BEAM, via the open Agent Memory Benchmark) rather than by reading it.

## What's in it

| change | kind |
|---|---|
| `created_at` on `record` / `record_text` / `record_batch` | new API, additive |
| `consolidate_cluster(rids, text, embedding)` | new API, additive |
| `get_memory(rid)` | new API, additive |
| code stripping before entity extraction | **behaviour change** |
| negative-elapsed clamp in `decay_score` / `recency_score` | behaviour change (bug fix) |

### `created_at` — historical import

Optional caller-supplied event time; `None` stamps `now()`, byte-for-byte the previous behaviour, so **no existing caller is affected**.

Without it a bulk-imported corpus collapses onto the ingest wall-clock: `recall_as_of` is inert, `time_window` is inert, and decay/recency become insertion-order noise. The value lands in `created_at`, `updated_at` **and** `last_access` — an imported record was last touched when it happened, so decay runs from the event, not the import.

It **joins the idempotency digest**: a re-dated write decays and `recall_as_of`s differently, so it is a different write. Fed only when present and appended after every v1 field, so an absent `created_at` digests byte-identically to v1 and stored pre-upgrade claims still match their retries. Pinned by a golden hex captured from the pre-change code.

### Negative-elapsed clamp

`decay = importance · 2^(-elapsed/half_life)` and `recency = e^(-age/7d)` both grow **without bound** for a negative age — which caller-supplied timestamps made reachable for the first time. A future-dated record now scores as "new" rather than as an unbounded ranking amplifier.

### Code stripping before entity extraction

The capitalized-chunk heuristic cannot distinguish `String`/`GET` in a code sample from `Alice`/`NASA` in prose. Measured on a code-bearing conversation corpus: ~360 records produced **5,550 entities** (~15 each), and **every** conflict the detector raised was a false positive keyed on the entity `GET`, pairing adjacent chunks of the same turn.

Fabricated entities don't merely add noise — they invent entity-scoped conflicts, inflate `mention_count`, and give graph expansion spurious bridges.

After: **4,918 entities**, false-positive conflicts **5 → 1**. Known limits (unterminated fences, escaped backticks, tilde/indented blocks) are documented in the function; all resolve toward *dropping*, because a fabricated entity is worse than a missed one.

### `consolidate_cluster`

The default `consolidate()` writes every member text joined with `" | "` carrying the **mean** of their embeddings. Nothing is lost — but N precise vectors collapse into one average that matches no specific query well, and a hit drags N chunks into the caller's context budget.

This path takes a caller-supplied synthesis whose vector describes *that text*. Both paths now share one `commit_consolidation` helper so bookkeeping (entity transfer, `consolidation_members` CRDT rows, source marking, oplog) cannot drift. Refuses empty clusters, empty text, unknown rids, wrong dimensions, and already-consolidated members.

### `get_memory(rid)`

The store had **no rid point-read**. `list_memories` pages, `recall` is semantic — so a caller holding a rid (what `get_conflicts`, `get_edges` and the consolidation APIs all return) could only resolve it by paging a namespace. Returns the record whatever its `consolidation_status`: naming a rid asks for *that* record, not a currency judgement.

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features` — **this caught that the benches never compiled against `created_at`** while `--lib --tests` passed 1837 tests
- `cargo test --lib`: **1845** default, **1836** `--no-default-features`
- `pylint --enable=E,F`: 10.00/10 on the changed Python
- **User-side smoke through a built wheel**, exercising all five surfaces as a consumer would

## Versioning

`RecordInput` gains a public field, so Rust struct-literal construction breaks — the benches are the proof. That warrants **0.14.0**, not a patch.

Version bumps and tagging are deliberately **not** in this PR; those stay with the operator per the release checklist.

## Release notes to carry forward

Entity extraction now yields a different (smaller, cleaner) set for code-bearing memories. Existing entities are untouched; only new writes differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
