### PR TITLE
fix: three ranking walls, the re-embed cutover, and a signal I deleted instead of moving

### DIFF
--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -338,6 +338,26 @@ pub enum YantrikDbError {
     )]
     ForgetDeferredDuringReembed { rid: String },
 
+    /// **2026-08-17.** `rebuild_vec_index` finished building a replacement
+    /// cold tier, but a `db.reembed()` cutover started (or completed) while
+    /// it was working.
+    ///
+    /// The rebuild reads `memories.embedding` — vectors in the space that
+    /// was active when it started — so installing it after a cutover would
+    /// place an index built entirely from OLD-space vectors into the NEW
+    /// generation's state. Every cold-tier distance would then be computed
+    /// against a query encoded by a different model: not a lost write, but
+    /// a whole tier of quietly meaningless scores that no test notices,
+    /// because the index is populated and every lookup returns something.
+    ///
+    /// Retryable: nothing was installed. Re-run the rebuild against the new
+    /// generation.
+    #[error(
+        "rebuild_vec_index deferred: {reason}. Nothing was installed — the rebuilt index was \
+         discarded rather than mixed into a different embedding space. Retry the rebuild."
+    )]
+    IndexRebuildDeferredDuringReembed { reason: String },
+
     /// **v0.10 Item 3 (correction seqlock, sol r5).** A recall could not
     /// obtain a coherent snapshot within its retry budget because
     /// text-changing corrections kept interleaving with its candidate

--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -292,6 +292,52 @@ pub enum YantrikDbError {
     )]
     BatchDeferredDuringReembed { count: usize },
 
+    /// **2026-08-17.** `record_with_rid` — the deterministic replay primitive
+    /// used by the cluster applier — could not acquire a `SyncWriteGuard`
+    /// because a `db.reembed()` cutover is in flight.
+    ///
+    /// It previously took its `SearchState` snapshot with NO guard at all
+    /// (`self.search_state.load_full()`), which is the exact hazard the
+    /// sibling paths were built to avoid: reembed could complete its swap
+    /// between the snapshot and the append, landing the vector in a
+    /// DISCARDED delta index. The row is then durably in SQL, marked active,
+    /// and absent from the live index — stored, alive, unfindable. That is
+    /// the HNSW-orphan failure shape, reached through a different door.
+    ///
+    /// It cannot use `record()`'s queued fallback: this path is deliberately
+    /// byte-deterministic (caller-supplied rid, embedding, timestamp and
+    /// model, engine embedder never invoked), and the queued materializer
+    /// re-encodes under the NEW embedder, which would change the bytes the
+    /// caller pinned. Deferring retryably — the `record_batch` precedent —
+    /// is the honest option: nothing durable has happened yet.
+    #[error(
+        "record_with_rid({rid}) deferred: a db.reembed() cutover is in progress, so the \
+         caller-supplied embedding cannot be committed against a stable generation. No \
+         durable state was changed — retry verbatim once the reembed completes. (This \
+         path cannot take record()'s queued fallback without re-encoding the vector the \
+         caller pinned, which would break its determinism contract.)"
+    )]
+    DeterministicWriteDeferredDuringReembed { rid: String },
+
+    /// **2026-08-17 — the F1/F2 forget-resurrection race.** `forget()` /
+    /// `tombstone_with_rid()` could not acquire a `SyncWriteGuard` because a
+    /// `db.reembed()` cutover is in flight.
+    ///
+    /// Both funnel through `tombstone_inner`, which tombstones the rid and
+    /// its chunks in `search_state.load().vec_index`. Unguarded, a cutover
+    /// could publish an index built from a SQL snapshot predating the
+    /// tombstone, and the delta tombstone died with the discarded state —
+    /// leaving the record tombstoned in SQL and ALIVE in the live index. A
+    /// delete that silently un-deletes.
+    ///
+    /// Retryable: SQL is untouched when this is returned.
+    #[error(
+        "forget({rid}) deferred: a db.reembed() cutover is in progress, so the tombstone \
+         could be applied to an index that is about to be discarded — which would resurrect \
+         the record. No durable state was changed; retry once the reembed completes."
+    )]
+    ForgetDeferredDuringReembed { rid: String },
+
     /// **v0.10 Item 3 (correction seqlock, sol r5).** A recall could not
     /// obtain a coherent snapshot within its retry budget because
     /// text-changing corrections kept interleaving with its candidate

--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -8,7 +8,7 @@
 // v40 adds `memory_chunks` (chunked embeddings — one record, N window
 // vectors; docs/chunked_embeddings_design.md). Same v39 shape: a new
 // CREATE TABLE IF NOT EXISTS in SCHEMA_SQL, no migration constant.
-pub const SCHEMA_VERSION: i32 = 40;
+pub const SCHEMA_VERSION: i32 = 41;
 
 pub const SCHEMA_SQL: &str = "
 -- Memory records: the source of truth
@@ -768,6 +768,11 @@ CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+-- Fresh stores record every impression under the post-2026-08-17 meaning
+-- of the ranking features, so the learner filters nothing. Upgraded stores
+-- get a real timestamp here instead. See MIGRATE_V40_TO_V41.
+INSERT OR IGNORE INTO meta (key, value) VALUES ('ranking_feature_epoch', '0');
 
 -- v27 (issue #41): durable audit log of db.reembed() phase transitions.
 -- Authoritative source for crash recovery and observability. The
@@ -2767,4 +2772,42 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_idempotency
 pub const MIGRATE_V37_TO_V38: &str = "
 CREATE INDEX IF NOT EXISTS idx_oplog_pending_ordered ON oplog(hlc, op_id) WHERE applied = 0;
 DROP INDEX IF EXISTS idx_oplog_pending;
+";
+
+/// v41 (2026-08-17): the ranking features changed MEANING, so every fit
+/// made against the old meaning is void.
+///
+/// `f_decay` is recorded at serve time from `ScoreBreakdown.decay`
+/// (engine/impressions.rs) and read back by the learner
+/// (engine/learning.rs) with no notion of which formula produced it. On
+/// 2026-08-17 `decay` stopped being "time since this record was last READ"
+/// (`decay_score(importance, half_life, now - last_access)`) and became
+/// "the record's own age" (`scoring::ranking_decay`). Same column, same
+/// name, different quantity.
+///
+/// Two consequences, both silent without this migration:
+///
+///  1. `learned_weights` holds a `w_decay` fitted against the OLD feature
+///     and applied, on every recall, to the NEW one. The other weights were
+///     fitted jointly with it, so the whole vector is suspect — not just
+///     `w_decay`. Reset to defaults; a store simply relearns.
+///  2. Future fits would mix old-meaning and new-meaning rows under one
+///     feature name. Rather than delete the operator's labelled episodes
+///     (production had ~12, they are expensive to collect), stamp the
+///     boundary and let the learner read only what lies after it.
+///
+/// `keyword_boost` is reset here for a second reason: the additive keyword
+/// boost was removed the same day, so that weight is now inert (see
+/// engine/lexical.rs). Its column stays for schema compatibility.
+///
+/// Fresh installs seed the epoch to 0 in SCHEMA_SQL — every impression they
+/// will ever record already uses the new meaning, so nothing is filtered.
+pub const MIGRATE_V40_TO_V41: &str = "
+UPDATE learned_weights SET
+    w_sim = 0.50, w_decay = 0.20, w_recency = 0.30,
+    gate_tau = 0.25, alpha_imp = 0.80, keyword_boost = 0.31,
+    generation = generation + 1, updated_at = strftime('%s','now')
+WHERE id = 1;
+INSERT OR REPLACE INTO meta (key, value)
+    VALUES ('ranking_feature_epoch', CAST(strftime('%s','now') AS TEXT));
 ";

--- a/crates/yantrikdb-core/src/base/scoring.rs
+++ b/crates/yantrikdb-core/src/base/scoring.rs
@@ -19,6 +19,69 @@ pub fn decay_score(importance: f64, half_life: f64, elapsed: f64) -> f64 {
     }
 }
 
+/// Half-life used by the RANKING freshness prior — 7 days, the schema
+/// default for `memories.half_life`.
+///
+/// A CONSTANT, deliberately, rather than the record's stored `half_life`.
+/// See [`ranking_decay`] for why.
+pub const RANKING_HALF_LIFE: f64 = 604_800.0;
+
+/// The decay half of the freshness prior, **for ranking only**.
+///
+/// # The currency bug this replaces (2026-08-17)
+///
+/// Every ranking lane computed its decay term as
+/// `decay_score(importance, row.half_life, now - row.last_access)`. Both of
+/// those inputs are mutated by `reinforce()`, which runs on every recall
+/// that returns a record: it sets `last_access = now` and multiplies
+/// `half_life` by 1.2. So the "freshness" prior was not a property of the
+/// record at all — it was a property of WHO HAD READ IT RECENTLY.
+///
+/// Because reinforcement is PARTIAL — a query freshens only the records IT
+/// returned — this leaks one query's access pattern into the next query's
+/// ranking. Measured on a synthetic store with total ground truth (a value
+/// restated three times: 5 cents → 3 cents → 2 cents):
+///
+/// ```text
+/// COLD store:  "what is the matching tolerance" → 2 cents (current) at #1
+/// after ONE unrelated recall that happened to return the older two:
+///              → 3 cents (STALE) at #1, current demoted to #3
+/// ```
+///
+/// The current record's score never changed (0.49188 both times). The stale
+/// records ROSE, by ~1.5%, purely because their decay term jumped from ~0 to
+/// 0.80 when an unrelated query touched them — and the similarity gap
+/// separating them was only 0.85%. The 30% policy budget is an inversion
+/// budget by design; feeding it access noise means access noise inverts
+/// rankings. It degrades with usage, so it is worst on the most-used stores.
+///
+/// # The rule
+///
+/// A prior is a property of the RECORD, not of the query and not of the
+/// reader. Freshness therefore reads the record's own event time and a fixed
+/// half-life. Usage is a legitimate but DIFFERENT prior with its own bounded,
+/// saturating share of the budget ([`usage_z`] / [`PW_USAGE`]); it must enter
+/// there or not at all, never disguised as freshness at freshness's weight.
+///
+/// `last_access` and the reinforced `half_life` keep driving LIFECYCLE —
+/// [`eviction_score`], tiering, and the `decay()` sweep — which is what
+/// spaced repetition is actually for. Nothing there changes.
+///
+/// # Why a constant half-life
+///
+/// The authored per-record `half_life` would be a fair prior ("this fact is
+/// ephemeral"), but reinforcement OVERWRITES the authored value in place, so
+/// on any store that has served traffic it no longer records what the author
+/// asked for — only how often the record has been read. Restoring it as a
+/// ranking signal needs a separate retention column so the two stop sharing
+/// storage; until then, reading it would re-admit the same leak at 80%
+/// strength (a record read 40 times reaches the 1-year cap and holds decay
+/// 0.37 where an unread peer of the same age holds ~0).
+#[inline]
+pub fn ranking_decay(importance: f64, created_at: f64, ts: f64) -> f64 {
+    decay_score(importance, RANKING_HALF_LIFE, ts - created_at)
+}
+
 /// Compute the recency score: exp(-age / (7 * 86400))
 ///
 /// Negative `age` clamps to 0 (score = 1.0, the maximum) — see
@@ -27,9 +90,61 @@ pub fn recency_score(age: f64) -> f64 {
     f64::exp(-age.max(0.0) / (7.0 * 86400.0))
 }
 
+/// The range `valence` is documented to occupy. Anything outside it is a
+/// caller error, and [`clamp_valence`] treats it as one.
+pub const VALENCE_RANGE: (f64, f64) = (-1.0, 1.0);
+
+/// Clamp a stored valence into its documented range before it multiplies
+/// anything.
+///
+/// # The defect this closes (2026-08-17)
+///
+/// `valence` is documented as `[-1, 1]`, but the write path validates only
+/// that scoring scalars are FINITE (`base/validate.rs`, `validate_scalars`),
+/// so any finite `f64` reaches storage — and from there the score, as an
+/// UNBOUNDED multiplier applied outside the policy budget. Measured on the
+/// published 0.15.2 wheel:
+///
+/// ```text
+/// record A: "…ingest pipeline parses OFX and CSV…"  valence 0    sim 0.7043
+/// record B: "…grandmother's lasagna recipe…"        valence 100  sim 0.0915
+/// query:    "what statement formats does the ingest parse"
+///
+///   B  score 1.49608  (valence multiplier 31.0)   <- rank 0
+///   A  score 0.48850  (valence multiplier  1.0)   <- rank 1
+/// ```
+///
+/// An irrelevant record outscored a relevant one 3:1, and the write that
+/// caused it was accepted without complaint. At `valence = 1e6` the
+/// multiplier is ~300,000: one stored scalar controls the whole ranking.
+///
+/// This is the FIFTH instance of one family — the importance wall, the
+/// recency wall, the graph wall, the currency bug, and now this. Every one
+/// was a signal permitted to create or invert relevance from outside the
+/// shared budget. Clamping HERE, at the two functions every lane's score
+/// passes through, fixes existing stores too: the out-of-range values are
+/// already written, so validating only new writes would leave them live.
+///
+/// Note this bounds the multiplier; it does not put it INSIDE the policy
+/// budget. On a neutral query the surviving `1 + 0.3*|valence|` is still a
+/// query-independent prior spending up to 1.30x outside the shared
+/// allocation, and an aligned sentiment reaches 1.56x against a documented
+/// 1.30x ceiling. That is a separate decision with its own measurement —
+/// deliberately NOT bundled into this fix.
+#[inline]
+pub fn clamp_valence(valence: f64) -> f64 {
+    // NaN maps to 0.0 (neutral): `f64::clamp` panics on a NaN bound and
+    // propagates a NaN value, and a NaN multiplier would poison the whole
+    // ranking rather than just this record.
+    if valence.is_nan() {
+        return 0.0;
+    }
+    valence.clamp(VALENCE_RANGE.0, VALENCE_RANGE.1)
+}
+
 /// Compute the valence boost: 1.0 + 0.3 * |valence|
 pub fn valence_boost(valence: f64) -> f64 {
-    1.0 + 0.3 * valence.abs()
+    1.0 + 0.3 * clamp_valence(valence).abs()
 }
 
 /// Negative sentiment keywords for query-aware valence matching.
@@ -141,7 +256,11 @@ pub fn detect_query_sentiment(query_text: &str) -> f64 {
 /// When query sentiment matches memory valence sign (e.g., negative query + negative memory),
 /// the boost is increased. When they mismatch, the boost is reduced.
 /// For neutral queries (sentiment == 0.0), falls back to the standard symmetric boost.
+///
+/// `memory_valence` is clamped to its documented range first — see
+/// [`clamp_valence`] for the unbounded-multiplier defect that required it.
 pub fn query_valence_boost(memory_valence: f64, query_sentiment: f64) -> f64 {
+    let memory_valence = clamp_valence(memory_valence);
     let base = 1.0 + 0.3 * memory_valence.abs();
     if query_sentiment == 0.0 {
         return base;
@@ -960,6 +1079,136 @@ mod tests {
         assert!(
             relevant_isolated > irrelevant_connected,
             "the graph wall is back: connected {irrelevant_connected} beat relevant {relevant_isolated}"
+        );
+    }
+
+    #[test]
+    fn valence_cannot_be_an_unbounded_multiplier() {
+        // THE 2026-08-17 fifth-wall defect. `valence` is documented [-1,1] but
+        // the write path validates only finiteness, so any f64 reached the
+        // score as a multiplier. Reproduced on the shipped 0.15.2 wheel: an
+        // irrelevant record (sim 0.0915, valence 100) scored 1.49608 and beat
+        // a relevant one (sim 0.7043, valence 0) at 0.48850 — a 31x multiplier.
+        //
+        // The property: no stored valence, however absurd, may lift a record
+        // past the documented ceiling.
+        let ceiling = valence_boost(1.0); // 1.30, the honest maximum
+        for v in [1.0, 1.000_001, 2.0, 100.0, 1e6, f64::MAX, f64::INFINITY] {
+            for signed in [v, -v] {
+                assert!(
+                    valence_boost(signed) <= ceiling + 1e-12,
+                    "valence {signed} escaped the ceiling: {} > {ceiling}",
+                    valence_boost(signed)
+                );
+                // Same bound on the query-aware path, at every sentiment.
+                for s in [-1.0, 0.0, 1.0] {
+                    let b = query_valence_boost(signed, s);
+                    assert!(
+                        b.is_finite() && b <= ceiling * 1.2 + 1e-12,
+                        "query_valence_boost({signed}, {s}) = {b} escaped the bound"
+                    );
+                }
+            }
+        }
+        // NaN must not poison the ranking — it is neutral, not infinite.
+        assert_eq!(valence_boost(f64::NAN), 1.0);
+        assert_eq!(query_valence_boost(f64::NAN, -1.0), 1.0);
+
+        // FAIL-ON-OLD, as an assertion: the pre-fix expression is what the
+        // engine computed. If this ever stops being an inversion, the fixture
+        // no longer models the defect and the assertions above prove nothing.
+        let old_boost_at_100 = 1.0 + 0.3 * 100.0_f64.abs();
+        let old_irrelevant = W_SIM * 0.0915 * old_boost_at_100;
+        let old_relevant = W_SIM * 0.7043 * 1.0;
+        assert!(
+            old_irrelevant > old_relevant,
+            "fixture must reproduce the measured inversion: {old_irrelevant:.5} vs {old_relevant:.5}"
+        );
+
+        // And the same pair under the fix: relevance wins.
+        let now_irrelevant = composite_score(0.0915, 0.0, 0.0, 0.5, 100.0);
+        let now_relevant = composite_score(0.7043, 0.0, 0.0, 0.5, 0.0);
+        assert!(
+            now_relevant > now_irrelevant,
+            "clamped: relevant {now_relevant:.5} must beat valence-inflated {now_irrelevant:.5}"
+        );
+    }
+
+    #[test]
+    fn ranking_decay_reads_event_time_not_access_time() {
+        // The property, stated directly: ranking freshness is a function of
+        // (importance, age) and NOTHING else. It cannot take `last_access` or
+        // the reinforced `half_life` — they are not parameters — so no amount
+        // of reading can move it.
+        let now = 1_000_000_000.0;
+        let age = 300.0 * 86400.0;
+        assert_eq!(
+            ranking_decay(0.8, now - age, now),
+            decay_score(0.8, RANKING_HALF_LIFE, age)
+        );
+        // Monotone in age, and a future-dated record is "new", never amplified.
+        assert!(ranking_decay(0.8, now, now) > ranking_decay(0.8, now - age, now));
+        assert_eq!(ranking_decay(0.8, now + age, now), 0.8);
+    }
+
+    #[test]
+    fn access_history_cannot_invert_a_currency_ranking() {
+        // THE 2026-08-17 currency bug, in score space, from the measured
+        // numbers. One claim restated three times on an aged corpus; the
+        // CURRENT value matches the query slightly better than the stale one
+        // (similarity 0.7428 vs 0.7365 — a 0.85% gap). An earlier, unrelated
+        // query happened to return the stale record and not the current one,
+        // so reinforcement set the stale record's `last_access` to now and its
+        // decay term to 0.80, while the current record kept ~0.
+        let (sim_current, sim_stale) = (0.742_794_8, 0.736_523_7);
+        let age_current = 768.0 * 86400.0;
+        let age_stale = 850.0 * 86400.0;
+        let imp = 0.8;
+
+        // What every ranking lane used to compute: decay from `now - last_access`.
+        let stale_reinforced = composite_score(
+            sim_stale,
+            decay_score(imp, 604_800.0, 0.0), // just read → elapsed 0
+            recency_score(age_stale),
+            imp,
+            0.0,
+        );
+        let current_untouched = composite_score(
+            sim_current,
+            decay_score(imp, 604_800.0, age_current), // never read → ~0
+            recency_score(age_current),
+            imp,
+            0.0,
+        );
+        // FAIL-ON-OLD, kept as an assertion: if this stops holding, the
+        // fixture no longer reproduces the defect and the test below is
+        // proving nothing.
+        assert!(
+            stale_reinforced > current_untouched,
+            "fixture must reproduce the inversion: stale {stale_reinforced:.6} \
+             must beat current {current_untouched:.6} under access-driven decay"
+        );
+
+        // What ranking computes now: freshness from the record's own event time.
+        let now = 1_000_000_000.0;
+        let stale_fixed = composite_score(
+            sim_stale,
+            ranking_decay(imp, now - age_stale, now),
+            recency_score(age_stale),
+            imp,
+            0.0,
+        );
+        let current_fixed = composite_score(
+            sim_current,
+            ranking_decay(imp, now - age_current, now),
+            recency_score(age_current),
+            imp,
+            0.0,
+        );
+        assert!(
+            current_fixed > stale_fixed,
+            "an unrelated prior query must not promote a superseded value: \
+             current {current_fixed:.6} vs stale {stale_fixed:.6}"
         );
     }
 

--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -469,6 +469,27 @@ fn materialize_op(db: &YantrikDB, op: &OplogEntry) -> Result<()> {
             // Remove from scoring cache + vec index + graph index
             let rid = op.payload["rid"].as_str().unwrap_or_default();
             if !rid.is_empty() {
+                // 2026-08-17: a replicated tombstone is a delete, and a
+                // delete applied to an index that is about to be discarded
+                // resurrects the record — the same F1/F2 shape closed at
+                // `tombstone_inner`, reached through the replication
+                // applier instead of forget(). Guard before touching
+                // SearchState so a cutover cannot land between the load and
+                // the tombstone.
+                //
+                // Returning Err here is the RETRYABLE outcome by
+                // construction: `apply_ops` calls `materialize_op` BEFORE
+                // marking the oplog row applied, so a deferred op stays
+                // pending and the next sync replays it. Guarded at the arm
+                // rather than at `purge_chunks` itself, because
+                // `tombstone_inner` already holds a guard when it calls
+                // that helper and a nested acquisition would fail the
+                // moment a cutover began mid-forget.
+                let Some(_sync_guard) = db.write_router.try_enter_sync_writer() else {
+                    return Err(crate::error::YantrikDbError::ForgetDeferredDuringReembed {
+                        rid: rid.to_string(),
+                    });
+                };
                 db.cache_remove(rid);
                 let _seq = db
                     .vec_seq
@@ -529,6 +550,16 @@ fn materialize_op(db: &YantrikDB, op: &OplogEntry) -> Result<()> {
             let strategy = op.payload["strategy"].as_str().unwrap_or("");
             if strategy == "keep_a" || strategy == "keep_b" {
                 if let Some(loser) = op.payload["loser_rid"].as_str() {
+                    // Conflict-loser suppression is a delete too — same
+                    // cutover hazard as the replicated forget above, and a
+                    // resurrected loser is worse than a resurrected forget
+                    // because the winner is still present: the store would
+                    // serve both sides of a resolved conflict.
+                    let Some(_sync_guard) = db.write_router.try_enter_sync_writer() else {
+                        return Err(crate::error::YantrikDbError::ForgetDeferredDuringReembed {
+                            rid: loser.to_string(),
+                        });
+                    };
                     db.cache_remove(loser);
                     let _seq = db
                         .vec_seq

--- a/crates/yantrikdb-core/src/engine/claims_lane.rs
+++ b/crates/yantrikdb-core/src/engine/claims_lane.rs
@@ -276,8 +276,7 @@ impl super::YantrikDB {
             };
             let mem_emb = crate::serde_helpers::deserialize_f32(emb_blob);
             let sim_score = crate::consolidate::cosine_similarity(query_embedding, &mem_emb) as f64;
-            let elapsed = ts - row.last_access;
-            let decay = scoring::decay_score(row.importance, row.half_life, elapsed);
+            let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
             let age = ts - row.created_at;
             let recency = scoring::recency_score(age);
             let composite = scoring::adaptive_composite_score(

--- a/crates/yantrikdb-core/src/engine/indices.rs
+++ b/crates/yantrikdb-core/src/engine/indices.rs
@@ -122,15 +122,59 @@ impl YantrikDB {
     }
 
     /// Rebuild the HNSW vector index from scratch. Called after replication.
+    ///
+    /// # Why the generation is snapshotted and re-checked (2026-08-17)
+    ///
+    /// The rebuild reads `memories.embedding` — vectors in the CURRENTLY
+    /// ACTIVE embedding space — and then installs the result as the cold
+    /// tier of whatever `SearchState` happens to be live at that moment. A
+    /// reembed cutover between those two points meant installing an index
+    /// built entirely from OLD-space vectors into the NEW generation's
+    /// state: every cold-tier distance computed against a query encoded by
+    /// a different model. Not a lost write — a whole tier of quietly
+    /// meaningless scores, which no test would notice because the index is
+    /// populated and every lookup returns something.
+    ///
+    /// The guard is NOT held across the build: on a large store that is
+    /// seconds to minutes of work, and blocking the cutover for its
+    /// duration would trade a correctness bug for an availability one.
+    /// Instead this follows the correction path's shape — snapshot the
+    /// generation, do the slow work unguarded, then take the guard and
+    /// revalidate. If the generation moved, the rebuilt index describes a
+    /// space that is no longer current and is discarded rather than
+    /// installed; the caller retries against the new generation.
     pub fn rebuild_vec_index(&self) -> Result<usize> {
+        let generation_before = self.search_state.load_full().generation;
+
         let conn = self.conn.lock();
         let new_index =
             Self::build_vec_index_with_enc(&conn, self.embedding_dim, self.enc.as_ref())?;
         let count = new_index.len();
         drop(conn);
+
+        let Some(_sync_guard) = self.write_router.try_enter_sync_writer() else {
+            return Err(
+                crate::error::YantrikDbError::IndexRebuildDeferredDuringReembed {
+                    reason: "a reembed cutover began while the index was being rebuilt".to_string(),
+                },
+            );
+        };
+        let state = self.search_state.load_full();
+        if state.generation != generation_before {
+            return Err(
+                crate::error::YantrikDbError::IndexRebuildDeferredDuringReembed {
+                    reason: format!(
+                        "generation moved {generation_before} -> {} during the rebuild; the built \
+                     index holds vectors from the old embedding space",
+                        state.generation
+                    ),
+                },
+            );
+        }
+
         // **Issue #41 brainstorm-4 §1.** Install the rebuilt cold tier
         // into the active-generation DeltaIndex via SearchState.
-        self.search_state.load().vec_index.install_cold(new_index);
+        state.vec_index.install_cold(new_index);
         Ok(count)
     }
 

--- a/crates/yantrikdb-core/src/engine/learning.rs
+++ b/crates/yantrikdb-core/src/engine/learning.rs
@@ -631,6 +631,21 @@ impl YantrikDB {
     /// episode and pair mass normalized per episode.
     fn load_preference_episodes(&self) -> Result<Vec<Episode>> {
         let conn = self.conn();
+        // Impressions recorded before `ranking_feature_epoch` were frozen
+        // under a DIFFERENT meaning of `f_decay` — "time since last read"
+        // rather than "the record's own age" (see MIGRATE_V40_TO_V41). The
+        // column name is identical, so nothing but this boundary
+        // distinguishes them, and fitting across it trains one weight on two
+        // quantities. Fresh stores stamp the epoch at 0 and filter nothing.
+        let epoch: f64 = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'ranking_feature_epoch'",
+                [],
+                |r| r.get::<_, String>(0),
+            )
+            .ok()
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0);
         let mut stmt = conn.prepare(
             "SELECT i.episode_id, i.rid, i.f_similarity, i.f_decay, i.f_recency, \
                     i.f_importance, i.f_valence, i.keyword_boosted, i.created_at, \
@@ -638,10 +653,11 @@ impl YantrikDB {
              FROM ranking_labels l \
              JOIN recall_impressions i \
                ON i.episode_id = l.episode_id AND i.rid = l.rid \
+             WHERE i.created_at >= ?1 \
              ORDER BY i.episode_id, i.rank",
         )?;
         let rows = stmt
-            .query_map([], |r| {
+            .query_map(params![epoch], |r| {
                 Ok(LabeledImpression {
                     episode_id: r.get(0)?,
                     first_seen: r.get(8)?,

--- a/crates/yantrikdb-core/src/engine/lexical.rs
+++ b/crates/yantrikdb-core/src/engine/lexical.rs
@@ -20,20 +20,15 @@
 //!    refused sim 0.057–0.20, i.e. exactly the records it was built to
 //!    rescue.
 //!
-//! The fusion: capture the raw bm25 rank FTS5 already computes and
-//! normalize it per query to a strength in (0, 1] (best match = 1).
-//! That strength then (a) admits reserve slots by lexical strength OR
-//! cosine, so an exact match is rescuable at any similarity, and (b)
-//! lets a top-tier lexical match bypass the FTS_MIN_SIM cosine floor,
-//! which is itself a dim-calibrated constant.
-//!
-//! There used to be a third use — scaling an ADDITIVE keyword boost onto
-//! the score. That was removed on 2026-08-17; see the note where
-//! `keyword_lane_boost` was defined for the measurement. Lexical evidence
-//! now reaches the score only through `apply_lane_agreement`'s budgeted
-//! `agreement_mult`, and lexical RESCUE happens through slot reservation
-//! below. Admission and rescue were always this lane's real jobs; the
-//! additive term was a fourth, unbounded one.
+//! The fusion: capture the raw bm25 rank FTS5 already computes,
+//! normalize per query to a strength in (0, 1] (best match = 1), and
+//! (a) scale the keyword boost by that strength — the query's best
+//! lexical match keeps the old boost magnitude (whose +0.034 MRR
+//! contribution on the production clone is the measured baseline to
+//! preserve), noise pays its own discount; (b) admit reserve slots by
+//! lexical strength OR cosine, so an exact match is rescuable at any
+//! similarity; (c) let a top-tier lexical match bypass the FTS_MIN_SIM
+//! cosine floor, which is itself a dim-calibrated constant.
 //!
 //! Everything here is shared by `recall_inner` and
 //! `recall_profiled_inner` — the two keyword lanes are copies, and a
@@ -128,46 +123,22 @@ pub(crate) fn rank_cmp(a: &RecallResult, b: &RecallResult) -> std::cmp::Ordering
         .then_with(|| a.rid.cmp(&b.rid))
 }
 
-// REMOVED 2026-08-17: `keyword_lane_boost` — the additive keyword boost.
-//
-// It was applied as `score += kb * lex * (1-sim).max(0.2)` at four sites
-// (two per recall twin), which is the one thing base/scoring.rs forbids in
-// its header: NOTHING may be added to similarity. With kb = 0.31 against a
-// relevance ceiling of W_SIM = 0.5, it was a wall of the same family as the
-// importance, recency, graph and valence walls.
-//
-// # Why it could invert a ranking, and why only in one shape
-//
-// Between two FTS-matched records it could NOT invert anything: relevance
-// grows at 0.5 per unit similarity while the boost SHRINKS at 0.31 per unit
-// similarity, so the better match always won. It bit only when the semantic
-// answer was NOT an FTS match — a question answered in synonyms — and so
-// received no boost while token-matching noise collected up to +0.31.
-// Measured on that fixture: the anchor at similarity 0.4774, HIGHER than
-// every distractor (0.4590/0.4578/0.4571), ranked 34th of 35 — score
-// 0.26581 against 0.42723. Subtracting the boost from the distractor gives
-// 0.25952, below the anchor: the additive term alone inverted a true
-// relevance ordering by 34 positions. The same defect was already recorded
-// against `keyword_boost_override` in base/tuning.rs (a target at cosine
-// rank 4 returning at recall rank 39) and left behind a knob.
-//
-// # Why deleting it does not reopen exact-phrase starvation
-//
-// The lane's rescue job is done by [`apply_keyword_reserve`], not by this
-// boost, and its corroboration job is done by `apply_lane_agreement`, which
-// already counts `keyword_match`/`fts_sourced` as a lane and applies the
-// BUDGETED `agreement_mult` (~+3.5%, inside the shared inversion budget).
-// Measured with the boost disabled: the semantic-anchor drop rate falls
-// 1.00 -> 0.00 while exact-phrase recall stays 1.00 and the permanent gate
-// `exact_phrase_in_a_long_record_survives_frame_noise` still passes. So the
-// evidence keeps a score effect — it just spends the shared budget like
-// every other prior instead of an unbounded additive allowance.
-//
-// `LearnedWeights::keyword_boost` and the `YANTRIKDB_KEYWORD_BOOST` knob are
-// deliberately left in place for now: the weight is persisted in the schema
-// and trained from the `keyword_boosted` impression feature. Both are now
-// INERT for ranking. Retiring them touches the schema and the learner, so it
-// is its own change — see the note on `keyword_boost` in base/types.rs.
+/// The keyword-lane boost: the pre-fusion `keyword_boost * (1 - sim)`
+/// scaled by lexical strength. `lex = 1.0` reproduces the old formula
+/// bit-for-bit, so the measured +0.034 contribution of the lane's
+/// genuine matches is preserved; weaker matches pay `lex` as a direct
+/// discount.
+pub(crate) fn keyword_lane_boost(keyword_boost: f64, sim: f64, lex: f64) -> f64 {
+    // A negative override defers to the learned weight, so the default path
+    // is unchanged and the knob exists only to be swept.
+    let t = crate::base::tuning::tuning();
+    let kb = if t.keyword_boost_override >= 0.0 {
+        t.keyword_boost_override
+    } else {
+        keyword_boost
+    };
+    kb * lex.clamp(0.0, 1.0) * (1.0 - sim).max(0.2)
+}
 
 /// Keyword slot reservation (step 3.5 of recall): sort by score, then
 /// lift the best keyword-matched candidates stranded below the top_k
@@ -322,16 +293,14 @@ mod tests {
     }
 
     #[test]
-    fn uniform_ranks_yield_equal_strength() {
-        // When bm25 does not discriminate, every strength is exactly 1.0.
-        // This used to assert that `keyword_lane_boost` then reproduced the
-        // pre-fusion flat formula; that boost is gone (see the note where it
-        // was defined), so what remains testable — and what actually matters
-        // to the reserve, the only consumer left — is the strength itself.
+    fn uniform_ranks_reproduce_the_pre_fusion_lane() {
+        // When bm25 does not discriminate, every strength is 1.0 and
+        // keyword_lane_boost equals the old flat formula exactly.
         let ranked = vec![("x".to_string(), -3.0), ("y".to_string(), -3.0)];
         let lex = lexical_strengths(&ranked);
         for rid in ["x", "y"] {
-            assert_eq!(lex[rid], 1.0);
+            let old = 0.31 * (1.0f64 - 0.4).max(0.2);
+            assert_eq!(keyword_lane_boost(0.31, 0.4, lex[rid]), old);
         }
     }
 

--- a/crates/yantrikdb-core/src/engine/lexical.rs
+++ b/crates/yantrikdb-core/src/engine/lexical.rs
@@ -20,15 +20,20 @@
 //!    refused sim 0.057–0.20, i.e. exactly the records it was built to
 //!    rescue.
 //!
-//! The fusion: capture the raw bm25 rank FTS5 already computes,
-//! normalize per query to a strength in (0, 1] (best match = 1), and
-//! (a) scale the keyword boost by that strength — the query's best
-//! lexical match keeps the old boost magnitude (whose +0.034 MRR
-//! contribution on the production clone is the measured baseline to
-//! preserve), noise pays its own discount; (b) admit reserve slots by
-//! lexical strength OR cosine, so an exact match is rescuable at any
-//! similarity; (c) let a top-tier lexical match bypass the FTS_MIN_SIM
-//! cosine floor, which is itself a dim-calibrated constant.
+//! The fusion: capture the raw bm25 rank FTS5 already computes and
+//! normalize it per query to a strength in (0, 1] (best match = 1).
+//! That strength then (a) admits reserve slots by lexical strength OR
+//! cosine, so an exact match is rescuable at any similarity, and (b)
+//! lets a top-tier lexical match bypass the FTS_MIN_SIM cosine floor,
+//! which is itself a dim-calibrated constant.
+//!
+//! There used to be a third use — scaling an ADDITIVE keyword boost onto
+//! the score. That was removed on 2026-08-17; see the note where
+//! `keyword_lane_boost` was defined for the measurement. Lexical evidence
+//! now reaches the score only through `apply_lane_agreement`'s budgeted
+//! `agreement_mult`, and lexical RESCUE happens through slot reservation
+//! below. Admission and rescue were always this lane's real jobs; the
+//! additive term was a fourth, unbounded one.
 //!
 //! Everything here is shared by `recall_inner` and
 //! `recall_profiled_inner` — the two keyword lanes are copies, and a
@@ -123,22 +128,46 @@ pub(crate) fn rank_cmp(a: &RecallResult, b: &RecallResult) -> std::cmp::Ordering
         .then_with(|| a.rid.cmp(&b.rid))
 }
 
-/// The keyword-lane boost: the pre-fusion `keyword_boost * (1 - sim)`
-/// scaled by lexical strength. `lex = 1.0` reproduces the old formula
-/// bit-for-bit, so the measured +0.034 contribution of the lane's
-/// genuine matches is preserved; weaker matches pay `lex` as a direct
-/// discount.
-pub(crate) fn keyword_lane_boost(keyword_boost: f64, sim: f64, lex: f64) -> f64 {
-    // A negative override defers to the learned weight, so the default path
-    // is unchanged and the knob exists only to be swept.
-    let t = crate::base::tuning::tuning();
-    let kb = if t.keyword_boost_override >= 0.0 {
-        t.keyword_boost_override
-    } else {
-        keyword_boost
-    };
-    kb * lex.clamp(0.0, 1.0) * (1.0 - sim).max(0.2)
-}
+// REMOVED 2026-08-17: `keyword_lane_boost` — the additive keyword boost.
+//
+// It was applied as `score += kb * lex * (1-sim).max(0.2)` at four sites
+// (two per recall twin), which is the one thing base/scoring.rs forbids in
+// its header: NOTHING may be added to similarity. With kb = 0.31 against a
+// relevance ceiling of W_SIM = 0.5, it was a wall of the same family as the
+// importance, recency, graph and valence walls.
+//
+// # Why it could invert a ranking, and why only in one shape
+//
+// Between two FTS-matched records it could NOT invert anything: relevance
+// grows at 0.5 per unit similarity while the boost SHRINKS at 0.31 per unit
+// similarity, so the better match always won. It bit only when the semantic
+// answer was NOT an FTS match — a question answered in synonyms — and so
+// received no boost while token-matching noise collected up to +0.31.
+// Measured on that fixture: the anchor at similarity 0.4774, HIGHER than
+// every distractor (0.4590/0.4578/0.4571), ranked 34th of 35 — score
+// 0.26581 against 0.42723. Subtracting the boost from the distractor gives
+// 0.25952, below the anchor: the additive term alone inverted a true
+// relevance ordering by 34 positions. The same defect was already recorded
+// against `keyword_boost_override` in base/tuning.rs (a target at cosine
+// rank 4 returning at recall rank 39) and left behind a knob.
+//
+// # Why deleting it does not reopen exact-phrase starvation
+//
+// The lane's rescue job is done by [`apply_keyword_reserve`], not by this
+// boost, and its corroboration job is done by `apply_lane_agreement`, which
+// already counts `keyword_match`/`fts_sourced` as a lane and applies the
+// BUDGETED `agreement_mult` (~+3.5%, inside the shared inversion budget).
+// Measured with the boost disabled: the semantic-anchor drop rate falls
+// 1.00 -> 0.00 while exact-phrase recall stays 1.00 and the permanent gate
+// `exact_phrase_in_a_long_record_survives_frame_noise` still passes. So the
+// evidence keeps a score effect — it just spends the shared budget like
+// every other prior instead of an unbounded additive allowance.
+//
+// `LearnedWeights::keyword_boost` and the `YANTRIKDB_KEYWORD_BOOST` knob are
+// deliberately left in place for now: the weight is persisted in the schema
+// and trained from the `keyword_boosted` impression feature. Both are now
+// INERT for ranking. Retiring them touches the schema and the learner, so it
+// is its own change — see the note on `keyword_boost` in base/types.rs.
 
 /// Keyword slot reservation (step 3.5 of recall): sort by score, then
 /// lift the best keyword-matched candidates stranded below the top_k
@@ -293,14 +322,16 @@ mod tests {
     }
 
     #[test]
-    fn uniform_ranks_reproduce_the_pre_fusion_lane() {
-        // When bm25 does not discriminate, every strength is 1.0 and
-        // keyword_lane_boost equals the old flat formula exactly.
+    fn uniform_ranks_yield_equal_strength() {
+        // When bm25 does not discriminate, every strength is exactly 1.0.
+        // This used to assert that `keyword_lane_boost` then reproduced the
+        // pre-fusion flat formula; that boost is gone (see the note where it
+        // was defined), so what remains testable — and what actually matters
+        // to the reserve, the only consumer left — is the strength itself.
         let ranked = vec![("x".to_string(), -3.0), ("y".to_string(), -3.0)];
         let lex = lexical_strengths(&ranked);
         for rid in ["x", "y"] {
-            let old = 0.31 * (1.0f64 - 0.4).max(0.2);
-            assert_eq!(keyword_lane_boost(0.31, 0.4, lex[rid]), old);
+            assert_eq!(lex[rid], 1.0);
         }
     }
 

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -638,6 +638,38 @@ impl YantrikDB {
         ts_micros: i64,
         seq: Option<u64>,
     ) -> Result<bool> {
+        // THE F1/F2 FORGET-RESURRECTION RACE, closed 2026-08-17.
+        //
+        // Both entry points — `forget()` and the cluster-deterministic
+        // `tombstone_with_rid()` — funnel here, and this body tombstones the
+        // rid AND its chunks in `self.search_state.load().vec_index` (see
+        // `purge_chunks`). Neither took the sync-writer guard, so a reembed
+        // cutover could interleave:
+        //
+        //   1. forget() tombstones the row in SQL and in the CURRENT delta;
+        //   2. reembed publishes a new SearchState whose index was built
+        //      from a SQL snapshot taken BEFORE that tombstone committed;
+        //   3. the delta tombstone died with the discarded state.
+        //
+        // The record is then tombstoned in SQL and ALIVE in the live index —
+        // a delete that silently un-deletes, visible only to whoever
+        // retrieves the thing the user asked to forget. Guarding here means
+        // the cutover cannot complete mid-delete: reembed switches to
+        // Queueing and then waits for in-flight sync writers to drain, so a
+        // forget either finishes before the swap or is refused outright.
+        //
+        // Guarded at `tombstone_inner` rather than at each caller
+        // deliberately — one predicate covering forget(), tombstone_with_rid()
+        // and the chunk purge they share, instead of three copies to keep in
+        // sync. (`purge_chunks` has two further direct callers on the
+        // replication conflict-loser path; those are not covered by this
+        // guard and are tracked separately.)
+        let Some(_sync_guard) = self.write_router.try_enter_sync_writer() else {
+            return Err(crate::error::YantrikDbError::ForgetDeferredDuringReembed {
+                rid: rid.to_string(),
+            });
+        };
+
         let ts_secs = (ts_micros as f64) / 1_000_000.0;
 
         // Resolve namespace + execute the UPDATE in a single conn block.

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -109,9 +109,9 @@ use crate::schema::{
     MIGRATE_V25_TO_V26, MIGRATE_V26_TO_V27, MIGRATE_V27_TO_V28, MIGRATE_V28_TO_V29,
     MIGRATE_V29_TO_V30, MIGRATE_V2_TO_V3, MIGRATE_V30_TO_V31, MIGRATE_V31_TO_V32,
     MIGRATE_V32_TO_V33, MIGRATE_V33_TO_V34, MIGRATE_V34_TO_V35, MIGRATE_V35_TO_V36,
-    MIGRATE_V36_TO_V37, MIGRATE_V37_TO_V38, MIGRATE_V3_TO_V4, MIGRATE_V4_TO_V5, MIGRATE_V5_TO_V6,
-    MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10, SCHEMA_SQL,
-    SCHEMA_VERSION,
+    MIGRATE_V36_TO_V37, MIGRATE_V37_TO_V38, MIGRATE_V3_TO_V4, MIGRATE_V40_TO_V41, MIGRATE_V4_TO_V5,
+    MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10,
+    SCHEMA_SQL, SCHEMA_VERSION,
 };
 use crate::types::*;
 
@@ -829,6 +829,9 @@ impl YantrikDB {
             (35, MIGRATE_V35_TO_V36),
             (36, MIGRATE_V36_TO_V37),
             (37, MIGRATE_V37_TO_V38),
+            // v38-v40 were code-only. v41 voids fits made against the old
+            // meaning of `f_decay` — see MIGRATE_V40_TO_V41.
+            (40, MIGRATE_V40_TO_V41),
         ];
         if let Some(v) = existing_version {
             for &(from_v, sql) in migrations {

--- a/crates/yantrikdb-core/src/engine/pack.rs
+++ b/crates/yantrikdb-core/src/engine/pack.rs
@@ -1565,8 +1565,7 @@ impl YantrikDB {
                 }
 
                 let sim_score = (1.0 - distance).max(0.0);
-                let elapsed = ts - row.last_access;
-                let decay = crate::scoring::decay_score(row.importance, row.half_life, elapsed);
+                let decay = crate::scoring::ranking_decay(row.importance, row.created_at, ts);
                 let age = ts - row.created_at;
                 let recency = crate::scoring::recency_score(age);
                 let composite = crate::scoring::adaptive_composite_score(

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -1575,6 +1575,15 @@ impl YantrikDB {
                                 if fts_rid_set.contains(result.rid.as_str())
                                     && !result.why_retrieved.iter().any(|w| w == "keyword_match")
                                 {
+                                    let sim = result.scores.similarity;
+                                    let lex =
+                                        lex_by_rid.get(result.rid.as_str()).copied().unwrap_or(1.0);
+                                    let boost = crate::engine::lexical::keyword_lane_boost(
+                                        learned_weights.keyword_boost,
+                                        sim,
+                                        lex,
+                                    );
+                                    result.score += boost;
                                     result.why_retrieved.push("keyword_match".to_string());
                                 }
                             }
@@ -1647,6 +1656,11 @@ impl YantrikDB {
                                     query_sentiment,
                                     &learned_weights,
                                 );
+                                let kw_boost = crate::engine::lexical::keyword_lane_boost(
+                                    learned_weights.keyword_boost,
+                                    sim_score,
+                                    lex,
+                                );
                                 let mut why =
                                     scoring::build_why(sim_score, recency, decay, row.valence);
                                 why.push("keyword_match".to_string());
@@ -1668,7 +1682,7 @@ impl YantrikDB {
                                     created_at: row.created_at,
                                     importance: row.importance,
                                     valence: row.valence,
-                                    score: composite,
+                                    score: composite + kw_boost,
                                     scores: ScoreBreakdown {
                                         similarity: sim_score,
                                         decay,
@@ -4497,6 +4511,15 @@ impl YantrikDB {
                                 if fts_rid_set.contains(result.rid.as_str())
                                     && !result.why_retrieved.iter().any(|w| w == "keyword_match")
                                 {
+                                    let sim = result.scores.similarity;
+                                    let lex =
+                                        lex_by_rid.get(result.rid.as_str()).copied().unwrap_or(1.0);
+                                    let boost = crate::engine::lexical::keyword_lane_boost(
+                                        learned_weights.keyword_boost,
+                                        sim,
+                                        lex,
+                                    );
+                                    result.score += boost;
                                     result.why_retrieved.push("keyword_match".to_string());
                                 }
                             }
@@ -4567,6 +4590,11 @@ impl YantrikDB {
                                     query_sentiment,
                                     &learned_weights,
                                 );
+                                let kw_boost = crate::engine::lexical::keyword_lane_boost(
+                                    learned_weights.keyword_boost,
+                                    sim_score,
+                                    lex,
+                                );
                                 let mut why =
                                     scoring::build_why(sim_score, recency, decay, row.valence);
                                 why.push("keyword_match".to_string());
@@ -4588,7 +4616,7 @@ impl YantrikDB {
                                     created_at: row.created_at,
                                     importance: row.importance,
                                     valence: row.valence,
-                                    score: composite,
+                                    score: composite + kw_boost,
                                     scores: ScoreBreakdown {
                                         similarity: sim_score,
                                         decay,

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -892,8 +892,7 @@ impl YantrikDB {
                 }
 
                 let sim_score = (1.0 - distance).max(0.0);
-                let elapsed = ts - row.last_access;
-                let decay = scoring::decay_score(row.importance, row.half_life, elapsed);
+                let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                 let age = ts - row.created_at;
                 let recency = scoring::recency_score(age);
                 let composite = scoring::adaptive_composite_score(
@@ -1007,8 +1006,7 @@ impl YantrikDB {
                         continue;
                     }
 
-                    let elapsed = ts - row.last_access;
-                    let decay = scoring::decay_score(row.importance, row.half_life, elapsed);
+                    let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                     let age = ts - row.created_at;
                     let recency = scoring::recency_score(age);
                     let composite = scoring::adaptive_composite_score(
@@ -1565,8 +1563,8 @@ impl YantrikDB {
                         // Scale boost inversely with similarity: memories where vector
                         // search failed but keywords matched get more boost.
                         // Per-query lexical strengths from every phase's bm25
-                        // rows — read by the boost sites below and by the
-                        // keyword reserve (see engine/lexical.rs).
+                        // rows — read by the keyword reserve, the only
+                        // consumer left (see engine/lexical.rs).
                         lex_by_rid = crate::engine::lexical::lexical_strengths(&lex_ranked);
                         explain_fts_ran = true;
 
@@ -1577,15 +1575,6 @@ impl YantrikDB {
                                 if fts_rid_set.contains(result.rid.as_str())
                                     && !result.why_retrieved.iter().any(|w| w == "keyword_match")
                                 {
-                                    let sim = result.scores.similarity;
-                                    let lex =
-                                        lex_by_rid.get(result.rid.as_str()).copied().unwrap_or(1.0);
-                                    let boost = crate::engine::lexical::keyword_lane_boost(
-                                        learned_weights.keyword_boost,
-                                        sim,
-                                        lex,
-                                    );
-                                    result.score += boost;
                                     result.why_retrieved.push("keyword_match".to_string());
                                 }
                             }
@@ -1645,9 +1634,8 @@ impl YantrikDB {
                                     continue;
                                 }
 
-                                let elapsed = ts - row.last_access;
                                 let decay =
-                                    scoring::decay_score(row.importance, row.half_life, elapsed);
+                                    scoring::ranking_decay(row.importance, row.created_at, ts);
                                 let age = ts - row.created_at;
                                 let recency = scoring::recency_score(age);
                                 let composite = scoring::adaptive_composite_score(
@@ -1658,11 +1646,6 @@ impl YantrikDB {
                                     row.valence,
                                     query_sentiment,
                                     &learned_weights,
-                                );
-                                let kw_boost = crate::engine::lexical::keyword_lane_boost(
-                                    learned_weights.keyword_boost,
-                                    sim_score,
-                                    lex,
                                 );
                                 let mut why =
                                     scoring::build_why(sim_score, recency, decay, row.valence);
@@ -1685,7 +1668,7 @@ impl YantrikDB {
                                     created_at: row.created_at,
                                     importance: row.importance,
                                     valence: row.valence,
-                                    score: composite + kw_boost,
+                                    score: composite,
                                     scores: ScoreBreakdown {
                                         similarity: sim_score,
                                         decay,
@@ -1817,8 +1800,7 @@ impl YantrikDB {
                         continue;
                     }
 
-                    let elapsed = ts - row.last_access;
-                    let decay = scoring::decay_score(row.importance, row.half_life, elapsed);
+                    let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                     let age = ts - row.created_at;
                     let recency = scoring::recency_score(age);
                     let composite = scoring::adaptive_composite_score(
@@ -1891,12 +1873,32 @@ impl YantrikDB {
             );
         }
 
-        // Step 2.9: Cold memory fallback
+        // Step 2.9: Lexical rescue fallback
         //
-        // Memories that have NEVER been retrieved (access_count == 0) may contain
-        // unique facts that get buried under frequently-accessed noise. When the
-        // best score so far is weak, search cold memories via FTS to surface
-        // forgotten knowledge.
+        // When the vector lane's best score is weak, sweep FTS for records it
+        // missed. Admission is a pure function of (query, corpus): the
+        // activation threshold, the `cold_min_sim` floor, the dedup against
+        // already-scored RIDs and `passes_recall_filters` do all the work.
+        //
+        // THIS LANE USED TO FILTER ON `access_count = 0` (2026-08-17). The
+        // stated intent was "surface knowledge buried under frequently-accessed
+        // noise", but `reinforce()` increments `access_count` on every recall
+        // that RETURNS a record, so the predicate had two effects the intent
+        // did not ask for:
+        //
+        //   1. Read history decided admission. A record surfaced once by an
+        //      UNRELATED query lost its only rescue route permanently — two
+        //      byte-identical stores gave different results because someone
+        //      had read one of them. Same defect family as the currency bug
+        //      (a prior computed from state a reader mutates), one layer up:
+        //      that one leaked into scoring, this one into candidate selection.
+        //   2. The lane SELF-DISABLED with use. On a mature store nearly every
+        //      record has been returned at least once, so the eligible set
+        //      drains toward empty — the rescue path stops working precisely
+        //      when the corpus is large enough to need it.
+        //
+        // The lift below is keyed on `row.importance`, a property of the
+        // record, so it was never part of this leak and is unchanged.
         if !self.is_encrypted() {
             if let Some(qt) = query_text {
                 let best_score = scored.iter().map(|r| r.score).fold(0.0f64, f64::max);
@@ -1942,14 +1944,13 @@ impl YantrikDB {
                         }
                         let cold_fts = fts_parts.join(" OR ");
 
-                        // Query ONLY cold memories (access_count = 0)
+                        // Lexical rescue over ALL active rows (see the lane comment)
                         let cold_sql = if memory_type.is_some() {
                             format!(
                                 "SELECT m.rid FROM memories m \
                                  JOIN memories_fts ON memories_fts.rowid = m.rowid \
                                  WHERE memories_fts MATCH ?1 \
                                  AND m.consolidation_status = 'active' \
-                                 AND m.access_count = 0 \
                                  AND m.type = ?2 \
                                  {} \
                                  ORDER BY m.importance DESC \
@@ -1967,7 +1968,6 @@ impl YantrikDB {
                                  JOIN memories_fts ON memories_fts.rowid = m.rowid \
                                  WHERE memories_fts MATCH ?1 \
                                  AND m.consolidation_status = 'active' \
-                                 AND m.access_count = 0 \
                                  {} \
                                  ORDER BY m.importance DESC \
                                  LIMIT {}",
@@ -2056,9 +2056,8 @@ impl YantrikDB {
                                     continue;
                                 }
 
-                                let elapsed = ts - row.last_access;
                                 let decay =
-                                    scoring::decay_score(row.importance, row.half_life, elapsed);
+                                    scoring::ranking_decay(row.importance, row.created_at, ts);
                                 let age = ts - row.created_at;
                                 let recency = scoring::recency_score(age);
                                 let composite = scoring::adaptive_composite_score(
@@ -2070,14 +2069,15 @@ impl YantrikDB {
                                     query_sentiment,
                                     &learned_weights,
                                 );
-                                // Cold memory bonus: these haven't been surfaced before
+                                // Rescue-lane lift, scaled by the record's own
+                                // importance — NOT by whether it has been read.
                                 // Bounded multiplicative lift (see
                                 // LANE_LIFT_MAX): admission is the lane's
                                 // job; it does not buy relevance.
                                 let cold_lift = scoring::lane_lift_mult(row.importance);
                                 let mut why =
                                     scoring::build_why(sim_score, recency, decay, row.valence);
-                                why.push("cold_memory".to_string());
+                                why.push("lexical_rescue".to_string());
                                 let contributions = scoring::adaptive_contributions(
                                     sim_score,
                                     decay,
@@ -2384,8 +2384,7 @@ impl YantrikDB {
                             crate::consolidate::cosine_similarity(query_embedding, &mem_embedding)
                                 as f64;
 
-                        let elapsed = ts - row.last_access;
-                        let decay = scoring::decay_score(row.importance, row.half_life, elapsed);
+                        let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                         let age = ts - row.created_at;
                         let recency = scoring::recency_score(age);
 
@@ -2623,8 +2622,8 @@ impl YantrikDB {
                     {
                         lanes.push("graph".into());
                     }
-                    if why.iter().any(|w| w == "cold_memory") {
-                        lanes.push("cold_fallback".into());
+                    if why.iter().any(|w| w == "lexical_rescue") {
+                        lanes.push("lexical_rescue".into());
                     }
                     if why.iter().any(|w| w == "keyword_reserved") {
                         lanes.push("keyword_reserve".into());
@@ -3899,8 +3898,7 @@ impl YantrikDB {
                 }
 
                 let sim_score = (1.0 - distance).max(0.0);
-                let elapsed = ts - row.last_access;
-                let decay = scoring::decay_score(row.importance, row.half_life, elapsed);
+                let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                 let age = ts - row.created_at;
                 let recency = scoring::recency_score(age);
                 let composite = scoring::adaptive_composite_score(
@@ -4007,8 +4005,7 @@ impl YantrikDB {
                         continue;
                     }
 
-                    let elapsed = ts - row.last_access;
-                    let decay = scoring::decay_score(row.importance, row.half_life, elapsed);
+                    let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                     let age = ts - row.created_at;
                     let recency = scoring::recency_score(age);
                     let composite = scoring::adaptive_composite_score(
@@ -4489,8 +4486,8 @@ impl YantrikDB {
                         }
 
                         // Per-query lexical strengths from every phase's bm25
-                        // rows — read by the boost sites below and by the
-                        // keyword reserve (see engine/lexical.rs).
+                        // rows — read by the keyword reserve, the only
+                        // consumer left (see engine/lexical.rs).
                         lex_by_rid = crate::engine::lexical::lexical_strengths(&lex_ranked);
 
                         {
@@ -4500,15 +4497,6 @@ impl YantrikDB {
                                 if fts_rid_set.contains(result.rid.as_str())
                                     && !result.why_retrieved.iter().any(|w| w == "keyword_match")
                                 {
-                                    let sim = result.scores.similarity;
-                                    let lex =
-                                        lex_by_rid.get(result.rid.as_str()).copied().unwrap_or(1.0);
-                                    let boost = crate::engine::lexical::keyword_lane_boost(
-                                        learned_weights.keyword_boost,
-                                        sim,
-                                        lex,
-                                    );
-                                    result.score += boost;
                                     result.why_retrieved.push("keyword_match".to_string());
                                 }
                             }
@@ -4566,9 +4554,8 @@ impl YantrikDB {
                                     continue;
                                 }
 
-                                let elapsed = ts - row.last_access;
                                 let decay =
-                                    scoring::decay_score(row.importance, row.half_life, elapsed);
+                                    scoring::ranking_decay(row.importance, row.created_at, ts);
                                 let age = ts - row.created_at;
                                 let recency = scoring::recency_score(age);
                                 let composite = scoring::adaptive_composite_score(
@@ -4579,11 +4566,6 @@ impl YantrikDB {
                                     row.valence,
                                     query_sentiment,
                                     &learned_weights,
-                                );
-                                let kw_boost = crate::engine::lexical::keyword_lane_boost(
-                                    learned_weights.keyword_boost,
-                                    sim_score,
-                                    lex,
                                 );
                                 let mut why =
                                     scoring::build_why(sim_score, recency, decay, row.valence);
@@ -4606,7 +4588,7 @@ impl YantrikDB {
                                     created_at: row.created_at,
                                     importance: row.importance,
                                     valence: row.valence,
-                                    score: composite + kw_boost,
+                                    score: composite,
                                     scores: ScoreBreakdown {
                                         similarity: sim_score,
                                         decay,
@@ -4719,8 +4701,7 @@ impl YantrikDB {
                         continue;
                     }
 
-                    let elapsed = ts - row.last_access;
-                    let decay = scoring::decay_score(row.importance, row.half_life, elapsed);
+                    let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                     let age = ts - row.created_at;
                     let recency = scoring::recency_score(age);
                     let composite = scoring::adaptive_composite_score(
@@ -4782,7 +4763,7 @@ impl YantrikDB {
             }
         }
 
-        // ── Step 2.9: Cold memory fallback (mirrors recall()) ──
+        // ── Step 2.9: Lexical rescue fallback (mirrors recall()) ──
         if !self.is_encrypted() {
             if let Some(qt) = query_text {
                 let best_score = scored.iter().map(|r| r.score).fold(0.0f64, f64::max);
@@ -4832,7 +4813,6 @@ impl YantrikDB {
                                  JOIN memories_fts ON memories_fts.rowid = m.rowid \
                                  WHERE memories_fts MATCH ?1 \
                                  AND m.consolidation_status = 'active' \
-                                 AND m.access_count = 0 \
                                  AND m.type = ?2 \
                                  {} \
                                  ORDER BY m.importance DESC \
@@ -4850,7 +4830,6 @@ impl YantrikDB {
                                  JOIN memories_fts ON memories_fts.rowid = m.rowid \
                                  WHERE memories_fts MATCH ?1 \
                                  AND m.consolidation_status = 'active' \
-                                 AND m.access_count = 0 \
                                  {} \
                                  ORDER BY m.importance DESC \
                                  LIMIT {}",
@@ -4938,9 +4917,8 @@ impl YantrikDB {
                                     continue;
                                 }
 
-                                let elapsed = ts - row.last_access;
                                 let decay =
-                                    scoring::decay_score(row.importance, row.half_life, elapsed);
+                                    scoring::ranking_decay(row.importance, row.created_at, ts);
                                 let age = ts - row.created_at;
                                 let recency = scoring::recency_score(age);
                                 let composite = scoring::adaptive_composite_score(
@@ -4958,7 +4936,7 @@ impl YantrikDB {
                                 let cold_lift = scoring::lane_lift_mult(row.importance);
                                 let mut why =
                                     scoring::build_why(sim_score, recency, decay, row.valence);
-                                why.push("cold_memory".to_string());
+                                why.push("lexical_rescue".to_string());
                                 let contributions = scoring::adaptive_contributions(
                                     sim_score,
                                     decay,
@@ -5251,9 +5229,7 @@ impl YantrikDB {
                                 query_embedding,
                                 &mem_embedding,
                             ) as f64;
-                            let elapsed = ts - row.last_access;
-                            let decay =
-                                scoring::decay_score(row.importance, row.half_life, elapsed);
+                            let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                             let age = ts - row.created_at;
                             let recency = scoring::recency_score(age);
                             let prox = gi.graph_proximity(rid, &expanded_map);

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1804,6 +1804,31 @@ impl YantrikDB {
             ],
         )?;
 
+        // Issue #41 layer 3, completed 2026-08-17: acquire the sync-writer
+        // guard BEFORE snapshotting, for the same reason record_batch
+        // documents at its own guard — "loaded AFTER the guard above, which
+        // is what actually makes that true: with the guard held, reembed
+        // cannot complete its swap for the rest of this call."
+        //
+        // Until now this path took the snapshot unguarded, so a reembed
+        // cutover could publish a new SearchState between the load and the
+        // index append below. The vector then landed in a DISCARDED delta
+        // index while the row committed to SQL as active: stored, alive,
+        // unfindable — the HNSW-orphan shape through a different door.
+        //
+        // Deferring rather than falling back to record()'s queued path is
+        // deliberate: the queued materializer RE-ENCODES under the new
+        // embedder, and this primitive exists to be byte-deterministic
+        // across leader and followers. Re-encoding would silently break the
+        // determinism contract that is its entire reason to exist.
+        let Some(_sync_guard) = self.write_router.try_enter_sync_writer() else {
+            return Err(
+                crate::error::YantrikDbError::DeterministicWriteDeferredDuringReembed {
+                    rid: rid.to_string(),
+                },
+            );
+        };
+
         // **Issue #41 brainstorm-4 §1.** SearchState snapshot for the
         // determinstic-replay path. The replicated write lands on the
         // currently-active generation's DeltaIndex.

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -642,19 +642,38 @@ impl YantrikDB {
         // The only `namespace =` predicate anywhere in this file is in a
         // test.
         //
-        // Rejecting rather than implementing: the engine has ONE embedder,
-        // one SearchState and one vector space, so a namespace-scoped
-        // re-embed needs per-namespace generations, provenance and indexes
-        // — a redesign, not a WHERE clause. Half of a vector space encoded
-        // with a different model is not a state this engine can represent,
-        // and silently doing the global thing is the worse failure.
+        // This rejection is PERMANENT, not a stopgap (architecture decision,
+        // Pranab, 2026-08-17: "embedding is not namespace specific, it is
+        // engine specific").
+        //
+        // The embedding space is a property of the ENGINE: one embedder, one
+        // SearchState, one vector space, and every query encoded by that one
+        // model. `reembed` exists to change that model, so it is inherently
+        // global — asking to change it for one namespace is not an
+        // unimplemented feature, it is a request the data model cannot
+        // represent. Half a vector space encoded with a different model is
+        // not a state this engine has, and the same reasoning already
+        // governs the cross-dimension refusal a few lines below: the
+        // documented escape hatch there is "open a NEW DB at the new dim and
+        // copy memories over", i.e. a second engine — which is also exactly
+        // what a mounted pack is.
+        //
+        // What a caller asking for this usually wants is a same-space
+        // REFRESH: re-encode a namespace's records with the embedder that is
+        // already active (repairing missing or damaged vectors, including
+        // replicated rows that arrive with no embedding at all). That is a
+        // repair operation, not a model change — it needs no generation
+        // bump, no cutover and no shadow index — and it belongs beside the
+        // other bulk same-space repairs in engine/repair.rs.
         if options.namespace.is_some() {
             return Err(YantrikDbError::InvalidInput(
-                "ReembedOptions::namespace is not implemented — it was accepted \
-                 and reported but applied to no query, so the whole store was \
-                 re-embedded regardless. A namespace-scoped re-embed needs \
-                 per-namespace embedding generations and indexes. Leave it None \
-                 to re-embed the store."
+                "ReembedOptions::namespace is not a supported request: the embedding space \
+                 belongs to the ENGINE, not to a namespace, so re-embedding is necessarily \
+                 store-wide. (Until 2026-08-17 this option was accepted and echoed back while \
+                 being applied to no query, so a 'scoped' call silently re-embedded everything.) \
+                 Leave it None to re-embed the store; to re-encode one namespace under the \
+                 CURRENT embedder, use the same-space refresh instead. For a genuinely separate \
+                 embedding space, use a separate engine — see the cross-dimension note below."
                     .to_string(),
             ));
         }

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -216,9 +216,14 @@ pub struct ReembedProgress {
 /// `batch_size = 256`, `resume_from_checkpoint = true`, no callbacks)
 /// and override per-field as needed.
 pub struct ReembedOptions {
-    /// If set, only re-embed memories in this namespace. Cross-
-    /// namespace reembed is rejected if another reembed is in flight
-    /// (single-job invariant via `meta.reembed_state`).
+    /// **NOT IMPLEMENTED — setting this returns `InvalidInput`.**
+    ///
+    /// It was accepted, echoed into every progress event and stamped into
+    /// the durable status while being applied to no query at all, so a
+    /// "scoped" re-embed silently rewrote the entire store. It now fails
+    /// loudly instead; see the check in [`YantrikDB::reembed`] for why
+    /// scoping needs per-namespace generations and indexes rather than a
+    /// `WHERE` clause.
     pub namespace: Option<String>,
 
     /// Best-effort progress callback fired after each Encoding batch +
@@ -619,6 +624,37 @@ impl YantrikDB {
         if matches!(options.write_policy, ReembedWritePolicy::Pause) {
             return Err(YantrikDbError::InvalidInput(
                 "ReembedWritePolicy::Pause is not implemented — concurrent                  writes would be QUEUED, not rejected. Use Queue explicitly,                  or quiesce writers at the application layer."
+                    .to_string(),
+            ));
+        }
+        // THE THIRD ONE THAT AUDIT MISSED (2026-08-17). `namespace` is
+        // parsed, cloned into every progress event and into the durable
+        // status record — and referenced by ZERO data queries. The count,
+        // the encoding scan, the HNSW rebuild, the tail scan and the final
+        // swap are all global:
+        //
+        //     UPDATE memories SET embedding = embedding_new, ...
+        //         WHERE embedding_new IS NOT NULL
+        //
+        // So `reembed(namespace: Some("a"))` re-embedded the WHOLE STORE
+        // while every progress callback reported namespace "a" — the
+        // failure is invisible precisely because the option is echoed back.
+        // The only `namespace =` predicate anywhere in this file is in a
+        // test.
+        //
+        // Rejecting rather than implementing: the engine has ONE embedder,
+        // one SearchState and one vector space, so a namespace-scoped
+        // re-embed needs per-namespace generations, provenance and indexes
+        // — a redesign, not a WHERE clause. Half of a vector space encoded
+        // with a different model is not a state this engine can represent,
+        // and silently doing the global thing is the worse failure.
+        if options.namespace.is_some() {
+            return Err(YantrikDbError::InvalidInput(
+                "ReembedOptions::namespace is not implemented — it was accepted \
+                 and reported but applied to no query, so the whole store was \
+                 re-embedded regardless. A namespace-scoped re-embed needs \
+                 per-namespace embedding generations and indexes. Leave it None \
+                 to re-embed the store."
                     .to_string(),
             ));
         }
@@ -1283,9 +1319,29 @@ impl YantrikDB {
                     "INSERT OR REPLACE INTO meta (key, value) VALUES ('active_generation', ?1)",
                     params![next_generation.to_string()],
                 )?;
+                // `embedding_model` is promoted from `embedding_new_model` in
+                // the SAME statement as the vector it describes.
+                //
+                // THE DEFECT (2026-08-17): it was not. The swap moved the
+                // vector and NULLed the staging columns while leaving
+                // `embedding_model` at the OLD embedder's name, so after every
+                // global reembed each row claimed a model it was not encoded
+                // with. Three places document the intended behaviour —
+                // base/schema.rs:74 ("an atomic transaction moves these into
+                // the active `embedding` + `embedding_model` columns"),
+                // base/schema.rs:2404 ("Used by the Swap phase to populate
+                // `embedding_model` correctly"), and the `Verifying` doc on
+                // ReembedPhase ("sanity-check that all rows have
+                // `embedding_model = new_embedder`") — and none of it was
+                // implemented. `idx_memories_embedding_model` indexes the
+                // column, so the wrong answer was also fast.
+                //
+                // It survived because NOTHING calls the full reembed pipeline
+                // in a test; `reembed_with_embedder` had zero test callers.
                 let n = conn.execute(
                     "UPDATE memories \
                      SET embedding = embedding_new, \
+                         embedding_model = embedding_new_model, \
                          embedding_generation = ?1, \
                          embedding_new = NULL, \
                          embedding_new_model = NULL \
@@ -1814,6 +1870,77 @@ mod tests {
         }
         fn name(&self) -> Option<String> {
             Some(self.name.clone())
+        }
+    }
+
+    #[test]
+    fn swap_promotes_the_model_identity_with_the_vector() {
+        // THE FIRST END-TO-END REEMBED TEST. `reembed_with_embedder` had
+        // ZERO test callers, which is how the Swap phase shipped without
+        // ever setting `embedding_model` — the vector moved to the new
+        // model, the provenance column kept the old model's name, and
+        // `idx_memories_embedding_model` served that wrong answer quickly.
+        //
+        // Three docs assert the behaviour this pins: base/schema.rs:74,
+        // base/schema.rs:2404, and the `Verifying` variant's own doc
+        // comment ("all rows have embedding_model = new_embedder").
+        let mut db = crate::YantrikDB::new(":memory:", 8).unwrap();
+        db.set_embedder(Box::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:old".to_string(),
+            name: "model-old".to_string(),
+            sentinel: 1.0,
+        }))
+        .unwrap();
+        for i in 0..4 {
+            db.record_text(
+                &format!("record {i}"),
+                "semantic",
+                0.5,
+                0.0,
+                86400.0,
+                &serde_json::json!({}),
+                "default",
+                0.9,
+                "general",
+                "user",
+                None,
+            )
+            .unwrap();
+        }
+
+        let new_embedder = std::sync::Arc::new(PhaseTestEmbedderSentinel {
+            dim: 8,
+            fp: "sha256:new".to_string(),
+            name: "model-new".to_string(),
+            sentinel: 2.0,
+        });
+        db.reembed_with_embedder("model-new", Some(new_embedder), ReembedOptions::default())
+            .unwrap();
+
+        // Every row must now agree with itself: the vector came from
+        // model-new (sentinel 2.0), so the provenance must say model-new.
+        let conn = db.conn();
+        let mut stmt = conn
+            .prepare("SELECT rid, embedding_model, embedding FROM memories")
+            .unwrap();
+        let rows: Vec<(String, Option<String>, Vec<u8>)> = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get::<_, Vec<u8>>(2)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert!(!rows.is_empty(), "fixture must have rows");
+        for (rid, model, blob) in rows {
+            let vec0 = f32::from_le_bytes(blob[0..4].try_into().unwrap());
+            assert_eq!(
+                vec0, 2.0,
+                "row {rid}: vector must come from the NEW embedder"
+            );
+            assert_eq!(
+                model.as_deref(),
+                Some("model-new"),
+                "row {rid}: vector is model-new's but provenance says {model:?} —                  the Swap phase must promote embedding_new_model alongside the vector"
+            );
         }
     }
 

--- a/crates/yantrikdb-core/src/engine/repair.rs
+++ b/crates/yantrikdb-core/src/engine/repair.rs
@@ -283,3 +283,262 @@ impl YantrikDB {
         Ok(report)
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Same-space embedding refresh.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Outcome of a [`YantrikDB::refresh_embeddings`] sweep.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct RefreshReport {
+    /// Whether this was a dry run (no mutations performed).
+    pub dry_run: bool,
+    /// Namespace the sweep was limited to, or `None` for the whole store.
+    pub namespace: Option<String>,
+    /// Recall-visible rows examined (active + consolidated).
+    pub scanned: usize,
+    /// Rows that cannot participate in vector search under the active space:
+    /// a NULL embedding, or a blob whose length is not `dim * 4` bytes.
+    pub unusable_found: usize,
+    /// Rows re-encoded and written back. Always zero on a dry run.
+    pub refreshed: usize,
+    /// Rows whose text changed between scan and apply — skipped, never
+    /// clobbered.
+    pub skipped_concurrent_modification: usize,
+    /// Up to `SAMPLE_CAP` rids that were found unusable.
+    pub sample_rids: Vec<String>,
+    /// Per-row failures. One bad row never aborts the sweep.
+    pub errors: Vec<RepairError>,
+}
+
+struct PendingRefresh {
+    rid: String,
+    scanned_ciphertext: String,
+    new_embedding_blob: Vec<u8>,
+}
+
+impl YantrikDB {
+    /// Re-encode records whose vectors are missing or unusable, using the
+    /// embedder that is **already active**.
+    ///
+    /// # Why this is not a re-embed
+    ///
+    /// The embedding space belongs to the ENGINE, not to a namespace
+    /// (architecture decision, 2026-08-17), so `reembed` — which exists to
+    /// change that model — is necessarily store-wide and rejects a namespace
+    /// scope outright. This is the operation callers usually want instead: it
+    /// changes no model, no fingerprint, no dimension and no generation. It
+    /// only fills in vectors that are absent or malformed, in the space the
+    /// engine is already using.
+    ///
+    /// Because nothing about the space changes, none of the re-embed
+    /// machinery applies: no staging columns, no cutover, no shadow index, no
+    /// `SearchState` swap.
+    ///
+    /// # What it repairs
+    ///
+    /// A row is "unusable" when it is recall-visible but cannot participate
+    /// in vector search: `embedding IS NULL`, or a blob whose length is not
+    /// `dim * 4` bytes. The most important source of the first case is
+    /// REPLICATION — the follower insert omits `embedding`,
+    /// `embedding_model` and `embedding_generation` entirely, so replicated
+    /// rows arrive active in SQL and invisible to semantic recall. This is
+    /// the repair for them.
+    ///
+    /// # Safety
+    ///
+    /// Mirrors [`Self::repair_tool_call_artifacts`], the precedent for bulk
+    /// same-space work: dry-run first, the slow embedding happens outside the
+    /// connection lock, the UPDATE is concurrency-guarded on the exact
+    /// ciphertext that was scanned, and one failing row is recorded rather
+    /// than thrown. The index is rebuilt once at the end — and
+    /// `rebuild_vec_index` now refuses to install across a re-embed cutover,
+    /// so a refresh that races one is reported rather than mixed into the
+    /// wrong space.
+    pub fn refresh_embeddings(
+        &self,
+        namespace: Option<&str>,
+        dry_run: bool,
+    ) -> Result<RefreshReport> {
+        let mut report = RefreshReport {
+            dry_run,
+            namespace: namespace.map(|s| s.to_string()),
+            ..Default::default()
+        };
+
+        // Apply mode re-encodes; fail fast rather than reporting success
+        // while leaving the rows exactly as unusable as they were.
+        if !dry_run && !self.has_embedder() {
+            return Err(YantrikDbError::NoEmbedder);
+        }
+
+        let expected_len = self.embedding_dim() * 4;
+
+        // ── Phase 1: scan. Read-only, conn released before any embedding.
+        // Matches build_vec_index's visible set so text and index stay in
+        // step, exactly as the sibling repair does.
+        let scanned: Vec<(String, String, Option<usize>)> = {
+            let conn = self.conn();
+            let sql = if namespace.is_some() {
+                "SELECT rid, text, length(embedding) FROM memories \
+                 WHERE consolidation_status IN ('active', 'consolidated') \
+                   AND namespace = ?1 \
+                 ORDER BY rid"
+            } else {
+                "SELECT rid, text, length(embedding) FROM memories \
+                 WHERE consolidation_status IN ('active', 'consolidated') \
+                 ORDER BY rid"
+            };
+            let mut stmt = conn.prepare(sql)?;
+            fn map_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<(String, String, Option<usize>)> {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, Option<i64>>(2)?.map(|n| n as usize),
+                ))
+            }
+            match namespace {
+                Some(ns) => stmt
+                    .query_map(params![ns], map_row)?
+                    .collect::<std::result::Result<Vec<_>, _>>()?,
+                None => stmt
+                    .query_map([], map_row)?
+                    .collect::<std::result::Result<Vec<_>, _>>()?,
+            }
+        };
+        report.scanned = scanned.len();
+
+        // ── Phase 2: select the unusable rows and, in apply mode, encode
+        // them OUTSIDE the conn lock.
+        let mut pending: Vec<PendingRefresh> = Vec::new();
+        for (rid, scanned_ciphertext, blob_len) in scanned {
+            // Encrypted stores pad the blob, so a strict length check would
+            // false-positive on every row; there, only a NULL vector is
+            // provably unusable. Better to under-repair than to churn a
+            // whole corpus on a bad predicate.
+            let usable = match blob_len {
+                None => false,
+                Some(n) if self.is_encrypted() => n > 0,
+                Some(n) => n == expected_len,
+            };
+            if usable {
+                continue;
+            }
+            report.unusable_found += 1;
+            if report.sample_rids.len() < SAMPLE_CAP {
+                report.sample_rids.push(rid.clone());
+            }
+            if dry_run {
+                continue;
+            }
+
+            let plaintext = match self.decrypt_text(&scanned_ciphertext) {
+                Ok(t) => t,
+                Err(e) => {
+                    report.errors.push(RepairError {
+                        rid,
+                        message: format!("decrypt failed: {e}"),
+                    });
+                    continue;
+                }
+            };
+            let embedding = match self.embed(&plaintext) {
+                Ok(v) => v,
+                Err(e) => {
+                    report.errors.push(RepairError {
+                        rid,
+                        message: format!("embed failed: {e}"),
+                    });
+                    continue;
+                }
+            };
+            let new_embedding_blob = match self.encrypt_embedding(&serialize_f32(&embedding)) {
+                Ok(b) => b,
+                Err(e) => {
+                    report.errors.push(RepairError {
+                        rid,
+                        message: format!("encrypt embedding failed: {e}"),
+                    });
+                    continue;
+                }
+            };
+            pending.push(PendingRefresh {
+                rid,
+                scanned_ciphertext,
+                new_embedding_blob,
+            });
+        }
+
+        if dry_run || pending.is_empty() {
+            return Ok(report);
+        }
+
+        // ── Phase 3: apply in one transaction. The generation is READ, never
+        // bumped: this is the same space the store was already in, and
+        // advancing the store-wide watermark for a repair would make every
+        // untouched row look stale.
+        let state = self.search_state.load_full();
+        let generation = state.generation as i64;
+        let model = state.runtime_embedder_name.clone();
+        let updated_at = now();
+        {
+            let conn = self.conn();
+            conn.execute_batch("SAVEPOINT refresh_embeddings")?;
+            let apply: Result<()> = (|| {
+                for p in &pending {
+                    // Guarded on the exact ciphertext scanned: if a
+                    // concurrent write changed the text, the vector just
+                    // computed describes content that no longer exists.
+                    let updated = conn.execute(
+                        "UPDATE memories \
+                         SET embedding = ?1, embedding_model = ?2, \
+                             embedding_generation = ?3, updated_at = ?4 \
+                         WHERE rid = ?5 AND text = ?6",
+                        params![
+                            p.new_embedding_blob,
+                            model,
+                            generation,
+                            updated_at,
+                            p.rid,
+                            p.scanned_ciphertext,
+                        ],
+                    )?;
+                    if updated == 0 {
+                        report.skipped_concurrent_modification += 1;
+                        continue;
+                    }
+                    report.refreshed += 1;
+                }
+                Ok(())
+            })();
+            match apply {
+                Ok(()) => conn.execute_batch("RELEASE refresh_embeddings")?,
+                Err(e) => {
+                    let _ = conn.execute_batch(
+                        "ROLLBACK TO refresh_embeddings; RELEASE refresh_embeddings",
+                    );
+                    return Err(e);
+                }
+            }
+        }
+
+        // ── Phase 4: one rebuild, so the newly-filled vectors become
+        // searchable. Refuses to install across a cutover.
+        if report.refreshed > 0 {
+            self.rebuild_vec_index()?;
+        }
+
+        tracing::info!(
+            target: "yantrikdb::audit::repair",
+            namespace = ?report.namespace,
+            scanned = report.scanned,
+            unusable_found = report.unusable_found,
+            refreshed = report.refreshed,
+            skipped_concurrent = report.skipped_concurrent_modification,
+            errors = report.errors.len(),
+            "same-space embedding refresh complete",
+        );
+
+        Ok(report)
+    }
+}

--- a/crates/yantrikdb-core/src/engine/tests/bundled_embedder.rs
+++ b/crates/yantrikdb-core/src/engine/tests/bundled_embedder.rs
@@ -2322,6 +2322,10 @@ fn install_pack_converts_a_foreign_dimension_pack_automatically() {
     );
 }
 
+// `with_default` only exists with the bundled embedder; every other test in
+// this file is gated the same way, and the slim (`--no-default-features`)
+// build is a real deployment surface for BYO-embedder users.
+#[cfg(feature = "bundled-embedder")]
 #[test]
 fn refresh_embeddings_heals_rows_that_have_no_vector() {
     // The replication shape, reproduced locally: a row that is present and

--- a/crates/yantrikdb-core/src/engine/tests/bundled_embedder.rs
+++ b/crates/yantrikdb-core/src/engine/tests/bundled_embedder.rs
@@ -2321,3 +2321,106 @@ fn install_pack_converts_a_foreign_dimension_pack_automatically() {
         after.iter().map(|h| &h.text).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn refresh_embeddings_heals_rows_that_have_no_vector() {
+    // The replication shape, reproduced locally: a row that is present and
+    // ACTIVE in SQL but carries no embedding, so it is invisible to semantic
+    // recall while looking perfectly healthy to `get()` and to any count.
+    // replication.rs materializes exactly this — its INSERT omits embedding,
+    // embedding_model and embedding_generation — and then declines to add the
+    // record to HNSW because it has no vector to add.
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let target = "The reconciliation service settles invoices against bank statements.";
+    let rid = db
+        .record_text(
+            target,
+            "semantic",
+            0.6,
+            0.0,
+            86400.0,
+            &serde_json::json!({}),
+            "repl",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    db.record_text(
+        "Unrelated note about the office coffee machine.",
+        "semantic",
+        0.5,
+        0.0,
+        86400.0,
+        &serde_json::json!({}),
+        "repl",
+        0.9,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap();
+
+    let indexed_before = db.rebuild_vec_index().unwrap();
+    assert_eq!(indexed_before, 2, "both rows start with usable vectors");
+
+    // Strip the vector, the way a replicated row arrives.
+    db.conn()
+        .execute(
+            "UPDATE memories SET embedding = NULL WHERE rid = ?1",
+            [&rid],
+        )
+        .unwrap();
+
+    // Assert on INDEX MEMBERSHIP, not on a recall result. A vector-less row
+    // is still reachable through the FTS lane whenever the query happens to
+    // share tokens with the text — the damage is confined to the vector lane,
+    // so that is where it has to be measured. (Worth knowing on its own: the
+    // replication gap degrades SEMANTIC recall specifically; it does not make
+    // a record wholly unfindable, which is part of why it stayed quiet.)
+    let indexed_damaged = db.rebuild_vec_index().unwrap();
+    assert_eq!(
+        indexed_damaged, 1,
+        "precondition: a row with no vector cannot be in the vector index"
+    );
+
+    // Dry run reports the damage and changes nothing.
+    let dry = db.refresh_embeddings(Some("repl"), true).unwrap();
+    assert!(dry.dry_run);
+    assert_eq!(
+        dry.unusable_found, 1,
+        "exactly one row lacks a usable vector"
+    );
+    assert_eq!(dry.refreshed, 0, "a dry run must not write");
+    assert!(dry.sample_rids.contains(&rid));
+
+    // Apply heals it.
+    let applied = db.refresh_embeddings(Some("repl"), false).unwrap();
+    assert_eq!(applied.refreshed, 1, "the damaged row must be re-encoded");
+    assert!(applied.errors.is_empty(), "errors: {:?}", applied.errors);
+
+    let indexed_after = db.rebuild_vec_index().unwrap();
+    assert_eq!(
+        indexed_after, 2,
+        "after refresh the healed row must be back in the vector index"
+    );
+    let back = db
+        .recall_text("how are invoices settled against statements", 5)
+        .unwrap();
+    assert!(
+        back.iter().any(|h| h.text == target),
+        "and reachable again; got {:?}",
+        back.iter().map(|h| &h.text).collect::<Vec<_>>()
+    );
+
+    // Idempotent: nothing is unusable now, so a second sweep is a no-op.
+    let again = db.refresh_embeddings(Some("repl"), false).unwrap();
+    assert_eq!(again.unusable_found, 0, "refresh must be idempotent");
+    assert_eq!(again.refreshed, 0);
+
+    // Namespace scoping is real: a sweep of another namespace sees nothing
+    // here, and the whole-store sweep still finds nothing to do.
+    let other = db.refresh_embeddings(Some("does-not-exist"), true).unwrap();
+    assert_eq!(other.scanned, 0, "namespace scope must actually filter");
+}

--- a/crates/yantrikdb-core/src/engine/tests/reembed_router.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reembed_router.rs
@@ -2456,3 +2456,60 @@ fn forget_defers_rather_than_tombstoning_into_a_doomed_index() {
         .unwrap();
     assert_eq!(status, "tombstoned");
 }
+
+// =====================================================================
+// 2026-08-17 — the last two index mutators that could cross a cutover.
+// Both are deletes-or-installs that read SearchState and then mutate it.
+// =====================================================================
+
+#[test]
+fn rebuild_vec_index_discards_rather_than_mixing_embedding_spaces() {
+    // The rebuild reads memories.embedding — the space active when it
+    // STARTED — and installs the result as the cold tier of whatever state
+    // is live when it FINISHES. Across a cutover that means old-space
+    // vectors inside the new generation's index: every cold-tier distance
+    // measured against a query encoded by a different model. Nothing is
+    // lost and nothing errors, which is exactly why no test caught it —
+    // the index is populated and every lookup returns something.
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    for i in 0..6 {
+        db.record(
+            &format!("rebuildable record {i}"),
+            "semantic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(i as f32 + 1.0, 8),
+            "default",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    }
+    // Healthy case: no cutover, the rebuild installs.
+    let n = db.rebuild_vec_index().expect("rebuild must work normally");
+    assert!(n > 0, "rebuild should install a populated cold tier");
+
+    // Cutover in flight: the rebuilt index describes a space that may no
+    // longer be current, so it must be thrown away, not installed.
+    db.write_router.switch_to_queueing();
+    let err = db
+        .rebuild_vec_index()
+        .expect_err("a rebuild finishing during a cutover must not install");
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::IndexRebuildDeferredDuringReembed { .. }
+        ),
+        "must be the typed retryable deferral, got: {err}"
+    );
+
+    db.write_router.switch_to_normal();
+    assert!(
+        db.rebuild_vec_index().unwrap() > 0,
+        "rebuild must work again once the cutover completes"
+    );
+}

--- a/crates/yantrikdb-core/src/engine/tests/reembed_router.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reembed_router.rs
@@ -2143,8 +2143,8 @@ fn unimplemented_reembed_namespace_is_rejected_not_silently_global() {
     };
     let msg = reembed_err(&db, opts);
     assert!(
-        msg.contains("namespace is not implemented"),
-        "namespace must be refused by name; got: {msg}"
+        msg.contains("embedding space belongs to the ENGINE"),
+        "namespace must be refused as an engine-scoped-embedding request; got: {msg}"
     );
 }
 

--- a/crates/yantrikdb-core/src/engine/tests/reembed_router.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reembed_router.rs
@@ -2111,3 +2111,348 @@ fn boundary_audit_pattern_detects_synthetic_violation() {
          the audit over-rejects which would prevent legitimate refactors"
     );
 }
+
+// =====================================================================
+// 2026-08-17: the three ReembedOptions knobs that are ACCEPTED but NOT
+// IMPLEMENTED must fail loudly.
+//
+// The 2026-08-15 knob audit found `write_policy: Pause` and
+// `resume_from_checkpoint` in that state and made them error — but pinned
+// neither, and MISSED `namespace`, which was the worst of the three: it was
+// echoed into every progress event and the durable status while applying to
+// no query, so a caller asking to re-embed one namespace silently re-embedded
+// the whole store and got told it had done what it asked.
+//
+// One test per knob, because "the audit fixed the instances it happened to
+// look at" is exactly how the third one survived.
+// =====================================================================
+
+fn reembed_err(db: &YantrikDB, opts: crate::engine::reembed::ReembedOptions) -> String {
+    match db.reembed("test-embedder", opts) {
+        Err(e) => e.to_string(),
+        Ok(_) => panic!("an unimplemented ReembedOptions knob must error, not succeed"),
+    }
+}
+
+#[test]
+fn unimplemented_reembed_namespace_is_rejected_not_silently_global() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let opts = crate::engine::reembed::ReembedOptions {
+        namespace: Some("only-this-one".to_string()),
+        ..Default::default()
+    };
+    let msg = reembed_err(&db, opts);
+    assert!(
+        msg.contains("namespace is not implemented"),
+        "namespace must be refused by name; got: {msg}"
+    );
+}
+
+#[test]
+fn unimplemented_reembed_pause_policy_is_rejected() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let opts = crate::engine::reembed::ReembedOptions {
+        write_policy: crate::engine::reembed::ReembedWritePolicy::Pause,
+        ..Default::default()
+    };
+    let msg = reembed_err(&db, opts);
+    assert!(
+        msg.contains("Pause is not implemented"),
+        "Pause must be refused rather than silently granting Queue; got: {msg}"
+    );
+}
+
+#[test]
+fn unimplemented_reembed_resume_from_checkpoint_is_rejected() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let opts = crate::engine::reembed::ReembedOptions {
+        resume_from_checkpoint: true,
+        ..Default::default()
+    };
+    let msg = reembed_err(&db, opts);
+    assert!(
+        msg.contains("resume_from_checkpoint is not implemented"),
+        "resume must be refused before an interrupted run discards its work; got: {msg}"
+    );
+}
+
+// =====================================================================
+// THE GATE for namespace-scoped reembed, written BEFORE the feature.
+//
+// A scoped reembed touches ONE namespace; everything about every other
+// namespace must be bit-identical afterwards. Four parts of this pipeline
+// are global by construction and each would violate that silently:
+//
+//   1. Rebuilding sources only rows with `embedding_new` (reembed.rs
+//      ~:1127), so a scoped run rebuilds an index containing ONLY the
+//      scoped namespace — every other namespace silently disappears from
+//      vector search while still being present and "active" in SQL. That
+//      is the HNSW-orphan failure shape again.
+//   2. The swap does `DELETE FROM memory_chunks` with no predicate
+//      (~:1343), destroying chunk vectors for untouched namespaces.
+//   3. `meta.active_generation` is bumped globally (~:1319), so untouched
+//      rows are left behind the generation watermark.
+//   4. Verifying asserts EVERY row carries the new embedder.
+//
+// While scoping is unimplemented this asserts the guard is SIDE-EFFECT
+// FREE — a rejected call must not leave the store half-migrated. When
+// scoping lands, the same assertions become the real invariant and this
+// test starts doing its full job without being rewritten.
+// =====================================================================
+#[test]
+fn scoped_reembed_must_not_disturb_other_namespaces() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    for i in 0..8 {
+        db.record(
+            &format!("keep record {i} about ledgers"),
+            "semantic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(i as f32 + 1.0, 8),
+            "keep",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+        db.record(
+            &format!("touch record {i} about deployments"),
+            "semantic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(i as f32 + 100.0, 8),
+            "touch",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    }
+
+    let snapshot = |db: &YantrikDB| -> Vec<(String, i64, usize)> {
+        let conn = db.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT rid, COALESCE(embedding_generation,0), length(embedding) \
+                 FROM memories WHERE namespace = 'keep' ORDER BY rid",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, i64>(2)? as usize,
+                ))
+            })
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        rows
+    };
+    let chunk_count = |db: &YantrikDB| -> i64 {
+        db.conn()
+            .query_row("SELECT COUNT(*) FROM memory_chunks", [], |r| r.get(0))
+            .unwrap_or(0)
+    };
+
+    let keep_before = snapshot(&db);
+    let chunks_before = chunk_count(&db);
+    assert!(
+        !keep_before.is_empty(),
+        "fixture must have 'keep' rows to protect"
+    );
+
+    let opts = crate::engine::reembed::ReembedOptions {
+        namespace: Some("touch".to_string()),
+        ..Default::default()
+    };
+    // Unimplemented today -> Err. Implemented later -> Ok. EITHER WAY the
+    // assertions below must hold; that is the whole point of the gate.
+    let _ = db.reembed("test-embedder", opts);
+
+    assert_eq!(
+        keep_before,
+        snapshot(&db),
+        "a namespace-scoped reembed (or its rejection) changed rows in ANOTHER \
+         namespace — rid/generation/embedding-length must be bit-identical"
+    );
+    assert_eq!(
+        chunks_before,
+        chunk_count(&db),
+        "memory_chunks was purged globally; untouched namespaces lost their \
+         chunk vectors (reembed.rs DELETE FROM memory_chunks has no predicate)"
+    );
+}
+
+// =====================================================================
+// 2026-08-17: record_with_rid must not cross a reembed cutover.
+//
+// It is the deterministic replay primitive (caller-supplied rid, vector,
+// timestamp and model; the engine's own embedder is never invoked), used by
+// the cluster applier and the materializer drain. It took its SearchState
+// snapshot with NO sync-writer guard, so a reembed cutover could publish a
+// new state between the snapshot and the index append — landing the vector
+// in a DISCARDED delta index while the row committed to SQL as active.
+// Stored, alive, unfindable: the HNSW-orphan shape through another door.
+//
+// It cannot use record()'s queued fallback, because the queued materializer
+// re-encodes under the NEW embedder and this path exists to be
+// byte-identical across leader and followers. So it defers retryably,
+// following the record_batch precedent.
+// =====================================================================
+#[test]
+fn record_with_rid_defers_instead_of_crossing_a_reembed_cutover() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+
+    // Put the router where a reembed cutover puts it.
+    db.write_router.switch_to_queueing();
+
+    let err = db
+        .record_with_rid(
+            "01900000-0000-7000-8000-0000000000ab",
+            "deterministic replicated fact",
+            "semantic",
+            0.6,
+            0.0,
+            1000.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "work",
+            0.9,
+            "general",
+            "inference",
+            None,
+            1_700_000_000_000_000,
+            &[],
+            "test-model",
+            None,
+            crate::provenance::WriteAdmission::Admitted,
+        )
+        .expect_err("a cutover in flight must defer, not commit against a doomed generation");
+
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::DeterministicWriteDeferredDuringReembed { .. }
+        ),
+        "must be the typed retryable deferral, got: {err}"
+    );
+
+    // NOTHING durable may have happened — the whole point of deferring.
+    let n: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE rid = '01900000-0000-7000-8000-0000000000ab'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        n, 0,
+        "a deferred deterministic write must leave no row behind"
+    );
+
+    // And it works again once the cutover finishes.
+    db.write_router.switch_to_normal();
+    db.record_with_rid(
+        "01900000-0000-7000-8000-0000000000ab",
+        "deterministic replicated fact",
+        "semantic",
+        0.6,
+        0.0,
+        1000.0,
+        &empty_meta(),
+        &vec_seed(1.0, 8),
+        "work",
+        0.9,
+        "general",
+        "inference",
+        None,
+        1_700_000_000_000_000,
+        &[],
+        "test-model",
+        None,
+        crate::provenance::WriteAdmission::Admitted,
+    )
+    .expect("must succeed once the router is Normal again");
+}
+
+// =====================================================================
+// 2026-08-17 — the F1/F2 forget-resurrection race, as a gate.
+//
+// forget() and tombstone_with_rid() both funnel into tombstone_inner,
+// which tombstones the rid AND its chunks in
+// search_state.load().vec_index. Unguarded, a reembed cutover could
+// publish an index built from a SQL snapshot predating the tombstone,
+// while the delta tombstone died with the discarded state: the record
+// ends up tombstoned in SQL and ALIVE in the live index. A delete that
+// silently un-deletes.
+// =====================================================================
+#[test]
+fn forget_defers_rather_than_tombstoning_into_a_doomed_index() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let rid = db
+        .record(
+            "a fact the user will ask to forget",
+            "semantic",
+            0.5,
+            0.0,
+            86400.0,
+            &empty_meta(),
+            &vec_seed(1.0, 8),
+            "default",
+            0.9,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+
+    // A reembed cutover is in flight.
+    db.write_router.switch_to_queueing();
+
+    let err = db
+        .forget(&rid)
+        .expect_err("forget during a cutover must defer, not tombstone into a doomed index");
+    assert!(
+        matches!(
+            err,
+            crate::error::YantrikDbError::ForgetDeferredDuringReembed { .. }
+        ),
+        "must be the typed retryable deferral, got: {err}"
+    );
+
+    // The row must be untouched — a deferred delete is not a partial delete.
+    let status: String = db
+        .conn()
+        .query_row(
+            "SELECT consolidation_status FROM memories WHERE rid = ?1",
+            [&rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        status, "active",
+        "a deferred forget must leave the row exactly as it was"
+    );
+
+    // And it works once the cutover completes.
+    db.write_router.switch_to_normal();
+    assert!(db.forget(&rid).unwrap(), "forget must succeed post-cutover");
+    let status: String = db
+        .conn()
+        .query_row(
+            "SELECT consolidation_status FROM memories WHERE rid = ?1",
+            [&rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "tombstoned");
+}

--- a/crates/yantrikdb-python/src/py_engine/sync.rs
+++ b/crates/yantrikdb-python/src/py_engine/sync.rs
@@ -221,6 +221,57 @@ impl PyYantrikDB {
         Ok(dict.into())
     }
 
+    /// Re-encode records whose vectors are missing or unusable, using the
+    /// embedder that is ALREADY ACTIVE.
+    ///
+    /// This is not a re-embed: it changes no model, fingerprint, dimension or
+    /// generation, so none of the cutover machinery applies. It fills in
+    /// vectors that are absent or malformed, in the space the engine is
+    /// already using.
+    ///
+    /// The case that matters most is REPLICATION — the follower insert omits
+    /// `embedding`, `embedding_model` and `embedding_generation` entirely, so
+    /// replicated rows arrive active in SQL and invisible to semantic recall.
+    /// Without this binding that repair was reachable only from Rust, which
+    /// meant an operator hitting the problem through the server or MCP had no
+    /// way to run it.
+    ///
+    /// `namespace=None` sweeps the whole store. Call with `dry_run=True`
+    /// first; it reports what it would touch without writing.
+    #[pyo3(signature = (namespace = None, dry_run = true))]
+    fn refresh_embeddings(
+        &self,
+        py: Python<'_>,
+        namespace: Option<&str>,
+        dry_run: bool,
+    ) -> PyResult<PyObject> {
+        let db = self.get_inner()?;
+        let report = db.refresh_embeddings(namespace, dry_run).map_err(map_err)?;
+
+        let dict = PyDict::new(py);
+        dict.set_item("dry_run", report.dry_run)?;
+        dict.set_item("namespace", report.namespace.clone())?;
+        dict.set_item("scanned", report.scanned)?;
+        dict.set_item("unusable_found", report.unusable_found)?;
+        dict.set_item("refreshed", report.refreshed)?;
+        dict.set_item(
+            "skipped_concurrent_modification",
+            report.skipped_concurrent_modification,
+        )?;
+        dict.set_item("sample_rids", report.sample_rids.clone())?;
+
+        let errors = pyo3::types::PyList::empty(py);
+        for e in &report.errors {
+            let ed = PyDict::new(py);
+            ed.set_item("rid", &e.rid)?;
+            ed.set_item("message", &e.message)?;
+            errors.append(ed)?;
+        }
+        dict.set_item("errors", errors)?;
+
+        Ok(dict.into())
+    }
+
     /// Revert stale, unused, high-importance memories toward baseline
     /// (use-it-or-lose-it, task 32). Background maintenance; call with
     /// `dry_run=True` first. Returns a report dict.

--- a/tests/capability_audit.py
+++ b/tests/capability_audit.py
@@ -1,0 +1,184 @@
+"""CAPABILITY AUDIT — is the temporal/ordering/abstention weakness REAL?
+
+BEAM says these categories score 0.30-0.50. Five treatment arms failed and
+the forensics blamed question ambiguity, wrong golds, and a strict rubric.
+That excuse is only credible if the capability itself is sound. This test
+removes every excuse: a synthetic corpus where I control every fact, with
+questions that have exactly ONE defensible answer, scored MECHANICALLY
+(no LLM judge anywhere).
+
+It measures RETRIEVAL — the memory system's actual job — not answering.
+If the right records come back in the right order, the memory works and
+any downstream failure is the reader's. If they do not, we have a real
+defect and this is the instrument to fix it against.
+
+Run against the PUBLISHED wheel, not the source tree.
+"""
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+from yantrikdb import YantrikDB
+
+NS = "audit"
+
+
+def ts(datestr: str) -> float:
+    return datetime.strptime(datestr, "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp()
+
+
+# ── The corpus: a project log with total ground truth ──
+# Six phases, strictly ordered, unambiguous dates, each phase mentioned once
+# as a phase-level statement plus two detail records.
+PHASES = [
+    ("2024-01-08", "kickoff", "Project Meridian kickoff: agreed the scope is a billing reconciliation service."),
+    ("2024-02-12", "schema", "Phase two began: designed the ledger schema with double-entry invariants."),
+    ("2024-03-18", "ingest", "Phase three began: built the bank-statement ingest pipeline."),
+    ("2024-05-02", "matching", "Phase four began: implemented the transaction matching engine."),
+    ("2024-06-14", "reporting", "Phase five began: added the monthly reconciliation reports."),
+    ("2024-08-01", "launch", "Phase six began: launched Meridian to the finance team."),
+]
+DETAILS = [
+    ("2024-01-15", "Meridian kickoff detail: the team is three engineers and one analyst."),
+    ("2024-01-22", "Meridian kickoff detail: chose PostgreSQL for the ledger store."),
+    ("2024-02-19", "Ledger schema detail: entries table has account_id, amount_cents, direction."),
+    ("2024-02-26", "Ledger schema detail: added a constraint that debits must equal credits."),
+    ("2024-03-25", "Ingest detail: parses OFX and CSV statement formats."),
+    ("2024-04-02", "Ingest detail: deduplicates by statement fingerprint hash."),
+    ("2024-05-09", "Matching detail: fuzzy matches on amount within two cents and date within three days."),
+    ("2024-05-16", "Matching detail: unmatched transactions go to a review queue."),
+    ("2024-06-21", "Reporting detail: reports export to XLSX and PDF."),
+    ("2024-06-28", "Reporting detail: month-end close report runs on the first business day."),
+    ("2024-08-08", "Launch detail: finance team trained in a two-hour session."),
+    ("2024-08-15", "Launch detail: first production close completed without manual adjustment."),
+]
+# A value that CHANGES over time — the succession case.
+SUCCESSION = [
+    ("2024-02-05", "The matching tolerance is set to 5 cents."),
+    ("2024-04-20", "The matching tolerance is now 3 cents."),
+    ("2024-07-11", "The matching tolerance is now 2 cents."),
+]
+# Facts DEFINITELY ABSENT from the corpus (abstention ground truth):
+ABSENT_TOPICS = [
+    "What is the Meridian mobile app release date?",
+    "Which cloud provider hosts the Meridian payroll module?",
+    "How many customers use the Meridian public API?",
+]
+
+
+def build(db):
+    for date, tag, text in PHASES:
+        db.record_text(text, memory_type="episodic", importance=0.7,
+                       metadata={"phase": tag}, namespace=NS, created_at=ts(date))
+    for date, text in DETAILS:
+        db.record_text(text, memory_type="episodic", importance=0.5,
+                       namespace=NS, created_at=ts(date))
+    for date, text in SUCCESSION:
+        db.record_text(text, memory_type="semantic", importance=0.8,
+                       namespace=NS, created_at=ts(date))
+
+
+def probe_ordering(db, results):
+    """Can retrieval reconstruct the phase sequence?"""
+    hits = db.recall(query="the phases of project Meridian in order", top_k=20, namespace=NS, expand_entities=False)
+    phase_texts = {p[2]: i for i, p in enumerate(PHASES)}
+    got = [(h.get("created_at"), h["text"]) for h in hits if h["text"] in phase_texts]
+    found_idx = [phase_texts[t] for _, t in got]
+    recalled = len(set(found_idx))
+    chrono = sorted(got, key=lambda x: x[0])
+    order_ok = [phase_texts[t] for _, t in chrono] == sorted([phase_texts[t] for _, t in chrono])
+    results["ordering_phase_recall"] = f"{recalled}/6 phase records retrieved"
+    results["ordering_chronological_when_sorted"] = order_ok
+    results["ordering_PASS"] = recalled == 6 and order_ok
+
+
+def probe_window(db, results):
+    """Time-window retrieval: exactly the records inside a known window."""
+    lo, hi = ts("2024-03-01"), ts("2024-05-31")
+    expected = {t for d, _, t in PHASES if lo <= ts(d) <= hi}
+    expected |= {t for d, t in DETAILS if lo <= ts(d) <= hi}
+    expected |= {t for d, t in SUCCESSION if lo <= ts(d) <= hi}
+    try:
+        hits = db.recall(query="project work", top_k=50, namespace=NS, time_window=(lo, hi), expand_entities=False)
+    except TypeError:
+        results["window_PASS"] = "time_window param unsupported in this build"
+        return
+    got = {h["text"] for h in hits}
+    inside = {t for t in got if t in expected}
+    leaked = [t for t in got if t not in expected]
+    results["window_recall"] = f"{len(inside)}/{len(expected)} in-window records"
+    results["window_leaks_outside_window"] = len(leaked)
+    results["window_PASS"] = len(inside) == len(expected) and not leaked
+
+
+def probe_succession(db, results):
+    """Current-value: the LATEST tolerance must outrank the superseded ones."""
+    hits = db.recall(query="what is the matching tolerance", top_k=5, namespace=NS, expand_entities=False)
+    texts = [h["text"] for h in hits]
+    current = SUCCESSION[-1][1]
+    rank = next((i for i, t in enumerate(texts) if t == current), None)
+    results["succession_current_rank"] = rank
+    results["succession_all_three_retrieved"] = sum(
+        1 for _, t in SUCCESSION if t in texts)
+    results["succession_PASS"] = rank == 0
+
+
+def probe_abstention(db, results):
+    """Absent facts must score MEASURABLY lower than present ones."""
+    present = db.recall(query="what statement formats does ingest parse", top_k=5, namespace=NS, expand_entities=False)
+    p_top = present[0].get("scores", {}).get("similarity") if present else 0
+    gaps = []
+    for q in ABSENT_TOPICS:
+        hits = db.recall(query=q, top_k=5, namespace=NS, expand_entities=False)
+        a_top = hits[0].get("scores", {}).get("similarity") if hits else 0
+        gaps.append((q[:42], round(a_top, 3)))
+    worst_absent = max(g[1] for g in gaps)
+    results["abstention_present_similarity"] = round(p_top, 3)
+    results["abstention_absent_similarities"] = gaps
+    results["abstention_separation"] = round(p_top - worst_absent, 3)
+    # A usable abstention signal needs the absent queries to sit clearly below.
+    results["abstention_PASS"] = (p_top - worst_absent) > 0.10
+
+
+def probe_interval(db, results):
+    """Temporal arithmetic with UNAMBIGUOUS referents — retrieval half only:
+    are both endpoint records retrievable and correctly dated?"""
+    a = db.recall(query="Project Meridian kickoff scope agreed", top_k=5, namespace=NS, expand_entities=False)
+    b = db.recall(query="launched Meridian to the finance team", top_k=5, namespace=NS, expand_entities=False)
+    got_a = next((h for h in a if h["text"] == PHASES[0][2]), None)
+    got_b = next((h for h in b if h["text"] == PHASES[-1][2]), None)
+    if not (got_a and got_b):
+        results["interval_PASS"] = False
+        results["interval_note"] = "endpoint record(s) not retrieved"
+        return
+    days = round((got_b["created_at"] - got_a["created_at"]) / 86400)
+    truth = round((ts(PHASES[-1][0]) - ts(PHASES[0][0])) / 86400)
+    results["interval_days_from_retrieved_metadata"] = days
+    results["interval_ground_truth_days"] = truth
+    results["interval_PASS"] = days == truth
+
+
+def main():
+    path = os.path.join(tempfile.mkdtemp(), "audit.db")
+    db = YantrikDB.with_default(path)
+    build(db)
+    results = {}
+    for fn in (probe_ordering, probe_window, probe_succession,
+               probe_abstention, probe_interval):
+        try:
+            fn(db, results)
+        except Exception as e:  # a probe must not kill the audit
+            results[fn.__name__ + "_ERROR"] = f"{type(e).__name__}: {e}"
+    db.close()
+    passes = [k for k, v in results.items() if k.endswith("_PASS") and v is True]
+    fails = [k for k, v in results.items() if k.endswith("_PASS") and v is not True]
+    print(json.dumps(results, indent=1, default=str))
+    print(f"\nCAPABILITY AUDIT: {len(passes)}/{len(passes)+len(fails)} probes PASS")
+    if fails:
+        print("FAILING:", ", ".join(fails))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/capability_audit.py
+++ b/tests/capability_audit.py
@@ -113,16 +113,23 @@ def probe_window(db, results):
     results["window_PASS"] = len(inside) == len(expected) and not leaked
 
 
-def probe_succession(db, results):
-    """Current-value: the LATEST tolerance must outrank the superseded ones."""
+def probe_succession(db, results, phase="warm"):
+    """Current-value: the LATEST tolerance must outrank the superseded ones.
+
+    Run TWICE — once on a COLD store and once after unrelated queries have
+    already run. Cold alone is not a test: the defect this pins was invisible
+    cold and only appeared once an unrelated recall had reinforced some other
+    record. A currency guarantee that holds only until someone else asks a
+    question is not a guarantee.
+    """
     hits = db.recall(query="what is the matching tolerance", top_k=5, namespace=NS, expand_entities=False)
     texts = [h["text"] for h in hits]
     current = SUCCESSION[-1][1]
     rank = next((i for i, t in enumerate(texts) if t == current), None)
-    results["succession_current_rank"] = rank
-    results["succession_all_three_retrieved"] = sum(
+    results[f"succession_current_rank_{phase}"] = rank
+    results[f"succession_all_three_retrieved_{phase}"] = sum(
         1 for _, t in SUCCESSION if t in texts)
-    results["succession_PASS"] = rank == 0
+    results[f"_succession_ok_{phase}"] = rank == 0
 
 
 def probe_abstention(db, results):
@@ -160,18 +167,40 @@ def probe_interval(db, results):
     results["interval_PASS"] = days == truth
 
 
-def main():
-    path = os.path.join(tempfile.mkdtemp(), "audit.db")
-    db = YantrikDB.with_default(path)
+def fresh_store():
+    db = YantrikDB.with_default(os.path.join(tempfile.mkdtemp(), "audit.db"))
     build(db)
+    return db
+
+
+def run(fn, results, *args):
+    """Call a probe; a probe that raises must not kill the audit."""
+    try:
+        fn(*args)
+    except Exception as e:
+        results[fn.__name__ + "_ERROR"] = f"{type(e).__name__}: {e}"
+
+
+def main():
     results = {}
-    for fn in (probe_ordering, probe_window, probe_succession,
-               probe_abstention, probe_interval):
-        try:
-            fn(db, results)
-        except Exception as e:  # a probe must not kill the audit
-            results[fn.__name__ + "_ERROR"] = f"{type(e).__name__}: {e}"
+
+    # COLD: a store nobody has queried yet.
+    cold = fresh_store()
+    run(probe_succession, results, cold, results, "cold")
+    cold.close()
+
+    # WARM: the same corpus, but after unrelated questions have been asked.
+    db = fresh_store()
+    for fn in (probe_ordering, probe_window):
+        run(fn, results, db, results)
+    run(probe_succession, results, db, results, "warm")
+    for fn in (probe_abstention, probe_interval):
+        run(fn, results, db, results)
     db.close()
+
+    # One probe, two conditions: currency must survive other people's queries.
+    results["succession_PASS"] = bool(
+        results.get("_succession_ok_cold") and results.get("_succession_ok_warm"))
     passes = [k for k, v in results.items() if k.endswith("_PASS") and v is True]
     fails = [k for k, v in results.items() if k.endswith("_PASS") and v is not True]
     print(json.dumps(results, indent=1, default=str))


### PR DESCRIPTION
Seven defects, each measured before and after. The last commit reverts part of
the first — that story is the most useful thing in this PR, so it is told plainly
below rather than buried.

## What is fixed

**Currency** (`80bbbbb`). All 14 ranking sites computed freshness as
`decay_score(importance, half_life, now - last_access)`. `reinforce()` runs on
every recall that RETURNS a record and mutates both inputs, so "freshness" was a
property of *who had read the record*, not of the record. Measured: a store where
the current value ranks #1 cold demotes it to #3 after one unrelated recall — the
current record never moved, the stale ones rose 1.5% past an 0.85% similarity gap.
`scoring::ranking_decay` reads event time and a fixed half-life; `last_access` and
the reinforced `half_life` keep driving lifecycle, untouched.

**Valence** (`80bbbbb`). `query_valence_boost` is applied outside the policy budget
and valence was never range-checked (`validate_scalars` tests only `is_finite`). A
record stored with `valence=100` took a 31x multiplier: an irrelevant record
(sim 0.09) scored 1.496 against a relevant one (sim 0.70) at 0.489. `clamp_valence`
bounds it at both entry points, which also repairs stores already holding
out-of-range values.

**Cold lane** (`80bbbbb`). The rescue lane admitted only `access_count = 0` rows and
`reinforce()` increments that, so a record surfaced once by an unrelated query lost
its only rescue route permanently AND the lane self-disabled with use: five ordinary
queries drained 53% of the eligible set. Renamed the marker to `lexical_rescue`,
since the lane no longer selects only cold records and an explanation that
misdescribes the computation is its own defect.

**Learner semantics, schema v41** (`74d57cc`). `decay` changed meaning, so a fit
against the old meaning is invalid. The migration resets `learned_weights` and
stamps `ranking_feature_epoch`; `load_preference_episodes` excludes episodes from
before it.

**Re-embed cutover** (`480770b`, `0edc1fa`). Four mutators could cross a cutover:
`record_with_rid` snapshotted `SearchState` before taking the guard, `tombstone_inner`
had no guard (forget-resurrection), both replication `materialize_op` arms were
unguarded, and `rebuild_vec_index` could commit an index built against a superseded
generation. Also: the Swap phase never promoted `embedding_model = embedding_new_model`,
so provenance stayed NULL through a completed re-embed — visible on the production
store, where `embedding_model` is NULL on all 5,390 rows.

**`refresh_embeddings`** (`66bb69c`, `6d4c5ab`). Same-space refresh, plus a permanent
rejection of namespace-scoped re-embed (embedding space is engine-wide, not per
namespace). The repair shipped with no caller until the Python binding was added.

## The revert, and why it matters more than the fix

`80bbbbb` also deleted the additive keyword boost at four sites, on the strength of
one fixture: BAAI/bge-base-en-v1.5, where a question answered in SYNONYMS put the
true anchor at rank 34 of 35 because token-matching noise collected up to +0.31 and
the anchor, not being an FTS match, collected none. That measurement is real and
still stands. The generalization did not.

Measured on a full clone of a production memory server — 5,218 records, 300 paired
self-retrieval probes, identical corpus and probes on every arm:

| | 0.15.0 | branch as-committed | branch + revert |
|---|---|---|---|
| MRR@10 | 0.957 | **0.621** | 0.965 |
| hit@1 | 0.923 | **0.490** | 0.937 |
| miss@10 | 0.000 | 0.073 | 0.000 |

The deletion cost a third of retrieval quality, uniformly across all four age
quartiles, and restoring it alone recovers all of it — which also exonerates the
other six changes.

Two populations, not one. The probe here is a literal 15-word prefix of the record,
so the target is ALWAYS an FTS match — by construction it samples only the case
where the boost helps and, per the analysis in `80bbbbb`'s own comment, provably
cannot invert anything. The bge fixture samples the opposite case. Both are correct;
neither generalizes. **A benchmark that samples one population will authorize
deleting a signal the other population depends on.**

`80bbbbb`'s message also claimed lexical evidence "now reaches the score only through
`apply_lane_agreement`'s already-budgeted `agreement_mult`". That is false.
`agreement_mult` is a binary lane count worth `PW_AGREEMENT = 0.13` (~+3.5% max) that
ignores lexical strength entirely, against a term worth up to +0.248 and proportional
to it. It was already there. Nothing was re-homed; something was removed.

## Known-open, deliberately not in this PR

Lexical match is filed as a query-INDEPENDENT prior, which structurally caps it inside
the 1.30x policy budget at ~5% no matter how weights are set. It is query-DEPENDENT
evidence, the same category as cosine similarity, and belongs in the relevance factor
as graded hybrid dense+sparse fusion — which would serve both populations instead of
trading one for the other. That needs a synonym/paraphrase probe population built
first; its absence is what let this through.

## Gates

- Suite **1967/0** `--all-features`, rustfmt clean.
- Capability audit 5/5; the succession probe now runs both cold and warm, because the
  currency defect was invisible cold and a guarantee that holds only until someone else
  asks a question is not a guarantee.
- Artifact verified as built: the Linux cp312 wheel reproduces the Windows census
  (MRR@10 0.964 vs 0.965, hit@1 0.937 identical).
- **Still running at time of writing:** the same paired census under
  `all-MiniLM-L6-v2` @ 384 dims, which is what the target deployment actually runs.
  Every number above was measured on the bundled potion-base-2M @ 64 dims. Embedder
  strength is exactly the variable that decides the keyword-boost question, so CI
  green does not settle it — that arm does. Do not deploy on the 64d numbers alone.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
