### PR TITLE
chore: 0.14.0

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.13.4"
+version = "0.14.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.13.4"
+version = "0.14.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.13.4"
+version = "0.14.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.13.4"
+version = "0.14.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump for the 0.14.0 release. Content already merged in #127 and #128.

## Why minor, not patch

`RecordInput` gained a public field (`created_at: Option<f64>`), which breaks
Rust callers that construct it by struct literal. Python and MCP callers are
unaffected: the field is optional everywhere it is read, and `None` reproduces
the previous behaviour byte-for-byte, including the payload digest (pinned by
a test against the v1 hex).

## What ships

From #127:
- **Historical import** — caller-supplied `created_at` lands in `created_at`,
  `updated_at` and `last_access`. The subtle half was the scoring cache:
  recall reads `scoring_cache`, not `memories`, so setting the timestamp only
  in the row table passed every SQL assertion while recall still saw `now()`.
- **`consolidate_cluster`** — caller supplies the consolidated text and,
  optionally, its embedding. Both paths run through one `commit_consolidation`
  so the default still passes the cluster mean and behaviour is unchanged.
- **`get_memory(rid)`** — the binding had no point-read by rid at all.
- **Pack namespace** exposed to callers.
- Code-block stripping fix in the knowledge graph (earliest-marker, not
  fence-first).

From #128:
- Process-global embedder init (was a per-instance `OnceLock` against a
  per-pid shared path — a genuine race, which is why aarch64 failed 1-in-4).
- Bounded download retry (4 attempts, 1s/2s/4s) for transport, 429 and 5xx
  only; never other 4xx.

## Four version trackers

All bumped in lockstep:

| file | note |
|---|---|
| `crates/yantrikdb-core/Cargo.toml` | |
| `crates/yantrikdb-python/Cargo.toml` | |
| `crates/yantrikdb-python/pyproject.toml` | |
| `pyproject.toml` | **the one maturin reads** |

The root `pyproject.toml` is the one that has been missed before: it sat at
0.6.3 from April to 2026-05-08 while every release from v0.6.4 to v0.7.2
republished 0.6.3 wheels, which PyPI skipped under `--skip-existing` while the
workflow still exited 0. Six weeks of users on a stale version behind a green
check.

## Local gates

`cargo fmt` clean · `clippy --all-targets --all-features` 0 errors · release
build OK · `flake8` error-select clean · previously on this content: 1848 tests
all-features, 1837 `--no-default-features`, 226 pytest.

## Downstream note

Hermes pins the engine `<0.14`, so 0.14.0 falls outside their pin by design —
plugin updates follow this release rather than gating it.

## After merge

Tag the squashed merge commit `v0.14.0` and push (that triggers
`pypi.yml` → PyPI + crates.io), then `gh release create` **manually** — this
repo's workflow does not create the release page, which is how v0.7.16 shipped
without one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>