### PR TITLE
chore: 0.14.1

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.14.0"
+version = "0.14.1"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.14.0"
+version = "0.14.1"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump for 0.14.1. Content merged in #134.

## What ships

Four retrieval-correctness defects, found by dogfooding the substrate through MCP and confirmed with `gpt-5.6-sol` and `qwen3.8-max`:

1. **The entity stoplist was case-sensitive** — `"AT"` survived stoplisting, became an entity, and matched every query containing the word "at"
2. **A capitalized run had no length bound** — entire ALL-CAPS sentences became single entities
3. **Existing pollution survived the fix** — `GraphIndex::build_from_db` now refuses to load entities today's extractor wouldn't mint, healed at load like the C5b alias fold
4. **The graph term was additive** at three sites — an irrelevant connected record scored 0.340 against a relevant one at 0.267; plus a discontinuity where an infinitesimal edge *cut* a score 30–40%

## Why patch, not minor

The new public items (`GRAPH_SCALE`, `graph_mult`, `is_rejected_entity_name`) are **additive**, so 0.14.1 is correct under 0.x semver.

More practically: **yantrikdb-hermes-plugin v0.16.0 just shipped a `>=0.12.1,<0.15.0` ceiling.** 0.14.1 lands inside it; 0.15.0 would fall outside and force another plugin release for what is a bug fix.

## Behaviour changes even though the API does not

**Recall ranking moves.** Graph proximity is now a bounded tie-breaker (≤ +12.5%) rather than an additive term, and phantom entities are no longer loaded at all. Any consumer with a retrieval gate should re-run it — this is a correctness fix, so numbers moving is the point, but they will move.

Note `expand_entities` defaults to **false**, so consumers on the default path see no change from the graph fixes. The MCP server enables expansion and is where the corruption was.

## Four version trackers

| file | |
|---|---|
| `crates/yantrikdb-core/Cargo.toml` | |
| `crates/yantrikdb-python/Cargo.toml` | |
| `crates/yantrikdb-python/pyproject.toml` | |
| `pyproject.toml` | **the one maturin reads** |

## After merge

Tag `v0.14.1` on the squashed merge commit, push (triggers `pypi.yml` → PyPI + crates.io), then `gh release create` **manually** — this repo's workflow does not create the release page.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>