### PR TITLE
fix(cognition): think() undercounted conflicts it had written (#142)

### DIFF
--- a/crates/yantrikdb-core/src/engine/cognition.rs
+++ b/crates/yantrikdb-core/src/engine/cognition.rs
@@ -118,6 +118,20 @@ impl YantrikDB {
             ),
         }
 
+        // #142: `conflicts_found` used to sum only the two Phase-2 scans, but
+        // Phase 1's `check_redundancy` ALSO persists conflicts (learned
+        // substitution categories, via create_conflict) and returns only its
+        // triggers — so a real, stored conflict reported as 0. Counting rows
+        // written across the whole cycle makes the number mean "what think()
+        // actually persisted", and stays correct when a fourth writer appears.
+        let conflicts_before: i64 = if config.run_conflict_scan {
+            self.conn()
+                .query_row("SELECT COUNT(*) FROM conflicts", [], |r| r.get(0))
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
         // Phase 0: Expire old triggers
         let expired = crate::triggers::expire_triggers(self, ts)?;
 
@@ -158,12 +172,18 @@ impl YantrikDB {
         // (so contradictions are flagged before similar memories get merged)
         // Uses consolidation_limit to cap work per call (incremental processing).
         let conflicts_found = if config.run_conflict_scan {
-            let entity_conflicts =
-                crate::conflict::scan_conflicts_limited(self, config.consolidation_limit)?.len();
+            crate::conflict::scan_conflicts_limited(self, config.consolidation_limit)?;
             // RFC 006 Phase 1: also scan claim-based conflicts (scoped, with severity + reason codes)
-            let claim_conflicts =
-                crate::conflict::scan_claim_conflicts(self, config.consolidation_limit)?.len();
-            entity_conflicts + claim_conflicts
+            crate::conflict::scan_claim_conflicts(self, config.consolidation_limit)?;
+            // Delta over the whole cycle rather than the sum of these two scans'
+            // return values — see the note at `conflicts_before`. Saturating
+            // because consolidation can tombstone rows, and a negative "found"
+            // would be worse than an undercount.
+            let after: i64 = self
+                .conn()
+                .query_row("SELECT COUNT(*) FROM conflicts", [], |r| r.get(0))
+                .unwrap_or(conflicts_before);
+            (after - conflicts_before).max(0) as usize
         } else {
             0
         };

--- a/crates/yantrikdb-core/src/engine/tests/bundled_embedder.rs
+++ b/crates/yantrikdb-core/src/engine/tests/bundled_embedder.rs
@@ -2428,3 +2428,75 @@ fn refresh_embeddings_heals_rows_that_have_no_vector() {
     let other = db.refresh_embeddings(Some("does-not-exist"), true).unwrap();
     assert_eq!(other.scanned, 0, "namespace scope must actually filter");
 }
+
+/// #142 — `think()`'s reported count must equal the rows it actually wrote.
+///
+/// The counter used to sum only the two Phase-2 scans, while Phase 1's
+/// redundancy check ALSO persisted conflicts through `create_conflict` and
+/// returned only its triggers. A real, stored conflict was reported as zero,
+/// so a caller following the documented example concluded the feature had not
+/// fired while their store held an open conflict.
+///
+/// The invariant is what matters, not the specific number: anything that
+/// persists to `conflicts` has to contribute, otherwise this recurs the next
+/// time a detector is added.
+///
+/// Honest limit: this asserts the invariant on the CLAIM path. The redundancy
+/// path that actually caused #142 needs >=0.85 embedding similarity, which the
+/// bundled 64-dim embedder does not reach for the motivating pair — so this
+/// test would NOT have caught the original bug. It catches the next one that
+/// lands on a path it can reach.
+#[test]
+#[cfg(feature = "bundled-embedder")]
+fn think_conflicts_found_matches_rows_written() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = YantrikDB::with_default(dir.path().join("i142.db").to_str().unwrap()).unwrap();
+
+    let count = |db: &YantrikDB| {
+        db.get_conflicts(None, None, None, None, None, 1000)
+            .unwrap()
+            .len()
+    };
+    let rec = |db: &YantrikDB, text: &str| {
+        db.record_text(
+            text,
+            "semantic",
+            0.8,
+            0.0,
+            604800.0,
+            &empty_meta(),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap()
+    };
+
+    let before = count(&db);
+    // Boston/Denver goes through scan_claim_conflicts, which fires on the
+    // bundled 64-dim embedder. The motivating case ("works at Google" vs
+    // "Meta") travels the REDUNDANCY path instead, and that path gates on
+    // >=0.85 embedding similarity — reachable with the 256-dim default
+    // embedder but not with the bundled one, so it cannot be exercised here.
+    // This test therefore guards the invariant rather than reproducing #142.
+    rec(&db, "Acme is based in Boston.");
+    rec(&db, "Acme is based in Denver.");
+
+    let report = db.think(&ThinkConfig::default()).unwrap();
+    let written = count(&db) - before;
+
+    // Guard the guard: if the redundancy path never fires here, the assertion
+    // below compares 0 to 0 and proves nothing. A test that cannot fail is
+    // worse than no test.
+    assert!(
+        written > 0,
+        "no conflict was written — this test cannot detect the undercount"
+    );
+    assert_eq!(
+        report.conflicts_found, written,
+        "think() reported {} conflicts but {} rows were written",
+        report.conflicts_found, written
+    );
+}


### PR DESCRIPTION
Closes #142.

## The bug

`conflicts_found` summed the two Phase-2 scans:

```rust
let conflicts_found = scan_conflicts_limited(..).len()
                    + scan_claim_conflicts(..).len();
```

but **Phase 1's `check_redundancy` also persists conflicts** — learned substitution categories, via `create_conflict`, result discarded with `let _ =` — and returns only its triggers. It runs *before* the counter is computed, so a real, stored conflict reported as zero.

Reproduced on **0.15.5** (filed against 0.14.1, so it survived the release train):

```
"Sarah works at Google" / "Sarah works at Meta"
  conflicts_found = 0        get_conflicts() = 1  (preference, llm_providers)

"Acme is based in Boston."  / "...Denver."
  conflicts_found = 1        correct — travels the claim path, which IS summed
```

That difference is why the two documented examples look incoherent to a user comparing them.

## The fix

Count the delta across the whole cycle rather than summing two of three writers, so the number means *"rows this `think()` persisted"* and stays correct when a fourth writer appears. Saturating at zero — consolidation can tombstone rows, and a negative "found" is worse than an undercount.

## On the test, honestly

The regression test asserts `conflicts_found == rows written`. Two things worth stating plainly:

- **The first version was vacuous.** It passed with the fix *reverted* — asserting `0 == 0`, because the redundancy path needs ≥0.85 embedding similarity and the bundled 64-dim embedder doesn't reach it for that pair. I added a `written > 0` guard so it can never silently become vacuous again.
- **It therefore would not have caught this bug.** It exercises the claim path and guards the invariant going forward. Reproducing #142 in-tree needs the 256-dim default embedder; worth doing separately if we want that coverage.

## Not addressed, worth a separate decision

`IDENTITY_CATEGORIES` contains only `cloud_providers`, so `llm_providers` maps to `Preference`. Where someone works is an identity fact, not a preference — and it affects priority routing downstream.

1959 tests pass, `cargo fmt` clean.