### PR TITLE
docs: 42% fewer tokens, not 42% of them

### DIFF
--- a/docs/benchmarks/beam-frozen-context.md
+++ b/docs/benchmarks/beam-frozen-context.md
@@ -314,7 +314,7 @@ repository, so conditions R and E need no access to their system.
    (2K/4K/8K/12K/16K) and plot rubric against context tokens. Removes the
    length objection entirely and yields quality-per-token rather than a single
    point. This is now the most valuable remaining experiment, because parity
-   at 42% of the tokens is a claim about the *curve*, and we have measured one
+   on 42% fewer tokens is a claim about the *curve*, and we have measured one
    point on it.
 2. **Matched-answerer end-to-end** — our context through
    `gemini-3.1-pro-preview`, completing the 2×2. This is the direct test of


### PR DESCRIPTION
One-word factual fix in the BEAM writeup.

13,673 against 23,689 is **58% of** the tokens — **42% fewer**. The paper states
it correctly under "What this establishes" and inverts it under "Open work":

    before   parity at 42% of the tokens is a claim about the curve
    after    parity on 42% fewer tokens is a claim about the curve

Caught while cross-checking the website version of the paper against the
verified statistics before publishing it. The same error was present in both
copies; the website copy is fixed in its own repo.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>