### PR TITLE
bench(amb): record global stage summary null

### DIFF
--- a/benchmarks/amb/CONTEXTUAL_CANDIDATE_BANK.md
+++ b/benchmarks/amb/CONTEXTUAL_CANDIDATE_BANK.md
@@ -167,6 +167,48 @@ stage needs an answer-sized synthesized item that preserves its distinguishing
 detail. The representative selector remains opt-in experimental harness code
 and must not be promoted to a product default.
 
+### Global stage-record result
+
+The next arm tested representation directly. It made one query-blind global
+synthesis call over the accepted eight-row Robert thread and required exactly
+one record for each of the five stored source conversations. The model could
+write only the stage sentence. The harness attached first-mention time, source
+conversation, turns, and all eight evidence IDs deterministically; full IDs
+remained in audit metadata instead of consuming answer context.
+
+The synthesis selection SHA-256 was
+`6b0ee0e74184740785c3decb4309524408d6fb271af4b024e54452882dfcd892`,
+the request SHA-256 was
+`e813693d86a49aed04e65890116bd74bd14c56e0b1a400032e4747290f1a1916`,
+and the response SHA-256 was
+`4edc534772bb19b440b7f619e1e323a08f5d77e325329b579c54e0af65c5e874`.
+The frozen control and treatment context SHA-256 values were respectively
+`0b09412744f477c6e095949f9a938271762978849d736e1805eb52f82efd9f17`
+and
+`f3229add21c6da073cdc766073c3c76129e467838dd9be40475ca489251abeb0`.
+The paired manifest SHA-256 was
+`a7aab531232e2be20bf60d05b8e32ba838b15458c8c06d167e851a6e2a8d0c49`.
+
+The frozen run rejected compact prose stage records:
+
+| Frozen arm | Rows | Context tokens | Median score | Judge votes |
+| --- | ---: | ---: | ---: | --- |
+| Relationship thread control | 8 | 624 | `0.60` | `0.60, 0.60, 0.70` |
+| Global stage records | 5 | 331 | `0.20` | `0.20, 0.20, 0.20` |
+
+The paired delta was `-0.40`; no rerun was made. The model converted the
+first-person concern about meeting Robert and making a good impression into a
+third-person fact. The answerer then explicitly excluded that record as not an
+academic-work aspect and split the June record into separate journal and
+conference items. The synthesis also omitted the central June decision to
+strengthen the essay before the conference paper and compressed the July
+confidence and conference-planning details into generic next steps.
+
+This rejects untyped compact prose as the item representation. A subsequent
+arm must preserve speaker perspective and separately encode the user's
+goal/concern/decision, event facts, and outcome or follow-up. Q7 is now a
+development case for that schema, not untouched validation.
+
 ### Untouched holdout
 
 The untouched Q9 family-support query provided that confirmation. Its raw bank

--- a/benchmarks/amb/CONTEXTUAL_CANDIDATE_BANK.md
+++ b/benchmarks/amb/CONTEXTUAL_CANDIDATE_BANK.md
@@ -169,12 +169,13 @@ and must not be promoted to a product default.
 
 ### Global stage-record result
 
-The next arm tested representation directly. It made one query-blind global
-synthesis call over the accepted eight-row Robert thread and required exactly
-one record for each of the five stored source conversations. The model could
-write only the stage sentence. The harness attached first-mention time, source
-conversation, turns, and all eight evidence IDs deterministically; full IDs
-remained in audit metadata instead of consuming answer context.
+The next arm tested representation directly. Query influence entered through
+the accepted relationship selection stage; synthesis itself then made one
+query-blind global call over the selected eight-row Robert thread and required
+exactly one record for each of the five stored source conversations. The model
+could write only the stage sentence. The harness attached first-mention time,
+source conversation, turns, and all eight evidence IDs deterministically; full
+IDs remained in audit metadata instead of consuming answer context.
 
 The synthesis selection SHA-256 was
 `6b0ee0e74184740785c3decb4309524408d6fb271af4b024e54452882dfcd892`,
@@ -204,10 +205,10 @@ conference items. The synthesis also omitted the central June decision to
 strengthen the essay before the conference paper and compressed the July
 confidence and conference-planning details into generic next steps.
 
-This rejects untyped compact prose as the item representation. A subsequent
-arm must preserve speaker perspective and separately encode the user's
-goal/concern/decision, event facts, and outcome or follow-up. Q7 is now a
-development case for that schema, not untouched validation.
+This rejects untyped compact prose for this arm and motivates a subsequent
+hypothesis that preserves speaker perspective and separately encodes the
+user's goal/concern/decision, event facts, and outcome or follow-up. Q7 is now
+a development case for that schema, not untouched validation.
 
 ### Untouched holdout
 

--- a/benchmarks/amb/prepare_relationship_stage_records.py
+++ b/benchmarks/amb/prepare_relationship_stage_records.py
@@ -1,0 +1,374 @@
+"""Freeze answer-sized relationship stages from one globally selected thread."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from .global_organizer_probe import _chat_json
+    from .prepare_contextual_synthesis_pair import (
+        render_relationship_thread,
+        select_relationship_thread,
+    )
+    from .replay_contextual_synthesis import _ollama_model_identity
+except ImportError:  # pragma: no cover - direct script execution
+    from global_organizer_probe import _chat_json
+    from prepare_contextual_synthesis_pair import (
+        render_relationship_thread,
+        select_relationship_thread,
+    )
+    from replay_contextual_synthesis import _ollama_model_identity
+
+
+PROTOCOL = "relationship-stage-records-global-v1"
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "records": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "source_group": {"type": "string"},
+                    "item": {"type": "string"},
+                },
+                "required": ["source_group", "item"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["records"],
+    "additionalProperties": False,
+}
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_json(value: object) -> str:
+    return _sha256_bytes(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    )
+
+
+def _normalize_host(host: str) -> str:
+    if not host.startswith("http"):
+        host = f"http://{host}"
+    for wildcard in ("//0.0.0.0", "//[::]", "//::"):
+        host = host.replace(wildcard, "//127.0.0.1")
+    return host.rstrip("/")
+
+
+def _load_query(path: Path, query_id: str) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("query_id") == query_id:
+        return payload
+    matches = [
+        row for row in payload.get("queries") or [] if row.get("query_id") == query_id
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"expected one {query_id!r} row, found {len(matches)}")
+    return matches[0]
+
+
+def _ordered_groups(artifact: dict) -> tuple[str, list[dict]]:
+    thread = select_relationship_thread(artifact)
+    ordered = sorted(
+        thread["groups"].items(),
+        key=lambda entry: (
+            min(
+                row.get("created_at")
+                if row.get("created_at") is not None
+                else float("inf")
+                for row in entry[1]
+            ),
+            min(
+                row.get("turn") if row.get("turn") is not None else float("inf")
+                for row in entry[1]
+            ),
+            str(entry[0]),
+        ),
+    )
+    groups = []
+    for group_key, rows in ordered:
+        rows = sorted(
+            rows,
+            key=lambda row: (
+                row.get("turn") if row.get("turn") is not None else float("inf"),
+                row.get("identity") or "",
+            ),
+        )
+        source_group = str(group_key[1])
+        groups.append(
+            {
+                "source_group": source_group,
+                "source_kind": group_key[0],
+                "first_mention_at": min(
+                    (
+                        row["created_at"]
+                        for row in rows
+                        if row.get("created_at") is not None
+                    ),
+                    default=None,
+                ),
+                "first_mention_turn": min(
+                    (row["turn"] for row in rows if row.get("turn") is not None),
+                    default=None,
+                ),
+                "evidence_ids": [row.get("identity") for row in rows],
+                "evidence_turns": [
+                    row.get("turn") for row in rows if row.get("turn") is not None
+                ],
+                "evidence": [
+                    {
+                        "evidence_id": row.get("identity"),
+                        "turn": row.get("turn"),
+                        "created_at": row.get("created_at"),
+                        "text": row.get("text") or "",
+                    }
+                    for row in rows
+                ],
+            }
+        )
+    return thread["anchor"], groups
+
+
+def build_prompt(anchor: str, groups: list[dict]) -> str:
+    input_groups = [
+        {
+            "source_group": group["source_group"],
+            "evidence": group["evidence"],
+        }
+        for group in groups
+    ]
+    return (
+        "You organize durable memory before any future question is known. "
+        "The input is synthetic benchmark evidence for one relationship thread. "
+        f"Create exactly one concise stage record for {anchor.title()} per source "
+        "conversation. Merge every evidence row within that source conversation, "
+        "but never merge across source_group values. Preserve the concrete details "
+        "that distinguish the stage: meeting medium or location, named work, "
+        "recommendations or feedback, decisions, outcomes, follow-up plans, and "
+        "explicit dates. Do not infer unsupported facts. Each item must be a single "
+        "sentence of at most 55 words. Copy each source_group exactly once. Return "
+        "only one JSON object with exactly this shape and no other keys: "
+        '{"records":[{"source_group":"COPY_FROM_INPUT","item":"ONE '
+        'SENTENCE"}]}. Do not answer or refer to any question.\n\nSOURCE GROUPS:\n'
+        + json.dumps(input_groups, indent=2, ensure_ascii=False)
+    )
+
+
+def materialize_records(response: dict, groups: list[dict]) -> list[dict]:
+    expected = {group["source_group"]: group for group in groups}
+    raw_records = response.get("records")
+    if not isinstance(raw_records, list):
+        raise ValueError("response records must be a list")
+    if any(not isinstance(record, dict) for record in raw_records):
+        raise ValueError("every response record must be an object")
+    actual_groups = [record.get("source_group") for record in raw_records]
+    if len(actual_groups) != len(set(actual_groups)):
+        raise ValueError("response contains duplicate source groups")
+    if set(actual_groups) != set(expected):
+        raise ValueError(
+            f"source group mismatch: expected {sorted(expected)}, "
+            f"got {sorted(str(value) for value in actual_groups)}"
+        )
+
+    materialized = []
+    by_group = {record["source_group"]: record for record in raw_records}
+    for group in groups:
+        raw_item = by_group[group["source_group"]].get("item")
+        item = " ".join(str(raw_item or "").split())
+        if not item:
+            raise ValueError(f"empty item for {group['source_group']}")
+        if len(item.split()) > 55:
+            raise ValueError(f"item exceeds 55 words for {group['source_group']}")
+        materialized.append(
+            {
+                "source_group": group["source_group"],
+                "source_kind": group["source_kind"],
+                "item": item,
+                "first_mention_at": group["first_mention_at"],
+                "first_mention_turn": group["first_mention_turn"],
+                "evidence_ids": group["evidence_ids"],
+                "evidence_turns": group["evidence_turns"],
+            }
+        )
+    return materialized
+
+
+def _date_text(timestamp: float | None) -> str:
+    if timestamp is None:
+        return "date unknown"
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).date().isoformat()
+
+
+def render_records(anchor: str, records: list[dict]) -> str:
+    memories = []
+    for index, record in enumerate(records, 1):
+        stamp = _date_text(record["first_mention_at"])
+        turn = record["first_mention_turn"]
+        if turn is not None:
+            stamp += f" | Turn {turn}"
+        memories.append(
+            f"## Memory {index}\n"
+            f"[{stamp}] Relationship stage with {anchor.title()}: "
+            f"{record['item']}\n"
+            f"Source conversation: {record['source_group']} | "
+            f"Evidence turns: {', '.join(map(str, record['evidence_turns']))}"
+        )
+    return "\n\n".join(memories)
+
+
+def build_preflight(artifact: dict, query_id: str, model: str) -> dict:
+    _, selector_audit = render_relationship_thread(artifact)
+    anchor, groups = _ordered_groups(artifact)
+    prompt = build_prompt(anchor, groups)
+    return {
+        "protocol": PROTOCOL,
+        "status": "dry_run",
+        "query_id": query_id,
+        "model": model,
+        "model_calls": 0,
+        "query_exposed_to_synthesis": False,
+        "anchor": anchor,
+        "source_group_count": len(groups),
+        "evidence_row_count": sum(len(group["evidence"]) for group in groups),
+        "selection_sha256": selector_audit["selection_sha256"],
+        "request_sha256": _sha256_json({"prompt": prompt, "schema": SCHEMA}),
+        "prompt": prompt,
+        "schema": SCHEMA,
+        "groups": groups,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--query-id", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--expect-selection-sha256")
+    parser.add_argument("--expect-request-sha256")
+    parser.add_argument("--model", default="deepseek-v4-flash:0731-cloud")
+    parser.add_argument(
+        "--ollama-host",
+        default=os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434"),
+    )
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--replay-response",
+        type=Path,
+        help="reuse a prior raw artifact's parsed_response without a model call",
+    )
+    args = parser.parse_args()
+
+    artifact = _load_query(args.source, args.query_id)
+    preflight = build_preflight(artifact, args.query_id, args.model)
+    if (
+        args.expect_selection_sha256
+        and preflight["selection_sha256"] != args.expect_selection_sha256
+    ):
+        raise ValueError(
+            "selection hash mismatch: expected "
+            f"{args.expect_selection_sha256}, got {preflight['selection_sha256']}"
+        )
+    if (
+        args.expect_request_sha256
+        and preflight["request_sha256"] != args.expect_request_sha256
+    ):
+        raise ValueError(
+            "request hash mismatch: expected "
+            f"{args.expect_request_sha256}, got {preflight['request_sha256']}"
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if args.dry_run:
+        args.output.write_text(
+            json.dumps(preflight, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        return 0
+
+    ollama_host = _normalize_host(args.ollama_host)
+    if args.replay_response:
+        replay = json.loads(args.replay_response.read_text(encoding="utf-8"))
+        if replay.get("request_sha256") != preflight["request_sha256"]:
+            raise ValueError("replayed response does not match the frozen request")
+        response = replay.get("parsed_response")
+        if not isinstance(response, dict):
+            raise ValueError("replayed artifact has no parsed_response object")
+        raw_path = args.replay_response
+        execution_model_calls = 0
+    else:
+        response, raw_response = _chat_json(
+            host=ollama_host,
+            model=args.model,
+            prompt=preflight["prompt"],
+            schema=SCHEMA,
+            num_predict=1600,
+            timeout=args.timeout,
+        )
+        raw_path = args.output.with_suffix(".raw.json")
+        raw_path.write_text(
+            json.dumps(
+                {
+                    "protocol": PROTOCOL,
+                    "request_sha256": preflight["request_sha256"],
+                    "parsed_response": response,
+                    "raw_response": raw_response,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        execution_model_calls = 1
+    records = materialize_records(response, preflight["groups"])
+    context = render_records(preflight["anchor"], records)
+    model_identity = _ollama_model_identity(args.model, ollama_host)
+    result = {
+        "results": [
+            {
+                "query_id": args.query_id,
+                "context": context,
+                "audit": {
+                    "protocol": PROTOCOL,
+                    "model": args.model,
+                    "model_identity": model_identity,
+                    "generation_model_calls": 1,
+                    "execution_model_calls": execution_model_calls,
+                    "query_exposed_to_synthesis": False,
+                    "anchor": preflight["anchor"],
+                    "source_group_count": len(records),
+                    "evidence_row_count": preflight["evidence_row_count"],
+                    "selection_sha256": preflight["selection_sha256"],
+                    "request_sha256": preflight["request_sha256"],
+                    "response_sha256": _sha256_json(response),
+                    "records": records,
+                },
+            }
+        ],
+        "raw_response_file": str(raw_path),
+    }
+    args.output.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/prepare_relationship_stage_records.py
+++ b/benchmarks/amb/prepare_relationship_stage_records.py
@@ -260,6 +260,7 @@ def main() -> int:
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--expect-selection-sha256")
     parser.add_argument("--expect-request-sha256")
+    parser.add_argument("--expect-response-sha256")
     parser.add_argument("--model", default="deepseek-v4-flash:0731-cloud")
     parser.add_argument(
         "--ollama-host",
@@ -336,6 +337,12 @@ def main() -> int:
             encoding="utf-8",
         )
         execution_model_calls = 1
+    response_sha256 = _sha256_json(response)
+    if args.expect_response_sha256 and response_sha256 != args.expect_response_sha256:
+        raise ValueError(
+            "response hash mismatch: expected "
+            f"{args.expect_response_sha256}, got {response_sha256}"
+        )
     records = materialize_records(response, preflight["groups"])
     context = render_records(preflight["anchor"], records)
     model_identity = _ollama_model_identity(args.model, ollama_host)
@@ -356,7 +363,7 @@ def main() -> int:
                     "evidence_row_count": preflight["evidence_row_count"],
                     "selection_sha256": preflight["selection_sha256"],
                     "request_sha256": preflight["request_sha256"],
-                    "response_sha256": _sha256_json(response),
+                    "response_sha256": response_sha256,
                     "records": records,
                 },
             }

--- a/tests/test_amb_prepare_relationship_stage_records.py
+++ b/tests/test_amb_prepare_relationship_stage_records.py
@@ -1,0 +1,135 @@
+import pytest
+
+from benchmarks.amb.prepare_relationship_stage_records import (
+    _normalize_host,
+    build_preflight,
+    build_prompt,
+    materialize_records,
+    render_records,
+)
+
+
+def _artifact():
+    rows = [
+        {
+            "identity": "e1",
+            "turn": 10,
+            "created_at": 1_700_000_000.0,
+            "source_doc_id": "s1",
+            "status": "kept",
+            "reason": "base_top_k",
+            "contextual_score": 0.8,
+            "text": "[Turn 10] User: I met mentor Robert at the library.",
+        },
+        {
+            "identity": "e2",
+            "turn": 12,
+            "created_at": 1_700_000_000.0,
+            "source_doc_id": "s1",
+            "status": "kept",
+            "reason": "context_bridge",
+            "parent_turn": 10,
+            "contextual_score": 0.7,
+            "text": "[Turn 12] User: I planned a follow-up call.",
+        },
+        {
+            "identity": "e3",
+            "turn": 30,
+            "created_at": 1_710_000_000.0,
+            "source_doc_id": "s2",
+            "status": "kept",
+            "reason": "base_top_k",
+            "contextual_score": 0.9,
+            "text": "[Turn 30] User: Robert reviewed my draft.",
+        },
+    ]
+    return {
+        "query": "List my academic mentorship stages in order.",
+        "preflight": {
+            "evidence_ledger": rows,
+            "source_evidence_ceiling": {
+                "available_source_turns": [10, 30],
+                "missing_source_turns": [],
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0:11434", "http://0.0.0.0:11434"])
+def test_normalize_host_rewrites_ollama_bind_address(host):
+    assert _normalize_host(host) == "http://127.0.0.1:11434"
+
+
+def test_preflight_is_global_query_blind_and_preserves_all_evidence():
+    preflight = build_preflight(_artifact(), "q", "model")
+
+    assert preflight["model_calls"] == 0
+    assert preflight["query_exposed_to_synthesis"] is False
+    assert preflight["source_group_count"] == 2
+    assert preflight["evidence_row_count"] == 3
+    assert "List my academic mentorship stages" not in preflight["prompt"]
+    assert preflight["prompt"].count('"source_group": "s1"') == 1
+    assert "e1" in preflight["prompt"]
+    assert "e2" in preflight["prompt"]
+    assert "e3" in preflight["prompt"]
+
+
+def test_materialize_records_restores_source_order_and_owns_provenance():
+    preflight = build_preflight(_artifact(), "q", "model")
+    response = {
+        "records": [
+            {"source_group": "s2", "item": "  Draft feedback.  "},
+            {"source_group": "s1", "item": "Library meeting and follow-up."},
+        ]
+    }
+
+    records = materialize_records(response, preflight["groups"])
+
+    assert [record["source_group"] for record in records] == ["s1", "s2"]
+    assert records[0]["item"] == "Library meeting and follow-up."
+    assert records[0]["first_mention_turn"] == 10
+    assert records[0]["evidence_ids"] == ["e1", "e2"]
+    assert records[0]["evidence_turns"] == [10, 12]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"records": [{"source_group": "s1", "item": "One."}]},
+        {"records": ["not-an-object"]},
+        {
+            "records": [
+                {"source_group": "s1", "item": "One."},
+                {"source_group": "s1", "item": "Duplicate."},
+            ]
+        },
+    ],
+)
+def test_materialize_records_rejects_missing_or_duplicate_groups(response):
+    preflight = build_preflight(_artifact(), "q", "model")
+
+    with pytest.raises(ValueError):
+        materialize_records(response, preflight["groups"])
+
+
+def test_prompt_and_render_make_the_record_contract_explicit():
+    preflight = build_preflight(_artifact(), "q", "model")
+    prompt = build_prompt(preflight["anchor"], preflight["groups"])
+    records = materialize_records(
+        {
+            "records": [
+                {"source_group": "s1", "item": "Library meeting and follow-up."},
+                {"source_group": "s2", "item": "Draft feedback."},
+            ]
+        },
+        preflight["groups"],
+    )
+    context = render_records(preflight["anchor"], records)
+
+    assert "before any future question is known" in prompt
+    assert "never merge across source_group" in prompt
+    assert '{"records":[{"source_group":"COPY_FROM_INPUT"' in prompt
+    assert "Source conversation: s1" in context
+    assert "Evidence turns: 10, 12" in context
+    assert "Evidence IDs:" not in context
+    assert records[0]["evidence_ids"] == ["e1", "e2"]

--- a/tests/test_amb_prepare_relationship_stage_records.py
+++ b/tests/test_amb_prepare_relationship_stage_records.py
@@ -2,6 +2,7 @@ import pytest
 
 from benchmarks.amb.prepare_relationship_stage_records import (
     _normalize_host,
+    _sha256_json,
     build_preflight,
     build_prompt,
     materialize_records,
@@ -133,3 +134,10 @@ def test_prompt_and_render_make_the_record_contract_explicit():
     assert "Evidence turns: 10, 12" in context
     assert "Evidence IDs:" not in context
     assert records[0]["evidence_ids"] == ["e1", "e2"]
+
+
+def test_response_hash_is_order_independent_for_replay_binding():
+    left = {"records": [{"source_group": "s1", "item": "One."}]}
+    right = {"records": [{"item": "One.", "source_group": "s1"}]}
+
+    assert _sha256_json(left) == _sha256_json(right)


### PR DESCRIPTION
## Summary
- add a query-blind global relationship-stage synthesis harness with deterministic provenance and offline replay
- pin selection/request hashes and reject missing, duplicate, or oversized stage records before scoring
- preserve the frozen Q7 negative: control 0.60 vs stage records 0.20 (delta -0.40), with no rerun

## Validation
- 20 focused and neighboring pytest tests passed
- Ruff format and lint passed
- frozen paired preflight passed: 624 control tokens vs 331 treatment tokens, 2 answer calls and 6 judge calls

## Interpretation
Compact untyped prose loses speaker perspective and decision/goal structure. This PR keeps the failed arm reproducible; it does not promote synthesis into the product engine.