### PR TITLE
fix(python): refuse an embedder that did not build these vectors (closes #117)

### DIFF
--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -48,6 +48,75 @@ impl PyYantrikDB {
         }
     }
 
+    /// Compare a Python embedder against the identity the store recorded for
+    /// the vectors already on disk (#117).
+    ///
+    /// The engine refuses a same-dim-different-digest swap in its own
+    /// `set_embedder`, but a Python embedder never reaches that path: it is
+    /// held on this wrapper, encoding queries and writes for an engine whose
+    /// `SearchState` has never seen it. So the comparison has to happen here.
+    ///
+    /// A Python object has no digest the engine can derive, so it declares
+    /// one — `fingerprint` or `digest`, a plain string attribute. Rules:
+    ///
+    /// * store has no recorded identity -> nothing to contradict, attach.
+    /// * declared fingerprint equals the recorded digest -> attach.
+    /// * declared fingerprint differs -> refuse. This is the provable
+    ///   mismatch, and it is silent corruption if allowed: cosine distance
+    ///   between two unrelated spaces still returns a plausible number
+    ///   (measured: 0.595 against vectors built by a different model).
+    /// * nothing declared -> refuse. "I cannot prove these vectors are mine"
+    ///   is the case that produced the 0.595, not a safe default.
+    ///
+    /// `allow_unverified_embedder` overrides the last two, matching the
+    /// convention `pack.rs` already uses for mounting.
+    fn check_embedder_identity(
+        &self,
+        py: Python<'_>,
+        embedder: &PyObject,
+        allow_unverified: bool,
+    ) -> PyResult<()> {
+        if allow_unverified {
+            return Ok(());
+        }
+        let Some(inner) = self.inner.as_ref() else {
+            return Ok(());
+        };
+        // (name, digest, dim) of whatever built the vectors already stored.
+        let recorded = inner.embedder_identity().map_err(map_err)?;
+        let Some((recorded_name, recorded_digest, recorded_dim)) = recorded else {
+            return Ok(()); // nothing recorded: nothing to contradict
+        };
+
+        let declared = ["fingerprint", "digest"].iter().find_map(|attr| {
+            embedder
+                .getattr(py, *attr)
+                .ok()
+                .and_then(|v| v.extract::<String>(py).ok())
+        });
+
+        match declared {
+            Some(fp) if fp == recorded_digest => Ok(()),
+            other => {
+                let named = recorded_name.unwrap_or_else(|| "<unnamed>".to_string());
+                let got = match other {
+                    Some(fp) => format!("declares fingerprint {fp:?}"),
+                    None => "declares no `fingerprint` or `digest`".to_string(),
+                };
+                Err(PyRuntimeError::new_err(format!(
+                    "this database's vectors were built by {named} (digest {recorded_digest}, \
+                     dim {recorded_dim}), and the embedder being attached {got}. Queries would \
+                     be encoded in a different space than the vectors they are compared against, \
+                     and cosine distance still returns a plausible number for unrelated spaces — \
+                     so the results would look fine and be wrong. Options: attach the embedder \
+                     that built them; set `.fingerprint = \"{recorded_digest}\"` on your \
+                     embedder if it IS that model; call reembed() to rebuild the vectors in the \
+                     new space; or pass allow_unverified_embedder=True if you accept the risk."
+                )))
+            }
+        }
+    }
+
     /// (Re)spawn the background worker pool against the live engine `Arc`.
     /// Paired with `self._workers = None` (which drops the guards and JOINs
     /// the worker threads) around any operation that needs exclusive
@@ -263,13 +332,15 @@ pub(crate) fn map_err(e: yantrikdb_core::YantrikDbError) -> PyErr {
 #[pymethods]
 impl PyYantrikDB {
     #[new]
-    #[pyo3(signature = (db_path=":memory:", embedding_dim=384, embedder=None, encryption_key=None, model_dir=None))]
+    #[pyo3(signature = (db_path=":memory:", embedding_dim=384, embedder=None, encryption_key=None, model_dir=None, allow_unverified_embedder=false))]
     fn new(
+        py: Python<'_>,
         db_path: &str,
         embedding_dim: usize,
         embedder: Option<PyObject>,
         encryption_key: Option<Vec<u8>>,
         model_dir: Option<&str>,
+        allow_unverified_embedder: bool,
     ) -> PyResult<Self> {
         #[allow(unused_mut)]
         let mut inner = if let Some(key_bytes) = encryption_key {
@@ -307,7 +378,16 @@ impl PyYantrikDB {
             ));
         }
 
-        Ok(Self::from_engine(inner, embedder))
+        // #117: the constructor is the path the original report used. Build
+        // the wrapper first so the engine is queryable, then prove the
+        // embedder belongs to these vectors BEFORE it is allowed to encode
+        // anything. Gating only `set_embedder` left this open.
+        let mut this = Self::from_engine(inner, None);
+        if let Some(emb) = embedder {
+            this.check_embedder_identity(py, &emb, allow_unverified_embedder)?;
+            this.embedder = Some(emb);
+        }
+        Ok(this)
     }
 
     /// **v0.7.4** — open with a default embedder pre-attached.
@@ -415,7 +495,13 @@ impl PyYantrikDB {
     /// reject anything that doesn't return a numeric vector. Costs one
     /// extra `encode()` call up front in exchange for a clear,
     /// localized error.
-    fn set_embedder(&mut self, py: Python<'_>, embedder: PyObject) -> PyResult<()> {
+    #[pyo3(signature = (embedder, allow_unverified_embedder = false))]
+    fn set_embedder(
+        &mut self,
+        py: Python<'_>,
+        embedder: PyObject,
+        allow_unverified_embedder: bool,
+    ) -> PyResult<()> {
         // Probe with a sentinel — if encode() doesn't produce a numeric
         // vector, the embedder is bogus and we raise immediately.
         let probe = embedder
@@ -444,6 +530,10 @@ impl PyYantrikDB {
                  charset codec, not an embedder).",
             ));
         }
+
+        // #117: the probe above proves it is AN embedder. This proves it is
+        // THE embedder — the one whose space the stored vectors live in.
+        self.check_embedder_identity(py, &embedder, allow_unverified_embedder)?;
 
         self.embedder = Some(embedder);
         Ok(())

--- a/tests/test_issue117_embedder_identity.py
+++ b/tests/test_issue117_embedder_identity.py
@@ -1,0 +1,133 @@
+"""#117 — a reopened DB must not accept an embedder that did not build its vectors.
+
+The engine already refused a same-dim-different-digest swap in its own
+`set_embedder`. Python embedders never reached that path: both the constructor
+and the pyo3 `set_embedder` stored the object on the *wrapper*, so the engine's
+SearchState held whatever was auto-attached while every query and write was
+encoded by an object it had never seen.
+
+Measured on 0.15.3 before the fix: open accepted, recall returned similarity
+**0.595** against vectors built by a different model, writes accepted. The
+number is the point — cosine distance between two unrelated spaces still looks
+like a weak-but-real match, so nothing in the response tells the caller the
+answer is meaningless.
+
+These tests run in BOTH directions deliberately. A gate that only ever refuses
+is indistinguishable from a gate that refuses everything, and this suite has
+been burned by one-directional checks before.
+"""
+
+import hashlib
+import sqlite3
+
+import pytest
+
+from yantrikdb import YantrikDB
+
+DIM = 64  # BUNDLED_EMBEDDER_DIM — same dim on both sides, so no dim check can catch it
+
+
+class _Hostile:
+    """A valid embedder (encode -> list[float]) from an unrelated space."""
+
+    def encode(self, text):
+        if not isinstance(text, str):
+            return [self.encode(t) for t in text]
+        h = hashlib.blake2b(text.encode("utf-8"), digest_size=DIM).digest()
+        v = [(b / 255.0) - 0.5 for b in h]
+        n = sum(x * x for x in v) ** 0.5 or 1.0
+        return [x / n for x in v]
+
+
+class _Declaring(_Hostile):
+    """Same, but claims an identity the engine can check."""
+
+    def __init__(self, fingerprint):
+        self.fingerprint = fingerprint
+
+
+@pytest.fixture
+def built(tmp_path):
+    """A store populated by the bundled embedder, plus its recorded digest."""
+    db_path = str(tmp_path / "i117.db")
+    db = YantrikDB(db_path=db_path, embedding_dim=DIM)
+    db.record("the deploy key for node4 is id_deploy", namespace="n")
+    db.record("the cluster runs on port 7438", namespace="n")
+    db.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        digest = conn.execute(
+            "SELECT value FROM meta WHERE key='embedder_digest'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    return db_path, digest
+
+
+def test_constructor_refuses_an_embedder_that_did_not_build_the_vectors(built):
+    """The path the original report used."""
+    db_path, _ = built
+    with pytest.raises(RuntimeError) as e:
+        YantrikDB(db_path=db_path, embedding_dim=DIM, embedder=_Hostile())
+    assert "vectors were built by" in str(e.value)
+
+
+def test_set_embedder_refuses_an_undeclared_embedder(built):
+    db_path, _ = built
+    db = YantrikDB(db_path=db_path, embedding_dim=DIM)
+    try:
+        with pytest.raises(RuntimeError):
+            db.set_embedder(_Hostile())
+    finally:
+        db.close()
+
+
+def test_set_embedder_refuses_a_wrong_declared_fingerprint(built):
+    """Declaring an identity is not the same as declaring the RIGHT one."""
+    db_path, _ = built
+    db = YantrikDB(db_path=db_path, embedding_dim=DIM)
+    try:
+        with pytest.raises(RuntimeError):
+            db.set_embedder(_Declaring("sha256:deadbeef"))
+    finally:
+        db.close()
+
+
+def test_set_embedder_admits_the_matching_fingerprint(built):
+    """The other direction: a gate that refuses everything is not a gate."""
+    db_path, digest = built
+    db = YantrikDB(db_path=db_path, embedding_dim=DIM)
+    try:
+        db.set_embedder(_Declaring(digest))  # must not raise
+    finally:
+        db.close()
+
+
+def test_allow_unverified_embedder_is_the_documented_escape_hatch(built):
+    db_path, _ = built
+    db = YantrikDB(db_path=db_path, embedding_dim=DIM)
+    try:
+        db.set_embedder(_Hostile(), allow_unverified_embedder=True)  # must not raise
+    finally:
+        db.close()
+
+    # and on the constructor, for parity
+    db2 = YantrikDB(
+        db_path=db_path,
+        embedding_dim=DIM,
+        embedder=_Hostile(),
+        allow_unverified_embedder=True,
+    )
+    db2.close()
+
+
+def test_a_store_with_no_recorded_identity_is_not_gated(tmp_path):
+    """Nothing recorded means nothing to contradict — attaching must still work,
+    or every BYO-embedder user is locked out of their own database."""
+    db_path = str(tmp_path / "fresh.db")
+    db = YantrikDB(db_path=db_path, embedding_dim=DIM, embedder=_Hostile())
+    db.record("a record written by the caller's own embedder", namespace="n")
+    hits = db.recall(query="the caller's own embedder", top_k=1, namespace="n")
+    assert hits, "a BYO-embedder store must still be usable end to end"
+    db.close()


### PR DESCRIPTION
Closes #117.

The engine **already** refused a same-dim-different-digest swap in its own `set_embedder`. Python embedders never reached it — both entry points stored the object on the **wrapper**:

```rust
constructor   -> Ok(Self::from_engine(inner, embedder))
set_embedder  -> self.embedder = Some(embedder); Ok(())
```

So the engine's `SearchState` kept whatever was auto-attached, while every query and write was encoded by an object it had never seen. There was no code path where the two identities were compared.

## What it looked like

Store built by `potion-base-2M`, reopened at the **same dim** with an unrelated embedder:

```
OPEN:   ACCEPTED
RECALL: 2 hits at similarity 0.595 / 0.318
WRITE:  ACCEPTED — store now mixes two embedding spaces
```

The **0.595** is the whole problem. Cosine distance between two unrelated spaces still returns a plausible weak match, so nothing in the response distinguishes a meaningless answer from a thin one.

## The check

A Python object has no digest the engine can derive, so it declares one — `fingerprint` or `digest` — compared against the identity recorded for the vectors on disk:

| store | embedder | result |
|---|---|---|
| no recorded identity | anything | **attach** — nothing to contradict, and BYO users must keep working |
| `Known` digest | declares the same | **attach** |
| `Known` digest | declares a different one | **refuse** |
| `Known` digest | declares nothing | **refuse** — "I cannot prove these vectors are mine" is the 0.595 case |

`allow_unverified_embedder=True` overrides the refusals, matching the convention `pack.rs` already uses for mounting. The error names the recorded model and digest and lists all four ways out.

## Both paths are gated

Gating only `set_embedder` left the **constructor** open — which is the path the original report used. I caught that only by re-running the *reported* repro rather than my own test.

## Tests, in both directions

`tests/test_issue117_embedder_identity.py` — refuses undeclared, refuses a wrong fingerprint, **admits the matching one**, honours the escape hatch on both surfaces, and asserts a store with no recorded identity stays fully usable end to end.

That last one is the compatibility guard: without it this change would lock every bring-your-own-embedder user out of their own database. A gate that only ever refuses is indistinguishable from one that refuses everything.

## Gates

Suite **1967/0** `--all-features`; Python **237 passed**; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
