### PR TITLE
fix(wasm): the browser build panicked on the first record() and again on think()

### DIFF
--- a/crates/yantrikdb-core/src/engine/warrant.rs
+++ b/crates/yantrikdb-core/src/engine/warrant.rs
@@ -517,11 +517,12 @@ fn content_hash(claims: &[ClaimRow]) -> String {
 }
 
 fn unix_seconds() -> i64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+    // `crate::time`, not `std::time` — this runs inside `ingest_claim`, which
+    // `think()` reaches through the materializer drain, and
+    // `SystemTime::now()` panics on wasm32-unknown-unknown. The browser build
+    // died here on the first `think()` after the equivalent fix in
+    // `DeltaIndex`.
+    crate::time::now_secs() as i64
 }
 
 /// ⊕ accumulation: sum of weighted supports with leave-one-out dependence

--- a/crates/yantrikdb-core/src/time.rs
+++ b/crates/yantrikdb-core/src/time.rs
@@ -40,7 +40,17 @@ pub fn now_ms() -> u64 {
 }
 
 /// Monotonic-ish instant for measuring elapsed time.
+///
+/// **Use this, not `std::time::Instant`, anywhere the engine's own code
+/// paths can reach.** `std::time::Instant::now()` panics on
+/// wasm32-unknown-unknown ("time not implemented on this platform"), and
+/// the panic is an `unreachable` trap with no message — the browser build
+/// died inside `DeltaIndex::append_inner` on the very first `record()`
+/// with nothing but a stack address to go on. `Copy` + `elapsed()` are
+/// here so a `std::time::Instant` field or local can be swapped for this
+/// one without touching the surrounding logic.
 #[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy)]
 pub struct Instant(std::time::Instant);
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -48,18 +58,25 @@ impl Instant {
     pub fn now() -> Self {
         Instant(std::time::Instant::now())
     }
+    pub fn elapsed(&self) -> std::time::Duration {
+        self.0.elapsed()
+    }
     pub fn elapsed_ms(&self) -> u64 {
         self.0.elapsed().as_millis() as u64
     }
 }
 
 #[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone, Copy)]
 pub struct Instant(f64);
 
 #[cfg(target_arch = "wasm32")]
 impl Instant {
     pub fn now() -> Self {
         Instant(js_sys::Date::now())
+    }
+    pub fn elapsed(&self) -> std::time::Duration {
+        std::time::Duration::from_secs_f64((js_sys::Date::now() - self.0).max(0.0) / 1000.0)
     }
     pub fn elapsed_ms(&self) -> u64 {
         (js_sys::Date::now() - self.0).max(0.0) as u64

--- a/crates/yantrikdb-core/src/vector/delta_index.rs
+++ b/crates/yantrikdb-core/src/vector/delta_index.rs
@@ -135,7 +135,7 @@ pub struct DeltaIndex {
     /// Lives on `DeltaIndex` rather than per-`DeltaEntry` so a busy
     /// workload with frequent appends doesn't pay one Instant per entry —
     /// we only care about the *oldest* unflushed entry's age.
-    oldest_dirty_at: parking_lot::Mutex<Option<std::time::Instant>>,
+    oldest_dirty_at: parking_lot::Mutex<Option<crate::time::Instant>>,
     /// Compaction trigger threshold for `oldest_dirty_at` — once the
     /// delta's oldest entry has been sitting longer than this, the
     /// compactor fires regardless of delta size.
@@ -372,7 +372,7 @@ impl DeltaIndex {
         // don't touch it — only the oldest entry's age matters for the
         // age-based trigger.
         if was_empty {
-            *self.oldest_dirty_at.lock() = Some(std::time::Instant::now());
+            *self.oldest_dirty_at.lock() = Some(crate::time::Instant::now());
         }
         // **Saga task 18 Option 4 (v0.7.2).** Wake the compactor early
         // when delta crosses ~80% of capacity. Without this, the
@@ -441,7 +441,7 @@ impl DeltaIndex {
         // entry in the delta (delta was empty before the push). Same rule
         // as append(): only the *oldest* dirty entry's age matters.
         if was_empty {
-            *self.oldest_dirty_at.lock() = Some(std::time::Instant::now());
+            *self.oldest_dirty_at.lock() = Some(crate::time::Instant::now());
         }
         // Saga task 18 Option 4: tombstone-only paths also fill the
         // delta and should wake the compactor at the same threshold.
@@ -493,7 +493,7 @@ impl DeltaIndex {
                 // entry ages into cold rather than sitting in the delta.
                 let mut clock = self.oldest_dirty_at.lock();
                 if clock.is_none() {
-                    *clock = Some(std::time::Instant::now());
+                    *clock = Some(crate::time::Instant::now());
                 }
                 return true;
             }
@@ -698,7 +698,7 @@ impl DeltaIndex {
         // compaction — otherwise a low-volume published correction could
         // sit in the linear-scan delta forever, defeating the age trigger.
         *self.oldest_dirty_at.lock() = if retained_any {
-            Some(std::time::Instant::now())
+            Some(crate::time::Instant::now())
         } else {
             None
         };
@@ -750,7 +750,7 @@ impl DeltaIndex {
             .store(0, std::sync::atomic::Ordering::Release);
         let published_remains = delta.iter().any(|e| e.published);
         *self.oldest_dirty_at.lock() = if published_remains {
-            Some(std::time::Instant::now())
+            Some(crate::time::Instant::now())
         } else {
             None
         };

--- a/crates/yantrikdb-wasm/Cargo.toml
+++ b/crates/yantrikdb-wasm/Cargo.toml
@@ -9,7 +9,11 @@ description = "YantrikDB compiled to WebAssembly — run cognitive memory in the
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-yantrikdb = { path = "../yantrikdb-core" }
+# default-features = false drops `bundled-embedder`. model2vec-rs pulls in
+# tokenizers -> hf-hub -> ureq -> socks, and socks does not compile for
+# wasm32-unknown-unknown (it calls UdpSocket::readv). The browser has no use
+# for an in-engine embedder anyway: the JS caller supplies the vectors.
+yantrikdb = { path = "../yantrikdb-core", default-features = false }
 wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Rebuilding the wasm bundle from main for the yantrikdb.com live demo produced a module that constructed fine and then trapped on `unreachable` as soon as it was asked to do anything. Two `std::time` calls sitting on paths the browser reaches:

- **`DeltaIndex`** stamped `oldest_dirty_at` with `std::time::Instant::now()`, which panics on `wasm32-unknown-unknown` ("time not implemented on this platform"). Every `record()` hit it through `append_inner`.
- **`warrant::unix_seconds()`** used `SystemTime::now()`. `think()` reaches it through the materializer drain added in #139 → `ingest_claim` → `compute_write_tier_mobility_conn`, so the first `think()` after a write died there too.

Both now use `crate::time`, which has had a wasm branch (`js_sys::Date`) since it was written — these two call sites just never used it. `crate::time::Instant` gains `Copy` and `elapsed() -> Duration` so it drops into a `std::time::Instant` field without reshaping the surrounding logic. Native behaviour is unchanged.

Also: `yantrikdb-wasm` now takes the core with `default-features = false`. `bundled-embedder` pulls `model2vec-rs → tokenizers → hf-hub → ureq → socks`, and `socks` does not compile for wasm32 at all (`UdpSocket::readv`), so the crate had quietly stopped building for its own target. The browser supplies its own vectors, so nothing is lost by dropping it.

### Verification

Native: `cargo test -p yantrikdb --lib delta_index` (30 passed) and `-- warrant cognition_gates conflict think` (86 passed).

In the browser build, which is the part that matters here — the demo's own sequence, driven through the actual wasm module:

```
>>> db.record("Acme is based in Boston.", importance=0.9)
>>> db.record("User prefers Python over JavaScript", importance=0.8)
>>> db.record("User is stressed about the Friday deadline", importance=0.9, valence=-0.6)

>>> db.recall("user stressed about deadline", top_k=3)
  1. [score 0.520] "User is stressed about the Friday deadline"
  2. [score 0.051] "User prefers Python over JavaScript"
  3. [score 0.000] "Acme is based in Boston."

>>> db.record("Acme is based in Denver.", importance=0.9)
>>> db.think()
Cognition complete in 22ms
  Conflicts found:  1

>>> db.recall("Acme is based in", top_k=3)
  1. [score 0.547] "Acme is based in Boston."
       ⚠ unresolved medium conflict (identity_fact) with …  — verify before relying
  2. [score 0.519] "Acme is based in Denver."
       ⚠ unresolved medium conflict (identity_fact) with …  — verify before relying
```

Before this change, the first `record()` above trapped.

### Note

`crates/yantrikdb-wasm/pkg/` is checked in and is stale build output from March; this PR deliberately leaves it alone. The artifact that ships lives in `yantrikdb-web/public/wasm/`, rebuilt from this branch, with the build recipe now scripted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)