### PR TITLE
fix(ci): pin maturin, and stop crates.io publishing ahead of the wheels

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -71,6 +71,27 @@ jobs:
           # v0.7.0/0.7.1/0.7.2 all hit the same CI failure.
           CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8 -march=armv8-a"
         with:
+          # **Pinned, not "latest".** Unpinned, the action resolves the
+          # newest maturin at run time and fetches it inside the manylinux
+          # container. On the v0.14.0 publish that fetch failed twice in a
+          # row on x86_64 linux — and only there, because it is the one
+          # target built inside Docker. Two different symptoms, seven
+          # minutes apart:
+          #
+          #   attempt 1  curl: (52) Empty reply from server   (0 bytes)
+          #   attempt 2  gzip: stdin: not in gzip format      (107 bytes)
+          #
+          # 107 bytes is an API error body, not a tarball, so the second
+          # attempt got a well-formed HTTP response carrying the wrong
+          # content. GitHub was fully operational throughout and the
+          # release endpoint answered 200 from outside CI, which rules out
+          # an outage and points at the run-time resolution itself.
+          #
+          # Pinning removes that lookup: the version is a constant, so the
+          # download is a direct asset URL. It also makes the wheel
+          # reproducible — an unpinned build tool silently changes what
+          # produced a published artifact.
+          maturin-version: v1.14.1
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
           # **abi3.** One wheel per platform, not one per interpreter.
@@ -99,6 +120,10 @@ jobs:
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
+          # Pinned for the same reason as the wheel build above. This job
+          # does not run in a container and did not fail, but an unpinned
+          # build tool is a moving part in a published artifact either way.
+          maturin-version: v1.14.1
           command: sdist
           args: --out dist
 
@@ -144,6 +169,17 @@ jobs:
   publish-crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # **The irreversible surface must not publish ahead of the recoverable
+    # one.** This job used to have no `needs:` at all, while publish-pypi
+    # waited on the full wheel matrix. On v0.14.0 one wheel failed to build:
+    # publish-pypi was skipped by its own `needs:`, and this job published
+    # anyway. The result was a split release — crates.io on 0.14.0, PyPI
+    # still on 0.13.4 — and crates.io versions are permanent, so the half
+    # that could never be taken back was the half that shipped.
+    #
+    # Same prerequisites as publish-pypi now, so a wheel failure blocks
+    # BOTH registries and the release can be retried as a whole.
+    needs: [build-wheels, build-sdist]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Two problems from the v0.14.0 publish: one blocked the release, the other made
the blockage worse than it needed to be.

## 1. Pin maturin to v1.14.1

Unpinned, `maturin-action` resolves the newest maturin at run time and fetches
it **inside the manylinux container**. That fetch failed twice on
`ubuntu-latest / x86_64-unknown-linux-gnu` — and only there, because it is the
one target built inside Docker. Five of six wheels built fine, including
aarch64 linux on the same runner image.

Two different symptoms, seven minutes apart:

| attempt | received | error |
|---|---|---|
| 1 | 0 bytes | `curl: (52) Empty reply from server` |
| 2 | **107 bytes** | `gzip: stdin: not in gzip format` |

107 bytes is an API error body, not a tarball — the second attempt got a
well-formed HTTP response carrying the wrong content. GitHub reported all
systems operational throughout, and the maturin release endpoint answered 200
from outside CI. That rules out an outage and points at the run-time
resolution itself.

Pinning removes the lookup: a constant version is a direct asset URL. It also
makes the wheel reproducible — an unpinned build tool silently changes what
produced a published artifact.

## 2. `publish-crates` had no `needs:`

This is the one worth fixing carefully.

`publish-crates` had **no prerequisites at all**, while `publish-pypi` waited
on the full wheel matrix. So when one wheel failed:

- `publish-pypi` was skipped by its own `needs:` — correct behaviour
- `publish-crates` published anyway — no `needs:` to stop it

The release split: **crates.io on 0.14.0, PyPI still on 0.13.4.**

crates.io versions are permanent — yank only, never delete or replace. So the
half that can never be taken back is the half that shipped, and the half that
could have been retried cleanly is the half that was skipped. Exactly backwards.

**The irreversible publish surface must never have fewer prerequisites than the
recoverable one.** Both now share `needs: [build-wheels, build-sdist]`, so a
wheel failure blocks both registries and the release either lands whole or can
be retried whole.

## Verification

`yaml.safe_load` parses, and job dependencies resolve as intended:

```
build-wheels:   needs=None
build-sdist:    needs=None
publish-pypi:   needs=['build-wheels', 'build-sdist']
publish-crates: needs=['build-wheels', 'build-sdist']
```

## After merge

`pypi.yml` also has `workflow_dispatch`, so 0.14.0 can be completed by
dispatching the fixed workflow from `main` — no retag, and no 0.14.1. `main`
already carries version 0.14.0, and the crates step is idempotent (exit 0 when
the version already exists), so the already-published crate is not disturbed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>