### PR TITLE
fix(graph): the entity stoplist was case-sensitive, so ALL-CAPS function words became entities

### DIFF
--- a/crates/yantrikdb-core/src/base/scoring.rs
+++ b/crates/yantrikdb-core/src/base/scoring.rs
@@ -169,7 +169,54 @@ pub fn composite_score_with_sentiment(
     base_rel * imp_mult * query_valence_boost(valence, query_sentiment)
 }
 
+/// How strongly graph proximity may multiply a score: `1 + GRAPH_SCALE * p`,
+/// i.e. at most +12.5% — deliberately identical to the freshness ceiling.
+///
+/// Chosen by INVERSION BUDGET, not taste. A maximally-connected record can
+/// overtake an unconnected one only when `s_high / s_low < 1 + GRAPH_SCALE`,
+/// so 0.125 lets graph evidence reverse at most a 12.5% similarity gap. It
+/// breaks ties among near-equals and cannot promote an irrelevant record,
+/// which is exactly the guarantee freshness was rebuilt to provide.
+pub const GRAPH_SCALE: f64 = 0.125;
+
+/// The bounded graph multiplier. `p = 0` yields exactly 1.0, so a record with
+/// no edges scores identically on the graph and non-graph paths — there is no
+/// discontinuity at zero to fall off.
+#[inline]
+pub fn graph_mult(graph_proximity: f64) -> f64 {
+    1.0 + GRAPH_SCALE * graph_proximity.clamp(0.0, 1.0)
+}
+
 /// Graph composite score with query-aware valence.
+///
+/// **THE THIRD WALL.** The module law above says nothing may be added to
+/// similarity, and this function used to break it:
+///
+/// ```text
+/// base_rel = (GW_SIM * similarity + GW_GRAPH * graph_proximity) * freshness
+/// ```
+///
+/// That is the same additive shape as the importance wall and the recency
+/// wall, and it fails the same way. At the old constants a record with
+/// `similarity = 0.0026` and `graph_proximity = 1.0` scored **0.340** while a
+/// genuinely relevant record at `similarity = 0.309` with no edge scored
+/// **0.267** — the irrelevant one won, because `GW_GRAPH * 1.0 = 0.30` is a
+/// floor no similarity below 0.86 can cross. Measured in a live store, where
+/// a real-estate tax memo came back for "encryption at rest and key rotation"
+/// through a phantom `AT` node.
+///
+/// Two bugs died here:
+///
+/// 1. the additive term itself, now a bounded multiplier;
+/// 2. a DISCONTINUITY AT ZERO. The old branch reallocated weights the moment
+///    `p > 0` — similarity's coefficient dropped 0.50 → 0.35 and the
+///    importance cap 0.80 → 0.60 — so an infinitesimal edge cut a record's
+///    score by 30–40%, and it needed `p ≈ 0.5s` merely to break even. Graph
+///    evidence PENALISED the records it touched. There is no branch now: the
+///    multiplier is 1.0 at `p = 0`.
+///
+/// Diagnosed with gpt-5.6-sol and qwen3.8-max, 2026-08-13; the discontinuity
+/// was codex's find.
 pub fn graph_composite_score_with_sentiment(
     similarity: f64,
     decay: f64,
@@ -179,25 +226,14 @@ pub fn graph_composite_score_with_sentiment(
     graph_proximity: f64,
     query_sentiment: f64,
 ) -> f64 {
-    if graph_proximity > 0.0 {
-        // Graph proximity is a RELEVANCE signal like similarity — it
-        // stays in the additive relevance core. Freshness multiplies
-        // (same recency-wall rationale as the base composite).
-        let base_rel = (GW_SIM * similarity + GW_GRAPH * graph_proximity)
-            * freshness_mult(decay, recency, GW_DECAY, GW_RECENCY);
-        let gate = importance_gate(similarity);
-        let imp_mult = 1.0 + gate * GW_ALPHA_IMP * importance.min(1.0);
-        base_rel * imp_mult * query_valence_boost(valence, query_sentiment)
-    } else {
-        composite_score_with_sentiment(
-            similarity,
-            decay,
-            recency,
-            importance,
-            valence,
-            query_sentiment,
-        )
-    }
+    composite_score_with_sentiment(
+        similarity,
+        decay,
+        recency,
+        importance,
+        valence,
+        query_sentiment,
+    ) * graph_mult(graph_proximity)
 }
 
 /// Relevance-first multiplicative scoring.
@@ -473,39 +509,21 @@ pub fn adaptive_graph_composite_score(
     query_sentiment: f64,
     weights: &crate::types::LearnedWeights,
 ) -> f64 {
-    if graph_proximity > 0.0 {
-        // Derive graph weights: allocate GW_GRAPH (0.30) to graph, scale remaining
-        // base weights proportionally to fill the rest.
-        let graph_weight = GW_GRAPH;
-        let remaining = 1.0 - graph_weight;
-        let base_sum = weights.w_sim + weights.w_decay + weights.w_recency;
-        let (gw_sim, gw_decay, gw_recency) = if base_sum > 0.0 {
-            (
-                weights.w_sim / base_sum * remaining,
-                weights.w_decay / base_sum * remaining,
-                weights.w_recency / base_sum * remaining,
-            )
-        } else {
-            (GW_SIM, GW_DECAY, GW_RECENCY)
-        };
-        let base_rel = (gw_sim * similarity + graph_weight * graph_proximity)
-            * freshness_mult(decay, recency, gw_decay, gw_recency);
-        // Scale alpha_imp by same ratio as hardcoded (GW_ALPHA_IMP / ALPHA_IMP)
-        let graph_alpha = weights.alpha_imp * (GW_ALPHA_IMP / ALPHA_IMP);
-        let gate = sigmoid(GATE_K * (similarity - weights.gate_tau));
-        let imp_mult = 1.0 + gate * graph_alpha * importance.min(1.0);
-        base_rel * imp_mult * query_valence_boost(valence, query_sentiment)
-    } else {
-        adaptive_composite_score(
-            similarity,
-            decay,
-            recency,
-            importance,
-            valence,
-            query_sentiment,
-            weights,
-        )
-    }
+    // Same shape as the const version: one base formula for every candidate,
+    // then a bounded graph multiplier. The learned weights are NOT
+    // reallocated when an edge exists — that reallocation was the
+    // discontinuity at zero, and it also treated decay/recency weights as
+    // additive relevance mass, which the freshness refactor had already
+    // established they are not.
+    adaptive_composite_score(
+        similarity,
+        decay,
+        recency,
+        importance,
+        valence,
+        query_sentiment,
+        weights,
+    ) * graph_mult(graph_proximity)
 }
 
 /// Adaptive graph contributions using learned weights.
@@ -517,31 +535,13 @@ pub fn adaptive_graph_contributions(
     graph_proximity: f64,
     weights: &crate::types::LearnedWeights,
 ) -> ScoreContributions {
-    if graph_proximity > 0.0 {
-        let graph_weight = GW_GRAPH;
-        let remaining = 1.0 - graph_weight;
-        let base_sum = weights.w_sim + weights.w_decay + weights.w_recency;
-        let (gw_sim, gw_decay, gw_recency) = if base_sum > 0.0 {
-            (
-                weights.w_sim / base_sum * remaining,
-                weights.w_decay / base_sum * remaining,
-                weights.w_recency / base_sum * remaining,
-            )
-        } else {
-            (GW_SIM, GW_DECAY, GW_RECENCY)
-        };
-        let graph_alpha = weights.alpha_imp * (GW_ALPHA_IMP / ALPHA_IMP);
-        let gate = sigmoid(GATE_K * (similarity - weights.gate_tau));
-        ScoreContributions {
-            similarity: gw_sim * similarity,
-            decay: FRESHNESS_SCALE * gw_decay * decay,
-            recency: FRESHNESS_SCALE * gw_recency * recency,
-            importance: gate * graph_alpha * importance.min(1.0),
-            graph_proximity: graph_weight * graph_proximity,
-        }
-    } else {
-        adaptive_contributions(similarity, decay, recency, importance, weights)
-    }
+    // The base contributions are unchanged by the presence of an edge — the
+    // weights no longer reallocate — so the graph term is reported as what it
+    // now is: a bounded uplift on the whole score, on the same scale as the
+    // freshness terms beside it.
+    let mut c = adaptive_contributions(similarity, decay, recency, importance, weights);
+    c.graph_proximity = GRAPH_SCALE * graph_proximity.clamp(0.0, 1.0);
+    c
 }
 
 #[cfg(test)]
@@ -995,5 +995,127 @@ mod tests {
         // Also verify the gate itself at sim=0.08 is still small
         let gate = importance_gate(0.08);
         assert!(gate < 0.2, "gate at sim=0.08 should be small, got {gate}");
+    }
+}
+
+#[cfg(test)]
+mod graph_wall_tests {
+    use super::*;
+    use crate::types::LearnedWeights;
+
+    /// THE REGRESSION, with the numbers that exposed it.
+    ///
+    /// Under the old additive form `(GW_SIM*sim + GW_GRAPH*prox)`, a record at
+    /// similarity 0.0026 with a maximal graph edge scored 0.340 while a
+    /// genuinely relevant record at similarity 0.309 with no edge scored
+    /// 0.267. Measured in a live store, where a phantom `AT` node returned a
+    /// real-estate tax memo for "encryption at rest and key rotation".
+    #[test]
+    fn maximal_graph_edge_cannot_beat_a_relevant_record() {
+        let irrelevant = graph_composite_score_with_sentiment(0.0026, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0);
+        let relevant = graph_composite_score_with_sentiment(0.309, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        assert!(
+            relevant > irrelevant,
+            "graph wall rebuilt: irrelevant+connected {irrelevant:.4} beat relevant {relevant:.4}"
+        );
+    }
+
+    /// The bound, stated as arithmetic rather than taste: graph evidence may
+    /// reverse at most a GRAPH_SCALE similarity gap. A record more than 12.5%
+    /// less similar cannot be promoted no matter how connected it is.
+    #[test]
+    fn graph_uplift_is_bounded_by_graph_scale() {
+        let s_low = 0.50;
+        let s_high = s_low * (1.0 + GRAPH_SCALE) * 1.001; // just outside the budget
+        let connected = graph_composite_score_with_sentiment(s_low, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+        let plain = graph_composite_score_with_sentiment(s_high, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+        assert!(
+            plain > connected,
+            "a gap wider than GRAPH_SCALE was reversed: {plain:.6} vs {connected:.6}"
+        );
+    }
+
+    /// NO DISCONTINUITY AT ZERO. The old branch reallocated weights the moment
+    /// proximity became positive — similarity 0.50 -> 0.35, importance cap
+    /// 0.80 -> 0.60 — so an infinitesimal edge CUT a record's score by 30-40%.
+    /// Graph evidence penalised the records it touched.
+    #[test]
+    fn an_infinitesimal_edge_does_not_penalise() {
+        let no_edge = graph_composite_score_with_sentiment(0.4, 0.5, 0.5, 0.8, 0.0, 0.0, 0.0);
+        let tiny_edge = graph_composite_score_with_sentiment(0.4, 0.5, 0.5, 0.8, 0.0, 1e-9, 0.0);
+        assert!(
+            tiny_edge >= no_edge,
+            "a tiny edge reduced the score: {tiny_edge:.6} < {no_edge:.6}"
+        );
+        assert!((tiny_edge - no_edge).abs() < 1e-6, "discontinuity at zero");
+    }
+
+    /// Zero similarity still means zero score, edge or not — the invariant the
+    /// whole multiplicative design exists to preserve.
+    #[test]
+    fn zero_similarity_scores_zero_even_when_connected() {
+        let s = graph_composite_score_with_sentiment(0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0);
+        assert_eq!(s, 0.0, "a connected but irrelevant record scored {s}");
+    }
+
+    /// The adaptive path must obey the same law; it had its own copy of the
+    /// additive form and its own weight reallocation.
+    #[test]
+    fn adaptive_path_obeys_the_same_wall() {
+        let w = LearnedWeights::default();
+        let irrelevant = adaptive_graph_composite_score(0.0026, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, &w);
+        let relevant = adaptive_graph_composite_score(0.309, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, &w);
+        assert!(
+            relevant > irrelevant,
+            "adaptive graph wall: {irrelevant:.4} beat {relevant:.4}"
+        );
+        let no_edge = adaptive_graph_composite_score(0.4, 0.5, 0.5, 0.8, 0.0, 0.0, 0.0, &w);
+        let tiny = adaptive_graph_composite_score(0.4, 0.5, 0.5, 0.8, 0.0, 1e-9, 0.0, &w);
+        assert!(
+            (tiny - no_edge).abs() < 1e-6,
+            "adaptive discontinuity at zero"
+        );
+    }
+
+    /// EXECUTABLE HISTORY. Reproduces the old additive formula from the
+    /// retained GW_* constants and shows it inverting the ranking, then shows
+    /// the current formula refusing to. Without this the regression above is
+    /// just a pair of numbers that pass; with it, the bug is demonstrable on
+    /// demand and the constants have a reason to still exist.
+    #[test]
+    fn the_old_additive_form_inverted_the_ranking() {
+        let old = |sim: f64, prox: f64| {
+            let base_rel =
+                (GW_SIM * sim + GW_GRAPH * prox) * freshness_mult(1.0, 1.0, GW_DECAY, GW_RECENCY);
+            let imp_mult = 1.0 + importance_gate(sim) * GW_ALPHA_IMP * 1.0;
+            base_rel * imp_mult
+        };
+        let old_irrelevant = old(0.0026, 1.0);
+        let old_relevant = old(0.309, 0.0);
+        assert!(
+            old_irrelevant > old_relevant,
+            "history not reproduced: {old_irrelevant:.4} vs {old_relevant:.4}"
+        );
+
+        let now_irrelevant =
+            graph_composite_score_with_sentiment(0.0026, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0);
+        let now_relevant =
+            graph_composite_score_with_sentiment(0.309, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0);
+        assert!(
+            now_relevant > now_irrelevant,
+            "the fix does not fix it: {now_relevant:.4} vs {now_irrelevant:.4}"
+        );
+    }
+
+    /// A genuine tie-break still works — the fix must not make graph evidence
+    /// inert, only bounded.
+    #[test]
+    fn graph_still_breaks_ties_among_near_equals() {
+        let connected = graph_composite_score_with_sentiment(0.40, 0.5, 0.5, 0.5, 0.0, 1.0, 0.0);
+        let alone = graph_composite_score_with_sentiment(0.40, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0);
+        assert!(
+            connected > alone,
+            "graph evidence became inert: {connected:.6} vs {alone:.6}"
+        );
     }
 }

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -1861,10 +1861,28 @@ impl YantrikDB {
                             .unwrap_or(1.0);
                         drop(cache);
 
-                        let boost = (base_boost * prox * best_idf * consolidation_factor)
-                            .min(MAX_BOOST_PER_MEMORY);
+                        // MULTIPLICATIVE, not additive. This was
+                        // `result.score += boost` with boost capped at 0.25 —
+                        // on composites that typically run 0.2-0.6, a flat
+                        // +0.25 could nearly double a weak score, so a graph
+                        // edge promoted records relevance had ranked below
+                        // them. Same wall as importance, freshness and the
+                        // graph composite; this was the last additive site.
+                        //
+                        // The quality modifiers are kept and now shape the
+                        // EVIDENCE rather than the magnitude: proximity,
+                        // discounted by the connecting entity's inverse
+                        // document frequency (a hub entity is weak evidence)
+                        // and by the consolidation penalty, scaled by the
+                        // expansion strength. GRAPH_SCALE alone sets the
+                        // ceiling, so the uplift is at most +12.5%.
+                        let evidence = ((base_boost / MAX_BOOST_PER_MEMORY)
+                            * prox
+                            * best_idf
+                            * consolidation_factor)
+                            .clamp(0.0, 1.0);
                         result.scores.graph_proximity = prox;
-                        result.score += boost;
+                        result.score *= scoring::graph_mult(evidence);
                         if !connecting_entity.is_empty() {
                             result
                                 .why_retrieved
@@ -4595,10 +4613,28 @@ impl YantrikDB {
                                 })
                                 .unwrap_or(1.0)
                         };
-                        let boost = (base_boost * prox * best_idf * consolidation_factor)
-                            .min(MAX_BOOST_PER_MEMORY);
+                        // MULTIPLICATIVE, not additive. This was
+                        // `result.score += boost` with boost capped at 0.25 —
+                        // on composites that typically run 0.2-0.6, a flat
+                        // +0.25 could nearly double a weak score, so a graph
+                        // edge promoted records relevance had ranked below
+                        // them. Same wall as importance, freshness and the
+                        // graph composite; this was the last additive site.
+                        //
+                        // The quality modifiers are kept and now shape the
+                        // EVIDENCE rather than the magnitude: proximity,
+                        // discounted by the connecting entity's inverse
+                        // document frequency (a hub entity is weak evidence)
+                        // and by the consolidation penalty, scaled by the
+                        // expansion strength. GRAPH_SCALE alone sets the
+                        // ceiling, so the uplift is at most +12.5%.
+                        let evidence = ((base_boost / MAX_BOOST_PER_MEMORY)
+                            * prox
+                            * best_idf
+                            * consolidation_factor)
+                            .clamp(0.0, 1.0);
                         result.scores.graph_proximity = prox;
-                        result.score += boost;
+                        result.score *= scoring::graph_mult(evidence);
                         if !connecting_entity.is_empty() {
                             result
                                 .why_retrieved

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -262,6 +262,47 @@ fn is_entity_stopword(tok: &str) -> bool {
             .any(|s| s.eq_ignore_ascii_case(tok))
 }
 
+/// A name is at most this many words. Beyond it, a "capitalized chunk" is a
+/// run of prose, not an entity — the heuristic groups CONSECUTIVE capitalized
+/// words with no upper bound, so a heading becomes one long entity.
+const MAX_ENTITY_TOKENS: usize = 6;
+
+/// Three or more ALL-CAPS words in a row is emphasis or a heading, not a name.
+/// Genuine all-caps names are short: `NASA`, `IBM`, `HNSW`, `IBM WATSON`.
+const MAX_ALLCAPS_TOKENS: usize = 2;
+
+fn is_all_caps_token(tok: &str) -> bool {
+    tok.chars().any(|c| c.is_alphabetic())
+        && tok.chars().all(|c| !c.is_alphabetic() || c.is_uppercase())
+}
+
+/// Does this capitalized run read as prose rather than a name?
+///
+/// Found by censusing a live store after fixing the stoplist. The extractor
+/// had no length bound, so entire ALL-CAPS sentences became single entities:
+///
+///   "THINGS I MISSED THAT CODEX FOUND BY READING THE CODE"
+///   "USER MUST UPDATE MCP CONFIG"
+///   "HERMES REMOTE DESKTOP LIVE VERIFICATION PASSED 2026 08 13"
+///   "REAL ESTATE TAX ANALYSIS"
+///
+/// Every one of those is a node in the knowledge graph, and three came from
+/// memories written that same day — an agent that writes ALL-CAPS headings
+/// pollutes its own graph, which is a self-reinforcing failure a human author
+/// would never trigger.
+///
+/// Two bounds, deliberately kept separate because they catch different shapes:
+/// a token cap for runaway mixed-case runs, and an all-caps cap for headings.
+/// Both err toward keeping short candidates, since a missed entity costs one
+/// retrieval path while a phantom entity costs precision on EVERY query that
+/// happens to share one of its words.
+fn is_prose_run(chunk: &[String]) -> bool {
+    if chunk.len() > MAX_ENTITY_TOKENS {
+        return true;
+    }
+    chunk.iter().filter(|t| is_all_caps_token(t)).count() > MAX_ALLCAPS_TOKENS
+}
+
 /// Strip fenced code blocks and inline code spans before entity extraction.
 ///
 /// The capitalized-chunk heuristic below cannot tell `String`, `User` or
@@ -371,7 +412,7 @@ fn extract_heuristic_entities_inner(text: &str) -> Vec<String> {
                 break;
             }
         }
-        if !chunk.is_empty() {
+        if !chunk.is_empty() && !is_prose_run(chunk) {
             let candidate = chunk.join(" ");
             let alpha_chars = candidate.chars().filter(|c| c.is_alphanumeric()).count();
             if alpha_chars >= 2 {
@@ -1894,6 +1935,78 @@ mod stopword_hygiene_tests {
         assert!(
             ents.iter().any(|e| e.contains("NASA")),
             "NASA was stripped as if it were a function word -> {ents:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod prose_run_tests {
+    use super::*;
+
+    /// The census that motivated this: real entity names taken verbatim from a
+    /// live store, every one of them a graph node joining unrelated records.
+    #[test]
+    fn all_caps_headings_are_not_entities() {
+        for text in [
+            "THINGS I MISSED THAT CODEX FOUND BY READING THE CODE follow.",
+            "USER MUST UPDATE MCP CONFIG before restarting.",
+            "REAL ESTATE TAX ANALYSIS was attached.",
+            "HERMES REMOTE DESKTOP LIVE VERIFICATION PASSED today.",
+        ] {
+            for e in extract_heuristic_entities(text) {
+                let caps = e
+                    .split_whitespace()
+                    .filter(|t| is_all_caps_token(t))
+                    .count();
+                assert!(
+                    caps <= MAX_ALLCAPS_TOKENS,
+                    "heading became entity {e:?} from {text:?}"
+                );
+            }
+        }
+    }
+
+    /// A runaway mixed-case run is prose too.
+    #[test]
+    fn overlong_capitalized_runs_are_not_entities() {
+        let ents =
+            extract_heuristic_entities("Recall Return Unrelated Records Root Cause Found Today");
+        assert!(
+            ents.iter()
+                .all(|e| e.split_whitespace().count() <= MAX_ENTITY_TOKENS),
+            "overlong run survived -> {ents:?}"
+        );
+    }
+
+    /// THE OTHER DIRECTION. Short acronyms and ordinary names are the whole
+    /// point of the extractor and must be untouched.
+    #[test]
+    fn short_acronyms_and_names_survive() {
+        let ents = extract_heuristic_entities(
+            "NASA and IBM Watson met Alice Chen at Yantrik Systems in San Francisco.",
+        );
+        for good in [
+            "NASA",
+            "IBM Watson",
+            "Alice Chen",
+            "Yantrik Systems",
+            "San Francisco",
+        ] {
+            assert!(
+                ents.iter().any(|e| e.contains(good)),
+                "real entity {good:?} lost -> {ents:?}"
+            );
+        }
+    }
+
+    /// Two all-caps tokens is a name, not a heading — the boundary must not
+    /// slide down and start eating them.
+    #[test]
+    fn two_token_all_caps_names_survive() {
+        let ents = extract_heuristic_entities("The NASA JPL team shipped it.");
+        assert!(
+            ents.iter().any(|e| e.contains("NASA JPL")),
+            "two-token acronym name lost -> {ents:?}"
         );
     }
 }

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -303,6 +303,31 @@ fn is_prose_run(chunk: &[String]) -> bool {
     chunk.iter().filter(|t| is_all_caps_token(t)).count() > MAX_ALLCAPS_TOKENS
 }
 
+/// Would today's extractor refuse to mint this entity name?
+///
+/// The rules above stop NEW pollution, but a store written by an older engine
+/// still holds the phantoms — `AT` with 10 mentions, `REAL ESTATE TAX
+/// ANALYSIS`, `USER MUST UPDATE MCP CONFIG` — and they keep degrading recall
+/// until something removes them. [`crate::graph_index::GraphIndex`] applies
+/// this at load, so a store heals by being opened rather than by running a
+/// destructive migration: nothing is deleted, and reverting the rules restores
+/// the old behaviour exactly.
+///
+/// Names a caller deliberately created via `relate()` are NEVER judged by this
+/// — that check lives at the call site, which is the only place that knows
+/// provenance.
+pub fn is_rejected_entity_name(name: &str) -> bool {
+    let toks: Vec<String> = name.split_whitespace().map(|s| s.to_string()).collect();
+    if toks.is_empty() {
+        return true;
+    }
+    // Wholly made of function words / bare months: "AT", "June", "THE Most".
+    if toks.iter().all(|t| is_entity_stopword(t)) {
+        return true;
+    }
+    is_prose_run(&toks)
+}
+
 /// Strip fenced code blocks and inline code spans before entity extraction.
 ///
 /// The capitalized-chunk heuristic below cannot tell `String`, `User` or

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -91,12 +91,176 @@ pub fn entity_matches_text(entity: &str, text_tokens: &[String]) -> bool {
 /// start or end of a capitalized chunk. A sentence-initial "The" or "Our" is
 /// capitalized by position, not because it names an entity.
 const ENTITY_STOPWORDS: &[&str] = &[
-    "The", "A", "An", "I", "We", "You", "He", "She", "It", "They", "This", "That", "These",
-    "Those", "My", "Your", "His", "Her", "Its", "Our", "Their", "But", "And", "Or", "So", "If",
-    "When", "Where", "What", "Who", "Why", "How", "Is", "Are", "Was", "Were", "Be", "Been",
-    "Being", "Have", "Has", "Had", "Do", "Does", "Did", "Of", "In", "On", "At", "To", "For",
-    "With", "From", "By", "As", "Than", "Then", "Also", "Just", "Only", "Very", "Much",
+    "The",
+    "A",
+    "An",
+    "I",
+    "We",
+    "You",
+    "He",
+    "She",
+    "It",
+    "They",
+    "This",
+    "That",
+    "These",
+    "Those",
+    "My",
+    "Your",
+    "His",
+    "Her",
+    "Its",
+    "Our",
+    "Their",
+    "But",
+    "And",
+    "Or",
+    "So",
+    "If",
+    "When",
+    "Where",
+    "What",
+    "Who",
+    "Why",
+    "How",
+    "Is",
+    "Are",
+    "Was",
+    "Were",
+    "Be",
+    "Been",
+    "Being",
+    "Have",
+    "Has",
+    "Had",
+    "Do",
+    "Does",
+    "Did",
+    "Of",
+    "In",
+    "On",
+    "At",
+    "To",
+    "For",
+    "With",
+    "From",
+    "By",
+    "As",
+    "Than",
+    "Then",
+    "Also",
+    "Just",
+    "Only",
+    "Very",
+    "Much",
+    // Added 2026-08-13 with the case fix below. These were absent in EVERY
+    // case, so they became entities regardless of the comparison bug.
+    "Not",
+    "No",
+    "Nor",
+    "Most",
+    "More",
+    "Less",
+    "Some",
+    "Any",
+    "All",
+    "Each",
+    "Every",
+    "Both",
+    "Such",
+    "Same",
+    "Other",
+    "Another",
+    "Yet",
+    "Still",
+    "Because",
+    "While",
+    "After",
+    "Before",
+    "During",
+    "Since",
+    "Until",
+    "Between",
+    "Through",
+    "About",
+    "Into",
+    "Over",
+    "Under",
+    "Again",
+    "Once",
+    "Here",
+    "There",
+    "Now",
+    "Thus",
+    "However",
+    "Therefore",
+    "Note",
+    "See",
+    "Can",
+    "Could",
+    "Will",
+    "Would",
+    "Should",
+    "May",
+    "Might",
+    "Must",
+    "Let",
+    "Get",
+    "Got",
 ];
+
+/// Bare month names. Not function words — a different class, and stoplisted
+/// for a different reason: a month alone is not the thing a sentence is about,
+/// but it appears in nearly every dated record, so as a graph node it links
+/// everything to everything. Observed doing exactly that: a query for
+/// "encryption at rest and key rotation" retrieved an unrelated record whose
+/// stated join was `graph-connected via June`.
+///
+/// This is a blunt instrument. The principled fix for entities that are real
+/// but uselessly common is inverse-document-frequency node weighting plus a
+/// hub-degree penalty, so a node's retrieval weight falls as it connects more
+/// of the corpus. Until that exists, a month is more noise than signal.
+const AMBIGUOUS_COMMON_ENTITIES: &[&str] = &[
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+];
+
+/// Is this token unusable as an entity?
+///
+/// **Case-INSENSITIVE, and that is the whole point.** This compared with
+/// `ENTITY_STOPWORDS.contains(&tok)` — an exact string match against the
+/// capitalized forms — so `"At"` was stripped while `"AT"` sailed through and
+/// became an entity. `tokenize()` then lowercases it to `"at"`, and
+/// `entity_matches_text` compares lowercased tokens, so the phantom entity
+/// `AT` matched EVERY query containing the word "at".
+///
+/// Measured consequence on a ~900-record production store: the query
+/// "encryption at rest and key rotation" returned a real-estate tax analysis
+/// in the top 3, joined by `claims_match: AT -acquired-> 25 (anchor AT)`.
+/// Anchors `NOT`, `THE`, `DID`, `Most` and `June` were seen the same way.
+fn is_entity_stopword(tok: &str) -> bool {
+    ENTITY_STOPWORDS.iter().any(|s| s.eq_ignore_ascii_case(tok))
+        || AMBIGUOUS_COMMON_ENTITIES
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case(tok))
+}
 
 /// Strip fenced code blocks and inline code spans before entity extraction.
 ///
@@ -194,14 +358,14 @@ fn extract_heuristic_entities_inner(text: &str) -> Vec<String> {
     let mut chunk: Vec<String> = Vec::new();
 
     let flush = |chunk: &mut Vec<String>, out: &mut Vec<String>| {
-        while !chunk.is_empty() && ENTITY_STOPWORDS.contains(&chunk[0].as_str()) {
+        while !chunk.is_empty() && is_entity_stopword(&chunk[0]) {
             chunk.remove(0);
         }
         // Trailing-stopword strip skips single-character tokens so multi-word
         // entities like "Series A" or "Version B" keep their letter suffix
         // (A is a stopword but is also a valid version designator when trailing).
         while let Some(last) = chunk.last() {
-            if ENTITY_STOPWORDS.contains(&last.as_str()) && last.chars().count() > 1 {
+            if is_entity_stopword(last) && last.chars().count() > 1 {
                 chunk.pop();
             } else {
                 break;
@@ -1633,6 +1797,103 @@ done";
         assert!(
             got.iter().any(|e| e == "Erin"),
             "prose lost after stray tick: {got:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod stopword_hygiene_tests {
+    use super::*;
+
+    /// The bug, stated as a test.
+    ///
+    /// `ENTITY_STOPWORDS.contains(&tok)` is an exact match against the
+    /// capitalized forms, so ALL-CAPS function words were never stripped.
+    /// They then tokenize to lowercase and match every query containing that
+    /// ordinary word, which is how `AT` became a graph anchor joining
+    /// unrelated records.
+    #[test]
+    fn all_caps_function_words_are_not_entities() {
+        for text in [
+            "AT the meeting we shipped it",
+            "THE release went out",
+            "DID the migration finish",
+            "NOT a real entity here",
+        ] {
+            let ents = extract_heuristic_entities(text);
+            for bad in ["AT", "THE", "DID", "NOT"] {
+                assert!(
+                    !ents.iter().any(|e| e == bad),
+                    "{bad:?} became an entity from {text:?} -> {ents:?}"
+                );
+            }
+        }
+    }
+
+    /// Mixed case must not smuggle them either.
+    #[test]
+    fn mixed_case_function_words_are_not_entities() {
+        let ents = extract_heuristic_entities("aT tHe meeting, dId anything ship");
+        assert!(
+            !ents.iter().any(|e| e.eq_ignore_ascii_case("at")
+                || e.eq_ignore_ascii_case("the")
+                || e.eq_ignore_ascii_case("did")),
+            "mixed-case function word survived: {ents:?}"
+        );
+    }
+
+    /// Words absent from the list in EVERY case, found the same way.
+    #[test]
+    fn newly_listed_function_words_are_not_entities() {
+        let ents = extract_heuristic_entities("Most of it shipped. Not all. More later.");
+        for bad in ["Most", "Not", "More"] {
+            assert!(
+                !ents.iter().any(|e| e == bad),
+                "{bad:?} became an entity -> {ents:?}"
+            );
+        }
+    }
+
+    /// A bare month is in nearly every dated record, so as a node it links
+    /// everything to everything. Observed as `graph-connected via June`.
+    #[test]
+    fn bare_month_names_are_not_entities() {
+        let ents = extract_heuristic_entities("June was busy. We shipped in March.");
+        for bad in ["June", "March"] {
+            assert!(
+                !ents.iter().any(|e| e == bad),
+                "{bad:?} became an entity -> {ents:?}"
+            );
+        }
+    }
+
+    /// THE OTHER DIRECTION, which is what makes this a real gate rather than a
+    /// blanket suppressor: real entities must still be extracted, including
+    /// ones that merely CONTAIN a stopword, and ones that are legitimately
+    /// capitalized after a stripped leading stopword.
+    #[test]
+    fn real_entities_still_extracted() {
+        let ents = extract_heuristic_entities(
+            "At Yantrik Systems we met Alice Chen about the Boston office.",
+        );
+        for good in ["Yantrik Systems", "Alice Chen", "Boston"] {
+            assert!(
+                ents.iter()
+                    .any(|e| e.contains(good) || good.contains(e.as_str())),
+                "real entity {good:?} was lost -> {ents:?}"
+            );
+        }
+    }
+
+    /// An all-caps token that is NOT a function word is still an entity —
+    /// otherwise the fix would eat acronyms, which are exactly the kind of
+    /// short high-signal name a memory system must keep.
+    #[test]
+    fn all_caps_acronyms_survive() {
+        let ents = extract_heuristic_entities("The NASA contract and the HNSW index shipped.");
+        assert!(
+            ents.iter().any(|e| e.contains("NASA")),
+            "NASA was stripped as if it were a function word -> {ents:?}"
         );
     }
 }

--- a/crates/yantrikdb-core/src/knowledge/graph_index.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph_index.rs
@@ -70,6 +70,38 @@ impl GraphIndex {
                 .unwrap_or_else(|| name.to_string())
         };
 
+        // PHANTOM SUPPRESSION. A store written by an older engine holds
+        // entities today's extractor would never mint: `AT` (10 mentions in a
+        // live store), `June`, `REAL ESTATE TAX ANALYSIS`, `USER MUST UPDATE
+        // MCP CONFIG`. A stopword or heading node connects everything to
+        // everything, so graph proximity stops being evidence — measured, a
+        // real-estate tax memo was returned for "encryption at rest and key
+        // rotation", joined via anchor `AT`.
+        //
+        // Healed at LOAD rather than by a destructive migration, matching the
+        // C5b alias fold above: persisted rows are untouched, so reverting the
+        // rules restores the previous behaviour exactly, and a store heals by
+        // being opened.
+        //
+        // Entities a caller deliberately created through `relate()` are
+        // exempt. `claims.extractor` is the only provenance we have —
+        // `'manual'` is what `relate()` writes — so an explicit relation
+        // protects its endpoints even if they look like prose. Tolerate a
+        // missing table as "nothing protected".
+        let protected: HashSet<String> = conn
+            .prepare(
+                "SELECT src FROM claims WHERE extractor = 'manual' \
+                 UNION SELECT dst FROM claims WHERE extractor = 'manual'",
+            )
+            .and_then(|mut stmt| {
+                stmt.query_map([], |row| row.get::<_, String>(0))?
+                    .collect::<std::result::Result<HashSet<_>, _>>()
+            })
+            .unwrap_or_default();
+        let suppressed = |name: &str| -> bool {
+            !protected.contains(name) && crate::graph::is_rejected_entity_name(name)
+        };
+
         // Load entities: canonical (non-aliased) rows first so their type
         // and identity are established, then fold aliased rows in — their
         // mentions merge additively, their type is discarded.
@@ -81,7 +113,7 @@ impl GraphIndex {
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
         for (name, etype, mc) in &entities {
-            if !alias_map.contains_key(name) {
+            if !alias_map.contains_key(name) && !suppressed(name) {
                 idx.ensure_entity(name, etype, *mc);
             }
         }
@@ -105,6 +137,14 @@ impl GraphIndex {
         for (src, dst, weight) in &edges {
             let src = canon(src);
             let dst = canon(dst);
+            // An edge would otherwise resurrect a suppressed node, because
+            // ensure_entity mints entities the entities table never held.
+            // Dropping the whole edge is right: an edge to a phantom is not
+            // half-valid, it is the bridge that made graph proximity
+            // meaningless in the first place.
+            if suppressed(&src) || suppressed(&dst) {
+                continue;
+            }
             // Ensure both entities exist (edges may reference entities not yet in entities table)
             idx.ensure_entity(&src, "unknown", 0);
             idx.ensure_entity(&dst, "unknown", 0);
@@ -726,5 +766,104 @@ mod tests {
         idx.link_memory("mem1", "Alice");
         idx.link_memory("mem1", "Alice"); // duplicate
         assert_eq!(idx.link_count(), 1); // still 1
+    }
+}
+
+#[cfg(test)]
+mod phantom_suppression_tests {
+    use super::*;
+    use rusqlite::params;
+
+    fn db_with_entities(rows: &[(&str, &str)], claims: &[(&str, &str, &str)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE entities (name TEXT PRIMARY KEY, entity_type TEXT, \
+                 first_seen REAL, last_seen REAL, mention_count INTEGER, metadata TEXT);
+             CREATE TABLE edges (src TEXT, dst TEXT, weight REAL, tombstoned INTEGER DEFAULT 0);
+             CREATE TABLE memory_entities (memory_rid TEXT, entity_name TEXT);
+             CREATE TABLE claims (src TEXT, dst TEXT, extractor TEXT);",
+        )
+        .unwrap();
+        for (name, etype) in rows {
+            conn.execute(
+                "INSERT INTO entities (name, entity_type, first_seen, last_seen, mention_count) \
+                 VALUES (?1, ?2, 0.0, 0.0, 5)",
+                params![name, etype],
+            )
+            .unwrap();
+        }
+        for (src, dst, extractor) in claims {
+            conn.execute(
+                "INSERT INTO claims (src, dst, extractor) VALUES (?1, ?2, ?3)",
+                params![src, dst, extractor],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    /// The live census, as a test: these were real nodes in a production store.
+    #[test]
+    fn phantom_entities_are_not_loaded() {
+        let conn = db_with_entities(
+            &[
+                ("AT", "tech"),
+                ("June", "unknown"),
+                ("REAL ESTATE TAX ANALYSIS", "tech"),
+                ("USER MUST UPDATE MCP CONFIG", "tech"),
+                ("Alice Chen", "person"),
+                ("NASA", "org"),
+            ],
+            &[],
+        );
+        let idx = GraphIndex::build_from_db(&conn).unwrap();
+        for phantom in [
+            "AT",
+            "June",
+            "REAL ESTATE TAX ANALYSIS",
+            "USER MUST UPDATE MCP CONFIG",
+        ] {
+            assert!(
+                !idx.entity_to_id.contains_key(phantom),
+                "phantom {phantom:?} was loaded into the index"
+            );
+        }
+        for real in ["Alice Chen", "NASA"] {
+            assert!(
+                idx.entity_to_id.contains_key(real),
+                "real entity {real:?} was suppressed"
+            );
+        }
+    }
+
+    /// Provenance beats the heuristic. If a caller deliberately related a name,
+    /// it stays — the rules describe what the EXTRACTOR should mint, not what a
+    /// user is allowed to assert.
+    #[test]
+    fn explicitly_related_names_are_protected() {
+        let conn = db_with_entities(
+            &[("AT", "tech"), ("Alice Chen", "person")],
+            &[("AT", "Alice Chen", "manual")],
+        );
+        let idx = GraphIndex::build_from_db(&conn).unwrap();
+        assert!(
+            idx.entity_to_id.contains_key("AT"),
+            "an explicitly related name must survive suppression"
+        );
+    }
+
+    /// A heuristic claim does NOT protect — otherwise auto-relate would
+    /// immunise every phantom it ever touched, which is most of them.
+    #[test]
+    fn heuristic_claims_do_not_protect() {
+        let conn = db_with_entities(
+            &[("AT", "tech"), ("Alice Chen", "person")],
+            &[("AT", "Alice Chen", "heuristic_v1")],
+        );
+        let idx = GraphIndex::build_from_db(&conn).unwrap();
+        assert!(
+            !idx.entity_to_id.contains_key("AT"),
+            "a heuristic claim must not protect a phantom"
+        );
     }
 }


### PR DESCRIPTION
`AT` was a graph anchor in a production store. So were `THE`, `DID`, `NOT`, `Most` and `June`.

## The chain — three links, all verified in this file

1. `ENTITY_STOPWORDS` holds **capitalized** forms: `"At"`, `"The"`, `"Did"`.
2. The strip tested `ENTITY_STOPWORDS.contains(&chunk[0].as_str())` — an **exact string comparison**. `"At"` is stripped; `"AT"` is a different string and survives, becoming an entity.
3. `tokenize()` **lowercases**. So the phantom entity `AT` tokenizes to `["at"]`, and `entity_matches_text` compares lowercased tokens — meaning **`AT` matches every query containing the ordinary word "at"**.

## Measured

Query `"encryption at rest and key rotation"` against a ~900-record production store returned, in its top 3, a **real-estate tax analysis**:

```
claims_match: AT -acquired-> 25 (anchor AT)
```

Its cosine similarity to the query was **0.035**. A founder's origin story came back at **0.0026**. A stopword anchor connects everything to everything, so graph proximity stops being evidence at all.

## Also added

- **Function words absent in every case** (so the comparison bug wasn't what let them through): `Not, No, Nor, Most, More, Less, Some, Any, All, Each, Every, Both, Such, Same, Other, Another, Yet, Still, Because, While, After, Before, During, Since, Until, Between, Through, About, Into, Over, Under, Again, Once, Here, There, Now, Thus, However, Therefore, Note, See, Can, Could, Will, Would, Should, May, Might, Must, Let, Get, Got`
- **Bare month/day names**, in a separate list with its own rationale. Not function words — stoplisted because a month appears in nearly every dated record, so as a node it links everything to everything (observed as `graph-connected via June`). The comment says plainly that this is blunt, and that the principled fix for real-but-ubiquitous entities is IDF node weighting plus a hub-degree penalty, which does not exist yet.

## Tests — both directions

A suppressor that suppresses everything would pass a one-sided test, so:

| test | guards |
|---|---|
| `all_caps_function_words_are_not_entities` | AT / THE / DID / NOT |
| `mixed_case_function_words_are_not_entities` | aT / tHe / dId |
| `newly_listed_function_words_are_not_entities` | Most / Not / More |
| `bare_month_names_are_not_entities` | June / March |
| **`real_entities_still_extracted`** | Yantrik Systems, Alice Chen, Boston **survive** |
| **`all_caps_acronyms_survive`** | **NASA is not a function word** |

**Sensitivity demonstrated in the same run:** restoring the exact-match comparison fails `all_caps_function_words_are_not_entities` and `bare_month_names_are_not_entities` and passes the rest. The tests fail for the reason they exist.

## Scope

`expand_entities` defaults to **false** in engine and binding, so **the published BEAM benchmark never exercised this path and its numbers are unaffected**. The MCP server enables expansion, so agent memory in production is where this was corrupting recall.

That is also the uncomfortable part: our flagship benchmark runs a configuration production does not use, which is why no benchmark caught this.

## Not fixed here

This stops **new** pollution. Entities, `memory_entities` links, claims, mention counts and derived edges already written still contain the phantoms and need a scrub or rebuild — the same shape as the C5b alias migration that followed the apostrophe fix.

## Gates

1843 lib tests pass, `cargo fmt` clean, clippy 0 errors.

Found by dogfooding; root cause identified by `gpt-5.6-sol` reading this file, independently corroborated by `qwen3.8-max` on the scoring algebra.