### PR TITLE
fix(cognition): think() drains the materializer backlog before it scans

### DIFF
--- a/crates/yantrikdb-core/src/engine/cognition.rs
+++ b/crates/yantrikdb-core/src/engine/cognition.rs
@@ -83,6 +83,41 @@ impl YantrikDB {
         let start = crate::time::Instant::now();
         let ts = now();
 
+        // Phase -1 (#95): materialize what the caller just wrote, BEFORE
+        // anything reads it.
+        //
+        // Every phase below reads derived state — the conflict scans read
+        // `claims`, consolidation reads `memory_entities`, the trigger checks
+        // read `entities`. None of that exists at `record()` time any more:
+        // the foreground write enqueues `OP_MATERIALIZE_RECORD_POST` and the
+        // extraction runs on the background materializer pool's 100 ms idle
+        // timer. So `record(); record(); think()` was a race, and the caller
+        // lost it by default — the documented contradiction example returned
+        // `conflicts_found: 0` immediately and `1` after a `sleep`, on
+        // identical input. Draining here makes think() read a store that
+        // contains the writes that preceded it, which is the contract every
+        // caller already assumed it had.
+        //
+        // FIRST STATEMENT ON PURPOSE, and it must stay first. The drain
+        // dispatches into materializers that take the conn lock, which is not
+        // reentrant — running it after any phase that holds a guard would
+        // deadlock. Nothing above this line takes one.
+        //
+        // Bounded and best-effort: `drain_materializer_backlog` caps the work
+        // (see its docs for the backlog tradeoff), and a drain FAILURE must
+        // not abort cognition. A store that cannot materialize is exactly a
+        // store that still needs its triggers expired and its existing
+        // conflicts scanned — degrading to the old racy behaviour beats
+        // returning an error from a maintenance call.
+        match self.drain_materializer_backlog() {
+            Ok(0) => {}
+            Ok(n) => tracing::debug!(applied = n, "think: drained materializer backlog"),
+            Err(e) => tracing::warn!(
+                error = %e,
+                "think: materializer drain failed; scanning possibly-stale derived state"
+            ),
+        }
+
         // Phase 0: Expire old triggers
         let expired = crate::triggers::expire_triggers(self, ts)?;
 

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -14,6 +14,22 @@ use super::{now, YantrikDB};
 /// its copies.
 pub(crate) const MAX_PENDING_OPS: i64 = 10_000;
 
+/// Ops drained per pass by [`YantrikDB::drain_materializer_backlog`].
+///
+/// The conn lock is released between passes, so this is the granularity at
+/// which a foreground drain yields to concurrent writers and to the
+/// background materializer pool. Matches the pool's own `DRAIN_BATCH_SIZE`
+/// order of magnitude; larger would hold the lock longer for no gain.
+const THINK_DRAIN_BATCH: usize = 64;
+
+/// Hard ceiling on ops a single `think()` will drain.
+///
+/// Deliberately below [`MAX_PENDING_OPS`] (10_000): a foreground call must
+/// stay bounded even when the queue is at its admission ceiling. See
+/// [`YantrikDB::drain_materializer_backlog`] for what is given up at the
+/// boundary and why a bounded drain beats an unbounded one.
+const THINK_DRAIN_BUDGET: usize = 4096;
+
 impl YantrikDB {
     /// Get engine statistics. Optionally filter memory counts by namespace.
     pub fn stats(&self, namespace: Option<&str>) -> Result<Stats> {
@@ -742,6 +758,77 @@ impl YantrikDB {
         }
 
         Ok(applied)
+    }
+
+    /// Drain the materializer backlog to a fixed point, bounded.
+    ///
+    /// **Why this exists (#95).** Foreground `record()` no longer extracts
+    /// entities or claims inline — it enqueues `OP_MATERIALIZE_RECORD_POST`
+    /// and returns (`engine/record.rs`). The extraction that actually
+    /// populates `entities`, `memory_entities` and `claims` runs in
+    /// [`Self::apply_materialize_record_post`], reached only from
+    /// [`Self::apply_pending_ops_once`] — which, before this, was called
+    /// only by the background materializer pool on its 100 ms idle timer
+    /// ([`crate::engine::materializer`]) and had no binding surface at all.
+    ///
+    /// So every `record(); record(); think()` sequence RACED that timer and
+    /// usually lost: the conflict scans read `claims`, `claims` was still
+    /// empty, and `think()` reported `conflicts_found: 0`. Adding a `sleep`
+    /// before `think()` — changing nothing else — flipped the same input to
+    /// `1`. The same race is why `search_entities` and
+    /// `backfill_memory_entities` returned 0 for freshly-written memories:
+    /// the ops were still sitting in the oplog at `applied = 0`.
+    ///
+    /// **Bounded, deliberately.** `think()` is a foreground call with a
+    /// latency budget; it must not become "block until an arbitrarily large
+    /// backlog clears". Two limits:
+    ///
+    /// - each pass drains at most [`THINK_DRAIN_BATCH`] ops, so the conn
+    ///   lock is released between passes and concurrent writers make
+    ///   progress;
+    /// - the call applies at most [`THINK_DRAIN_BUDGET`] ops in total.
+    ///
+    /// The budget is the honest tradeoff and worth stating plainly: the
+    /// drain query is `ORDER BY hlc, op_id` (oldest first), so on a store
+    /// whose backlog exceeds the budget, `think()` clears the *oldest*
+    /// ops and the just-written ones may still be pending. Determinism is
+    /// therefore guaranteed for the case that matters — an interactive
+    /// caller whose backlog is its own handful of writes — and degrades to
+    /// today's behaviour under a backlog larger than 4096 ops, rather than
+    /// degrading into an unbounded stall. A hang would be strictly worse
+    /// than the bug being fixed.
+    ///
+    /// **Terminates.** Each pass either applies at least one op or returns
+    /// zero and breaks. Ops that a materializer refuses (an apply error, or
+    /// a record deferred mid-reembed) stay `applied = 0` and are simply not
+    /// counted, so a queue of nothing-but-deferred ops yields `0` on the
+    /// first pass and exits — it cannot spin.
+    ///
+    /// **Cannot deadlock.** `apply_pending_ops_once` and the materializers
+    /// it dispatches to acquire [`Self::conn`] themselves, and that mutex
+    /// is not reentrant. Every caller must therefore hold NO connection
+    /// guard across this call. `think()` satisfies that by calling it as
+    /// its first statement, before any phase takes a guard.
+    ///
+    /// **Safe against the background pool.** Concurrent foreground and
+    /// worker drains are the design `apply_pending_ops_once` already
+    /// documents: the materializers are idempotent, and `mark_op_applied`
+    /// awards the count to exactly one racer. A pass that loses every race
+    /// returns `0` while the effects it applied are nonetheless in place,
+    /// which is why breaking on zero is correct rather than premature.
+    ///
+    /// Returns the number of ops this call was credited with applying.
+    pub(crate) fn drain_materializer_backlog(&self) -> Result<usize> {
+        let mut total = 0usize;
+        while total < THINK_DRAIN_BUDGET {
+            let batch = THINK_DRAIN_BATCH.min(THINK_DRAIN_BUDGET - total);
+            let applied = self.apply_pending_ops_once(batch)?;
+            if applied == 0 {
+                break;
+            }
+            total += applied;
+        }
+        Ok(total)
     }
 
     /// **Phase 4.3 — apply a queued `materialize_record_post` op.**

--- a/crates/yantrikdb-core/src/engine/tests/cognition_gates.rs
+++ b/crates/yantrikdb-core/src/engine/tests/cognition_gates.rs
@@ -622,3 +622,131 @@ fn test_schema_v20_mobility_state_roundtrip() {
         "untouched background components should remain NULL"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────
+// #95 — think() is deterministic against the writes that precede it.
+// ─────────────────────────────────────────────────────────────────
+
+/// Record two contradicting memories, then `think()` **immediately** — no
+/// sleep, no manual `apply_pending_ops_once` — and require the conflict.
+///
+/// This is the regression this change exists for. Foreground `record()` only
+/// enqueues `OP_MATERIALIZE_RECORD_POST`; the extraction that fills `claims`
+/// runs in the materializer. Before the fix the only thing that ever ran it
+/// was the background pool's 100 ms idle timer, so this sequence reported
+/// `conflicts_found: 0` and the same input with a `sleep` inserted reported
+/// `1`. A documented example whose result depends on wall-clock timing is not
+/// a documented example.
+///
+/// Deliberately NOT a timing test. `YantrikDB::new` spawns no materializer
+/// pool (only the Python binding does), so there is no thread that could
+/// incidentally make this pass — before the fix it fails every time, after it
+/// passes every time. No sleep appears anywhere in this test, and none may be
+/// added to it: a sleep here would re-admit exactly the defect being pinned.
+#[test]
+fn think_is_deterministic_without_sleeping_for_the_materializer() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+
+    // "<Entity> is based in <Place>" — extracted by the heuristic relation
+    // pass into headquartered_in, which is a FUNCTIONAL relation, so two
+    // distinct places for one subject is a genuine claim conflict.
+    for (i, text) in ["Acme is based in Boston.", "Acme is based in Denver."]
+        .iter()
+        .enumerate()
+    {
+        db.record(
+            text,
+            "semantic",
+            0.9,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            &vec_seed(i as f32 + 1.0, 8),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    }
+
+    // No sleep. No explicit drain. Just think().
+    let cfg = ThinkConfig {
+        run_consolidation: false,
+        run_personality: false,
+        ..Default::default()
+    };
+    let res = db.think(&cfg).unwrap();
+
+    assert!(
+        res.conflicts_found >= 1,
+        "think() must see the writes that preceded it; got conflicts_found = {} \
+         (this is #95: the materialize op was still pending at scan time)",
+        res.conflicts_found
+    );
+
+    let conflicts = db
+        .get_conflicts(Some("open"), None, None, None, None, 50)
+        .unwrap();
+    assert!(
+        conflicts
+            .iter()
+            .any(|c| c.rel_type.as_deref() == Some("headquartered_in")),
+        "expected a headquartered_in claim conflict, got: {:?}",
+        conflicts
+            .iter()
+            .map(|c| (&c.rel_type, &c.detection_reason))
+            .collect::<Vec<_>>()
+    );
+
+    // Same race, second symptom (#95): `search_entities` returned nothing for
+    // freshly-written memories because the ops were still at applied = 0.
+    let entities = db.search_entities(Some("Acme"), None, 10).unwrap();
+    assert!(
+        !entities.is_empty(),
+        "entities must be materialized by the time think() returns"
+    );
+}
+
+/// The drain is BOUNDED, and empty/idle stores cost nothing.
+///
+/// `think()` is a foreground call. Draining to a fixed point must not become
+/// "block until an arbitrarily large backlog clears", and a store with no
+/// pending work must not pay for the check twice. Draining an already-drained
+/// store applies zero ops and is a no-op on the second call — which is also
+/// what guarantees the loop cannot spin.
+#[test]
+fn draining_an_idle_store_is_a_no_op() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    db.record(
+        "Acme is based in Boston.",
+        "semantic",
+        0.9,
+        0.0,
+        604800.0,
+        &empty_meta(),
+        &vec_seed(1.0, 8),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap();
+
+    let first = db.drain_materializer_backlog().unwrap();
+    assert!(first >= 1, "the pending materialize op should be applied");
+
+    // Fixed point: nothing left, and re-draining terminates immediately.
+    assert_eq!(db.drain_materializer_backlog().unwrap(), 0);
+    assert_eq!(db.drain_materializer_backlog().unwrap(), 0);
+
+    let pending: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM oplog WHERE applied = 0", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(pending, 0, "drain should reach a fixed point");
+}


### PR DESCRIPTION
## The bug

`think()` reads derived state — the conflict scans read `claims`, consolidation reads `memory_entities`, the trigger checks read `entities`. None of that exists at `record()` time any more. Foreground `record()` enqueues `OP_MATERIALIZE_RECORD_POST` and returns (`engine/record.rs:729`); the extraction that actually populates those tables lives in `apply_materialize_record_post` (`engine/stats.rs`), reachable only through `apply_pending_ops_once`.

Before this change, the only thing that ever called `apply_pending_ops_once` in production was the background materializer pool, on its 100 ms idle timer (`engine/materializer.rs:28`). `think()` never drained, and `apply_pending_ops_once` has no binding surface — so **every `record(); record(); think()` sequence raced that timer, and the caller lost by default.**

Measured on the published 0.15.4 wheel. Identical input; the only difference is a `sleep`:

```
db.record("Acme is based in Boston."); db.record("Acme is based in Denver.")

think() immediately   -> conflicts_found: 0    search_entities("Acme") -> []
sleep(1.2); think()   -> conflicts_found: 1    search_entities("Acme") -> [{'name': 'Acme', ...}]
                         "Claim conflict: Acme has different headquartered_in values:
                          'Boston' vs 'Denver'"
```

A documented example whose result depends on wall-clock timing is not a documented example. This affects **every** `record -> think` sequence in the docs, not just the contradiction one.

**This also explains the `search_entities` / `backfill_memory_entities` returning 0 confusion in #95.** That was not a separate defect and not missing extraction — the materialize ops were simply still sitting in the oplog at `applied = 0` when those calls ran. Same race, second symptom.

## The change

`think()` drains the materializer backlog as its **first statement**, before any phase reads anything.

- `YantrikDB::drain_materializer_backlog()` (`engine/stats.rs`) loops `apply_pending_ops_once` to a fixed point.
- `think()` calls it first and treats the result as best-effort: a drain failure is logged and cognition continues, because a store that cannot materialize still needs its triggers expired and its existing conflicts scanned.

No behaviour is added to the detectors. Nothing is newly *detected* that was not detectable before — the same claims, reached reliably instead of by luck.

## The hazards, and why each is closed

**Bounded — it cannot stall.** Two limits: `THINK_DRAIN_BATCH = 64` ops per pass (the conn lock is released between passes, so concurrent writers and the background pool keep making progress), and `THINK_DRAIN_BUDGET = 4096` ops per call, deliberately below the `MAX_PENDING_OPS = 10_000` admission ceiling so a foreground call stays bounded even with the queue full.

The budget is a real tradeoff and the doc comment states it plainly rather than hiding it: the drain query is `ORDER BY hlc, op_id` (oldest first), so on a store whose backlog exceeds 4096 the oldest ops clear first and the just-written ones may still be pending. Determinism is therefore guaranteed for the case that matters — an interactive caller whose backlog is its own handful of writes — and degrades to today's behaviour beyond it, rather than degrading into an unbounded stall. **A hang would be strictly worse than the bug being fixed.**

**Terminates — it cannot spin.** Each pass either applies at least one op or returns zero and breaks. Ops a materializer refuses (an apply error, or a record deferred mid-reembed) stay `applied = 0` and are not counted, so a queue of nothing-but-deferred ops returns 0 on the first pass and exits.

**Cannot deadlock.** `apply_pending_ops_once` and the materializers it dispatches to take `conn()` themselves, and that mutex is not reentrant, so no caller may hold a connection guard across the drain. `think()` satisfies this by calling it first, before any phase takes a guard. Checked the other in-tree `think()` callers (`maintenance.rs:235` `run_maintenance_cycle`, the wasm surface) — neither holds a guard at the call site. The requirement is stated in the function's doc comment so the next caller inherits it.

**Does not block on the background pool.** The drain never waits for a worker; it does the work itself. Concurrent foreground and worker drains are the contract `apply_pending_ops_once` already documents: the materializers are idempotent and `mark_op_applied` awards the count to exactly one racer. A pass that loses every race returns 0 while the effects it applied are nonetheless in place — which is why breaking on zero is correct rather than premature.

## Tests

`think_is_deterministic_without_sleeping_for_the_materializer` (`engine/tests/cognition_gates.rs`) is the point of the PR: record two contradicting memories, `think()` immediately, require the conflict. **No sleep anywhere in the test, and none may be added** — a sleep there would re-admit the exact defect being pinned.

It is deliberately not a timing test. `YantrikDB::new` spawns no materializer pool (only the Python binding does), so there is no thread that could incidentally make it pass: it fails every time before the change and passes every time after. It also asserts `search_entities` is populated by the time `think()` returns, covering the second symptom above.

`draining_an_idle_store_is_a_no_op` pins the fixed point and the no-op re-entry that guarantee termination.

Full suite green: `cargo test --workspace --exclude yantrikdb-python` (CI's command), plus the slim `--no-default-features` path and `--features testing`. `cargo fmt --check` and `cargo clippy --all-targets --all-features --workspace --exclude yantrikdb-python` clean.

## Scope — what this deliberately does NOT do

**It does not make the README's contradiction example work.** `db.record("CEO is Alice"); db.record("CEO is Bob"); db.think()` still returns `conflicts_found: 0`, and correctly so: that path is gated on `ThinkConfig.extract_attribute_claims`, which defaults to `false` and is a separate product decision documented in #95. Flipping it produced 5 false conflicts and 0 true ones on a 20-memory corpus of ordinary consistent memories, so it is not in this PR.

**Flagging, not fixing (one change per PR):** heuristic extraction mints `ceo_of(person -> org)`, but `scan_claim_conflicts` only groups same-`src`/different-`dst` (`e1.src = e2.src AND e1.dst < e2.dst`). So "Alice is the CEO of Acme" vs "Bob is the CEO of Acme" can never fire from free text, even though `ceo_of` is in `FUNCTIONAL_REL_TYPES` — the relation is **inverse**-functional (an org has one CEO; a person may legitimately be CEO of several). Confirmed still 0 with a generous sleep, so it is not this race. Same applies to `cto_of`, `cfo_of`, `subsidiary_of`. It is also why the `graph(action="relate")` workaround works: that call happens to put the org in the `src` slot. Fixing it means a new inverse-functional scan with its own false-positive profile (co-CEOs, historical succession) and deserves the labelled-set treatment `a5fdf79` established. Details in #95.

Minor, same family: `lives_in` is in `FUNCTIONAL_REL_TYPES` but no `RELATION_PATTERNS` entry ever produces it, so `"Alice lives in Boston"` extracts nothing.

Refs #95.
