### PR TITLE
release: v0.15.6 — think() reports the conflicts it wrote

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2021"
 license = "Apache-2.0"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.15.5"
+version = "0.15.6"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Patch release for #142, merged in #143.

## What shipped

`conflicts_found` summed two of the **three** code paths that persist conflicts, so a real, stored conflict reported as zero — the number every caller reads, every example prints, and every integration logs.

## Verified on the real path, not just CI

The in-tree regression test cannot reach the path that caused this: it uses the bundled 64-dim embedder, and the redundancy path gates on ≥0.85 embedding similarity. So the wheel was built from the merge and the issue's own repro run against the 256-dim default embedder:

```
before (0.15.5):  conflicts_found=0   get_conflicts()=1
after  (0.15.6):  conflicts_found=1   get_conflicts()=1
```

Regression sweep on the same build:

| | think #1 | rows | match |
|---|---|---|---|
| #142 redundancy path | 1 | 1 | ✅ |
| claim path (already correct) | 1 | 1 | ✅ |
| unrelated memories | 0 | 0 | ✅ |
| CEO pair (#95 gap) | 0 | 0 | ✅ |

Fixed where broken, unchanged where it worked, no over-counting, #95 untouched, idempotent across repeated `think()`.

## Gates

- `cargo fmt --all --check` clean
- Lint / Tests / Benchmark green on `main`
- 1959 tests pass

**Co-iteration gate deliberately not run:** it exists for retrieval-quality changes that could regress hermes-plugin in the field. This changes a reported count and touches no ranking, tokenizer, or recall path. Cluster validation likewise not applicable — that gates *server* releases, and the server is not being re-pinned.