### PR TITLE
bench(amb): record within-thread representative null

### DIFF
--- a/benchmarks/amb/CONTEXTUAL_CANDIDATE_BANK.md
+++ b/benchmarks/amb/CONTEXTUAL_CANDIDATE_BANK.md
@@ -116,6 +116,57 @@ otherwise correct source groups, so within-session representative selection is
 the residual gap. Keep this route experimental until an untouched relationship
 timeline query confirms the lift without a category regression.
 
+### Within-source representative preregistration
+
+The residual arm was frozen before scoring. Inside each selected source
+conversation, it ranks direct relationship mentions by a small decision-cue
+signal (`decide`, `whether`, `prioritize`, `focus`, or `approach`), then by the
+existing contextual score and chronology. It retains only the winner plus any
+`context_bridge` row whose stored `parent_turn` points to that winner. This cue
+lexicon is benchmark harness logic only; a product implementation must consume
+structured organizer intent rather than these words.
+
+The rule was derived from Q7, so Q7 alone is not validation. Before freezing the
+judged pair, the identical rank was applied to Q9_1's five family-support source
+groups. All cue counts were zero and the contextual-score fallback reproduced
+the exact prior identities and turns (`24, 76, 118, 208, 260`). The full frozen
+18-query audit retained `10/10` fired gold turns, preserved cohort reachability
+at `60/95`, had zero negative queries, and reduced fired rows from `92` to `11`.
+Its audit SHA-256 is
+`757e9a4226e156701146a89a0c705ca171123abf3495b22bcaaae87d90b7a0d3`.
+
+The Q7 control is the accepted eight-row relationship thread and exactly
+reproduces SHA-256
+`6dc0a4610ac2b9ca2bbc3fab4224ec4675bc4c80f41f72f670951b6cd3d29df7`.
+The six-row treatment keeps turns `14, 64, 124, 170, 212, 214`, drops only
+`156, 168`, and has SHA-256
+`2c8bd6368ca1bb4cd7a68de0edbe8679101c427efd59f12656d97595d6609494`.
+The paired manifest SHA-256 is
+`3fdd24417b933d8c5938026ceb6ffff6e68d6e4b05269fb5a76368d5c77fb2f8`.
+
+The preregistered hypothesis is that removing the two same-source distractors
+raises Q7 above the control's unanimous `0.70`. The null is a median paired
+delta of `0.00`; any negative delta is a failed arm. Answering and three repeated
+judgments use the pinned `deepseek-v4-flash:0731-cloud` snapshot. The result is
+internally paired but not line-comparable to the rolling `:cloud` benchmark.
+No other query will be judged for this residual.
+
+The frozen run rejected the hypothesis:
+
+| Frozen arm | Rows | Context tokens | Median score | Judge votes |
+| --- | ---: | ---: | ---: | --- |
+| Relationship thread control | 8 | 624 | `0.70` | `0.70, 0.70, 0.70` |
+| Within-source representatives | 6 | 489 | `0.50` | `0.40, 0.50, 0.50` |
+
+The paired delta was `-0.20`, a preregistered failed arm. No rerun was made.
+The treatment answer identified the five broad stages, but compressed away exact
+rubric details such as the Zoom-call context, improving the essay before the
+conference paper, and follow-up Zoom/conference planning. This result rejects
+raw-row deletion as the residual fix. It points back to representation: a source
+stage needs an answer-sized synthesized item that preserves its distinguishing
+detail. The representative selector remains opt-in experimental harness code
+and must not be promoted to a product default.
+
 ### Untouched holdout
 
 The untouched Q9 family-support query provided that confirmation. Its raw bank

--- a/benchmarks/amb/prepare_contextual_synthesis_pair.py
+++ b/benchmarks/amb/prepare_contextual_synthesis_pair.py
@@ -50,6 +50,10 @@ _ACTIVE_RELATIONSHIP_SUPPORT_RE = re.compile(
     r"care package|letters?|rehears\w*|concern\w*|check-ins?)\b",
     re.IGNORECASE,
 )
+_DECISION_CUE_RE = re.compile(
+    r"\b(decid\w*|whether|prioriti[sz]\w*|focus\w*|approach\w*)\b",
+    re.IGNORECASE,
+)
 
 
 def _sha256_bytes(payload: bytes) -> str:
@@ -192,11 +196,52 @@ def select_relationship_thread(artifact: dict) -> dict:
     return selected
 
 
-def render_relationship_thread(artifact: dict) -> tuple[str, dict]:
+def _representative_rank_key(row: dict) -> tuple:
+    """Rank answer-bearing events inside one source conversation."""
+    return (
+        len(_DECISION_CUE_RE.findall(row.get("text") or "")),
+        row.get("contextual_score") or 0.0,
+        -(row.get("turn") or 0),
+        row.get("identity") or "",
+    )
+
+
+def _representative_thread_groups(thread: dict) -> dict:
+    """Keep one direct mention per source plus its linked context bridges."""
+    mention = re.compile(
+        rf"\b{re.escape(thread['anchor'])}\b", re.IGNORECASE
+    )
+    groups = {}
+    for group_key, members in thread["groups"].items():
+        direct = [
+            row for row in members if mention.search(row.get("text") or "")
+        ]
+        if not direct:
+            continue
+        representative = max(direct, key=_representative_rank_key)
+        selected = [representative]
+        selected.extend(
+            row
+            for row in members
+            if row.get("reason") == "context_bridge"
+            and row.get("parent_turn") == representative.get("turn")
+        )
+        groups[group_key] = selected
+    return groups
+
+
+def render_relationship_thread(
+    artifact: dict, *, representative_per_source: bool = False
+) -> tuple[str, dict]:
     """Render one selected person timeline as source-conversation buckets."""
     thread = select_relationship_thread(artifact)
+    groups = (
+        _representative_thread_groups(thread)
+        if representative_per_source
+        else thread["groups"]
+    )
     ordered_groups = sorted(
-        thread["groups"].items(),
+        groups.items(),
         key=lambda item: (
             min(
                 row.get("created_at")
@@ -235,17 +280,20 @@ def render_relationship_thread(artifact: dict) -> tuple[str, dict]:
     gold_turns = set(ceiling.get("available_source_turns") or []) | set(
         ceiling.get("missing_source_turns") or []
     )
+    selected_rows = [row for rows in groups.values() for row in rows]
     selected_turns = {
-        row.get("turn") for row in thread["members"] if row.get("turn") is not None
+        row.get("turn") for row in selected_rows if row.get("turn") is not None
     }
     selection_payload = {
         "anchor": thread["anchor"],
         "groups": source_groups,
     }
+    if representative_per_source:
+        selection_payload["representative_per_source"] = True
     audit = {
         "selected_anchor": thread["anchor"],
         "role_matches": thread["role_matches"],
-        "selected_row_count": len(thread["members"]),
+        "selected_row_count": len(selected_rows),
         "source_group_count": len(source_groups),
         "selected_turns": sorted(selected_turns),
         "selected_gold_turns": sorted(gold_turns & selected_turns),
@@ -258,6 +306,23 @@ def render_relationship_thread(artifact: dict) -> tuple[str, dict]:
         ).encode("utf-8")),
         "source_groups": source_groups,
     }
+    if representative_per_source:
+        original_turns = {
+            row.get("turn")
+            for row in thread["members"]
+            if row.get("turn") is not None
+        }
+        audit.update({
+            "representative_per_source": True,
+            "dropped_turns": sorted(original_turns - selected_turns),
+            "decision_cue_counts": {
+                str(row.get("turn")): len(
+                    _DECISION_CUE_RE.findall(row.get("text") or "")
+                )
+                for row in thread["members"]
+                if row.get("turn") is not None
+            },
+        })
     return "\n\n".join(memories), audit
 
 
@@ -299,7 +364,7 @@ def render_relationship_support_stages(artifact: dict) -> tuple[str, dict]:
     if not groups:
         raise ValueError("no active family-support stages")
 
-    representatives = [
+    legacy_representatives = [
         max(
             members,
             key=lambda row: (
@@ -310,6 +375,11 @@ def render_relationship_support_stages(artifact: dict) -> tuple[str, dict]:
         )
         for members in groups.values()
     ]
+    representative_candidates = [
+        max(members, key=_representative_rank_key)
+        for members in groups.values()
+    ]
+    representatives = legacy_representatives
     representatives.sort(key=lambda row: (
         row.get("created_at")
         if row.get("created_at") is not None else float("inf"),
@@ -341,6 +411,12 @@ def render_relationship_support_stages(artifact: dict) -> tuple[str, dict]:
         "anchors": sorted(anchors),
         "source_groups": source_groups,
     }
+    legacy_identities = sorted(
+        row.get("identity") or "" for row in legacy_representatives
+    )
+    representative_candidate_identities = sorted(
+        row.get("identity") or "" for row in representative_candidates
+    )
     audit = {
         "selected_anchors": sorted(anchors),
         "selected_row_count": len(representatives),
@@ -348,6 +424,13 @@ def render_relationship_support_stages(artifact: dict) -> tuple[str, dict]:
         "selected_turns": sorted(selected_turns),
         "selected_gold_turns": sorted(gold_turns & selected_turns),
         "missing_gold_turns": sorted(gold_turns - selected_turns),
+        "legacy_selected_identities": legacy_identities,
+        "representative_candidate_identities": (
+            representative_candidate_identities
+        ),
+        "representative_selection_identity_unchanged": (
+            legacy_identities == representative_candidate_identities
+        ),
         "selection_sha256": _sha256_bytes(json.dumps(
             selection_payload,
             sort_keys=True,
@@ -374,6 +457,10 @@ def context_row(
         context = render_selected_evidence(preflight)
     elif context_mode == "relationship-thread":
         context, thread_audit = render_relationship_thread(artifact)
+    elif context_mode == "relationship-thread-representatives":
+        context, thread_audit = render_relationship_thread(
+            artifact, representative_per_source=True
+        )
     elif context_mode == "relationship-support-stages":
         context, thread_audit = render_relationship_support_stages(artifact)
     else:
@@ -441,6 +528,7 @@ def main() -> int:
         "--context-mode",
         choices=(
             "synthesis", "selected-evidence", "relationship-thread",
+            "relationship-thread-representatives",
             "relationship-support-stages",
         ),
         default="synthesis",
@@ -449,6 +537,7 @@ def main() -> int:
         "--context-mode-a",
         choices=(
             "synthesis", "selected-evidence", "relationship-thread",
+            "relationship-thread-representatives",
             "relationship-support-stages",
         ),
     )
@@ -456,6 +545,7 @@ def main() -> int:
         "--context-mode-b",
         choices=(
             "synthesis", "selected-evidence", "relationship-thread",
+            "relationship-thread-representatives",
             "relationship-support-stages",
         ),
     )

--- a/benchmarks/amb/relationship_stage_cohort_audit.py
+++ b/benchmarks/amb/relationship_stage_cohort_audit.py
@@ -31,7 +31,7 @@ def _sha256_json(value: object) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def audit_query(row: dict) -> dict:
+def audit_query(row: dict, *, relationship_representatives: bool = False) -> dict:
     """Route one query, falling back to the unchanged bank on abstention."""
     query = row.get("query") or ""
     bank_ceiling = row.get("bank_ceiling") or (
@@ -48,7 +48,9 @@ def audit_query(row: dict) -> dict:
             _, selector_audit = render_relationship_support_stages(row)
         elif _RELATIONSHIP_TIMELINE_QUERY_RE.search(query):
             route = "relationship_thread"
-            _, selector_audit = render_relationship_thread(row)
+            _, selector_audit = render_relationship_thread(
+                row, representative_per_source=relationship_representatives
+            )
     except ValueError as exc:
         route = "abstain"
         error = str(exc)
@@ -130,6 +132,7 @@ def main() -> int:
     parser.add_argument("--cohort", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--expect-cohort-sha256")
+    parser.add_argument("--relationship-representatives", action="store_true")
     args = parser.parse_args()
 
     cohort = json.loads(args.cohort.read_text(encoding="utf-8"))
@@ -139,9 +142,19 @@ def main() -> int:
             f"cohort hash mismatch: expected {args.expect_cohort_sha256}, "
             f"got {cohort_sha256}"
         )
-    rows = [audit_query(row) for row in cohort.get("queries") or []]
+    rows = [
+        audit_query(
+            row,
+            relationship_representatives=args.relationship_representatives,
+        )
+        for row in cohort.get("queries") or []
+    ]
     artifact = {
-        "protocol": "query-dependent-relationship-stage-cohort-audit-v1",
+        "protocol": (
+            "query-dependent-relationship-stage-representative-audit-v1"
+            if args.relationship_representatives
+            else "query-dependent-relationship-stage-cohort-audit-v1"
+        ),
         "answer_calls": 0,
         "judge_calls": 0,
         "cohort_sha256": cohort_sha256,

--- a/tests/test_amb_prepare_contextual_synthesis_pair.py
+++ b/tests/test_amb_prepare_contextual_synthesis_pair.py
@@ -147,6 +147,90 @@ def test_relationship_thread_renders_one_memory_per_source_conversation():
     assert audit["missing_gold_turns"] == []
 
 
+def test_relationship_thread_representatives_drop_only_same_source_distractors():
+    artifact = {
+        "query": (
+            "List my academic work and mentorship in order. Mention only five items."
+        ),
+        "preflight": {
+            "source_evidence_ceiling": {
+                "available_source_turns": [14, 64, 124, 170, 214],
+                "missing_source_turns": [],
+            },
+            "evidence_ledger": [
+                {
+                    "identity": "meet", "turn": 14, "created_at": 100.0,
+                    "source_doc_id": "s0", "contextual_score": 0.55,
+                    "status": "kept",
+                    "text": "[Turn 14] I met my mentor Robert.",
+                },
+                {
+                    "identity": "essay", "turn": 64, "created_at": 200.0,
+                    "source_doc_id": "s1", "contextual_score": 0.55,
+                    "status": "kept",
+                    "text": "[Turn 64] Robert shared his academic essay.",
+                },
+                {
+                    "identity": "feedback", "turn": 124, "created_at": 300.0,
+                    "source_doc_id": "s2", "contextual_score": 0.52,
+                    "status": "kept",
+                    "text": (
+                        "[Turn 124] I am deciding whether to prioritize and focus "
+                        "on Robert's review feedback."
+                    ),
+                },
+                {
+                    "identity": "confidence", "turn": 156, "created_at": 300.0,
+                    "source_doc_id": "s2", "contextual_score": 0.49,
+                    "status": "kept",
+                    "text": "[Turn 156] Robert's feedback improved my confidence.",
+                },
+                {
+                    "identity": "schedule", "turn": 168, "created_at": 400.0,
+                    "source_doc_id": "s3", "contextual_score": 0.59,
+                    "status": "kept",
+                    "text": "[Turn 168] I prioritized a schedule Robert recommended.",
+                },
+                {
+                    "identity": "choice", "turn": 170, "created_at": 400.0,
+                    "source_doc_id": "s3", "contextual_score": 0.57,
+                    "status": "kept",
+                    "text": (
+                        "[Turn 170] I am deciding how to approach and focus on "
+                        "Robert's essay advice before the conference paper."
+                    ),
+                },
+                {
+                    "identity": "grade", "turn": 212, "created_at": 500.0,
+                    "source_doc_id": "s4", "contextual_score": 0.54,
+                    "status": "kept",
+                    "text": "[Turn 212] Robert and I discussed next steps after my grade.",
+                },
+                {
+                    "identity": "bridge", "turn": 214, "created_at": 500.0,
+                    "source_doc_id": "s4", "contextual_score": 0.53,
+                    "status": "kept", "reason": "context_bridge",
+                    "parent_turn": 212,
+                    "text": "[Turn 214] I planned our follow-up meeting.",
+                },
+            ],
+        },
+    }
+
+    legacy_context, legacy_audit = render_relationship_thread(artifact)
+    context, audit = render_relationship_thread(
+        artifact, representative_per_source=True
+    )
+
+    assert legacy_context.count("[Turn") == 8
+    assert legacy_audit["selected_row_count"] == 8
+    assert context.count("[Turn") == 6
+    assert audit["selected_turns"] == [14, 64, 124, 170, 212, 214]
+    assert audit["selected_gold_turns"] == [14, 64, 124, 170, 214]
+    assert audit["missing_gold_turns"] == []
+    assert audit["dropped_turns"] == [156, 168]
+
+
 def test_family_support_stages_choose_one_active_event_per_conversation():
     artifact = {
         "query": "How did my family support me across our conversations?",
@@ -205,3 +289,8 @@ def test_family_support_stages_choose_one_active_event_per_conversation():
     assert "Turn 32" not in context
     assert audit["selected_anchors"] == ["tanya", "wendy"]
     assert audit["selected_gold_turns"] == [12, 30]
+    assert audit["representative_selection_identity_unchanged"] is True
+    assert (
+        audit["representative_candidate_identities"]
+        == audit["legacy_selected_identities"]
+    )

--- a/tests/test_amb_relationship_stage_cohort_audit.py
+++ b/tests/test_amb_relationship_stage_cohort_audit.py
@@ -62,6 +62,36 @@ def test_family_support_route_selects_one_active_stage_per_source():
     assert result["source_turn_delta"] == 0
 
 
+def test_representative_audit_preserves_gold_and_reduces_same_source_rows():
+    evidence = [
+        _evidence("setup", 10, "Robert gave academic feedback.", "s1", 0.9),
+        _evidence(
+            "decision",
+            12,
+            "I decided whether to focus on Robert's academic feedback.",
+            "s1",
+            0.8,
+        ),
+        _evidence("followup", 20, "Robert reviewed my academic draft.", "s2", 0.7),
+    ]
+
+    result = audit_query(
+        _row(
+            "mentor",
+            "List my academic work and mentorship in order.",
+            evidence,
+            [12, 20],
+        ),
+        relationship_representatives=True,
+    )
+
+    assert result["route"] == "relationship_thread"
+    assert result["selected_row_count"] == 2
+    assert result["selected_source_turns"] == [12, 20]
+    assert result["source_turn_delta"] == 0
+    assert result["selector"]["dropped_turns"] == [10]
+
+
 def test_aggregate_reports_fire_abstention_retention_and_reduction():
     rows = [
         {


### PR DESCRIPTION
## Summary
- add an opt-in within-source representative arm for relationship-thread probes
- cross-validate the candidate rank against Q9_1 without changing its accepted selector
- record the preregistered Q7 negative: 0.70 -> 0.50, so row deletion is rejected for product promotion
- extend the judge-free cohort audit with an opt-in representative mode

## Frozen evidence
- cohort: 18 queries, 10/10 fired gold retained, 60/95 reachability unchanged, 92 -> 11 fired rows, 0 negative queries
- Q9_1: exact five selected identities unchanged
- Q7 manifest: 3fdd24417b933d8c5938026ceb6ffff6e68d6e4b05269fb5a76368d5c77fb2f8
- control: 0.70 (0.70/0.70/0.70)
- treatment: 0.50 (0.40/0.50/0.50)
- no rerun; arm remains harness-only and experimental

## Verification
- Ruff: clean
- focused tests: 12 passed
- AMB harness tests not requiring a separately built Rust extension: 160 passed
- two organizer presentation test modules were not collected in the isolated worktree because no local Rust extension was built