### PR TITLE
bench(amb): repeat answer draws in paired evals

### DIFF
--- a/benchmarks/amb/paired_frozen_context_eval.py
+++ b/benchmarks/amb/paired_frozen_context_eval.py
@@ -1,9 +1,11 @@
 """Paired frozen-context evaluation for two memory retrieval arms.
 
 Each query is answered and judged for both arms in the same worker. Arm order
-alternates deterministically by query id, reducing time/order drift while the
-answerer, judge, query, and rubric remain fixed. Checkpoints contain complete
-pairs and can be resumed after an interrupted cloud run.
+alternates deterministically by query id and answer draw, reducing time/order
+drift while the answerer, judge, query, and rubric remain fixed. Repeated answer
+draws retain their full score distributions and select the median-scored result
+for the pair-level comparison. Checkpoints contain complete pairs and can be
+resumed after an interrupted cloud run.
 
 This fingerprint is sufficient only because contexts are frozen artifacts. A
 live paired harness must also bind the provider code/version that creates its
@@ -64,6 +66,7 @@ def validate_manifest(
     model: str,
     judge_repeats: int,
     token_counter: Callable[[str], int],
+    answer_repeats: int = 1,
 ) -> dict:
     """Validate the exact frozen payload and projected external call budget."""
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -104,23 +107,27 @@ def validate_manifest(
     if len(expected_arms) != 2:
         errors.append(f"manifest: expected exactly 2 arms, found {len(expected_arms)}")
     if len(ordered_ids_by_arm) == 2 and ordered_ids_by_arm[0] != ordered_ids_by_arm[1]:
-        errors.append("context arms do not contain the same query_ids in the same order")
+        errors.append(
+            "context arms do not contain the same query_ids in the same order"
+        )
     total_context_tokens = sum(arm["context_tokens"] for arm in actual_arms)
     row_count = len(ordered_ids_by_arm[0]) if ordered_ids_by_arm else 0
-    answer_calls = row_count * 2
+    answer_calls = row_count * 2 * answer_repeats
     judge_calls = answer_calls * judge_repeats
     checks = {
         "model": model,
+        "answer_repeats": answer_repeats,
         "judge_repeats": judge_repeats,
         "total_context_tokens": total_context_tokens,
         "answer_calls": answer_calls,
         "judge_calls": judge_calls,
     }
     for field, actual in checks.items():
-        if manifest.get(field) != actual:
-            errors.append(
-                f"manifest: {field} expected={manifest.get(field)!r} actual={actual!r}"
-            )
+        expected = (
+            manifest.get(field, 1) if field == "answer_repeats" else manifest.get(field)
+        )
+        if expected != actual:
+            errors.append(f"manifest: {field} expected={expected!r} actual={actual!r}")
     if manifest.get("query_ids_encoding") != "utf8-json-compact-ordered-v1":
         errors.append("manifest: unsupported or missing query_ids_encoding")
     if not manifest.get("synthetic_benchmark_data_only"):
@@ -158,7 +165,9 @@ def _load_resume_checkpoint(path: Path, run_fingerprint: str) -> dict[str, dict]
         )
     pairs = prior.get("pairs", [])
     query_ids = [pair.get("query_id") for pair in pairs]
-    if any(not query_id for query_id in query_ids) or len(set(query_ids)) != len(query_ids):
+    if any(not query_id for query_id in query_ids) or len(set(query_ids)) != len(
+        query_ids
+    ):
         raise ValueError("resume checkpoint contains missing or duplicate query_ids")
     return {pair["query_id"]: pair for pair in pairs}
 
@@ -172,6 +181,45 @@ def _median_judgement(dataset, result, judge, repeats: int) -> float:
 def _stable_arm_order(query_id: str, seed: int) -> tuple[str, str]:
     digest = hashlib.sha256(f"{seed}:{query_id}".encode()).digest()
     return ("a", "b") if digest[0] % 2 == 0 else ("b", "a")
+
+
+def _answer_arm_orders(query_id: str, seed: int, repeats: int) -> list[tuple[str, str]]:
+    """Interleave repeated answers so neither arm always runs first."""
+    first = _stable_arm_order(query_id, seed)
+    return [first if repeat % 2 == 0 else first[::-1] for repeat in range(repeats)]
+
+
+def _median_scored_result(results: list):
+    if not results:
+        raise ValueError("cannot select a median from no answer results")
+    ranked = sorted(
+        enumerate(results),
+        key=lambda entry: (float(entry[1].score or 0.0), entry[0]),
+    )
+    return ranked[len(ranked) // 2][1]
+
+
+def _answer_repeat_comparison(samples: dict[str, list]) -> dict:
+    scores_a = [float(result.score or 0.0) for result in samples["a"]]
+    scores_b = [float(result.score or 0.0) for result in samples["b"]]
+    if len(scores_a) != len(scores_b):
+        raise ValueError("answer repeat arms have different sample counts")
+    deltas = [score_b - score_a for score_a, score_b in zip(scores_a, scores_b)]
+    return {
+        "scores_a": scores_a,
+        "scores_b": scores_b,
+        "mean_a": statistics.fmean(scores_a),
+        "mean_b": statistics.fmean(scores_b),
+        "median_a": statistics.median(scores_a),
+        "median_b": statistics.median(scores_b),
+        "range_a": [min(scores_a), max(scores_a)],
+        "range_b": [min(scores_b), max(scores_b)],
+        "deltas_b_minus_a": deltas,
+        "mean_delta_b_minus_a": statistics.fmean(deltas),
+        "wins_b": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "wins_a": sum(delta < 0 for delta in deltas),
+    }
 
 
 def _paired_bootstrap_interval(
@@ -204,6 +252,7 @@ def main() -> int:
     parser.add_argument("--split", default="100k")
     parser.add_argument("--limit", type=int)
     parser.add_argument("--workers", type=int, default=2)
+    parser.add_argument("--answer-repeats", type=int, default=1)
     parser.add_argument("--judge-repeats", type=int, default=1)
     parser.add_argument("--seed", type=int, default=20260820)
     parser.add_argument("--manifest", type=Path, required=True)
@@ -213,6 +262,8 @@ def main() -> int:
     args = parser.parse_args()
     if args.judge_repeats < 1 or args.judge_repeats % 2 == 0:
         parser.error("--judge-repeats must be a positive odd number")
+    if args.answer_repeats < 1 or args.answer_repeats % 2 == 0:
+        parser.error("--answer-repeats must be a positive odd number")
     if args.limit is not None:
         parser.error("--limit is incompatible with a frozen manifest run")
     if not args.preflight_only and args.out is None:
@@ -230,6 +281,7 @@ def main() -> int:
             args.model,
             args.judge_repeats,
             count_tokens,
+            args.answer_repeats,
         )
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         parser.error(str(error))
@@ -261,7 +313,12 @@ def main() -> int:
             "dataset/context eligibility changed after manifest validation; "
             "refusing to score a partial or reordered cohort"
         )
-    print(json.dumps({key: value for key, value in preflight.items() if key != "query_ids"}, indent=2))
+    print(
+        json.dumps(
+            {key: value for key, value in preflight.items() if key != "query_ids"},
+            indent=2,
+        )
+    )
     if args.preflight_only:
         return 0
 
@@ -278,6 +335,7 @@ def main() -> int:
         "label_b": args.label_b,
         "model": args.model,
         "split": args.split,
+        "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "seed": args.seed,
         "workers": args.workers,
@@ -289,7 +347,13 @@ def main() -> int:
     if args.resume and checkpoint.exists():
         try:
             completed = _load_resume_checkpoint(checkpoint, run_fingerprint)
-        except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        except (
+            OSError,
+            KeyError,
+            TypeError,
+            ValueError,
+            json.JSONDecodeError,
+        ) as error:
             parser.error(str(error))
         unknown = set(completed) - set(ids)
         if unknown:
@@ -308,11 +372,13 @@ def main() -> int:
     answer_mode = RAGMode(llm=answer_llm)
     judge_llm = OllamaLLM(args.model)
 
-    def evaluate_arm(query_id: str, arm: str) -> QueryResult:
+    def evaluate_answer(query_id: str, arm: str) -> QueryResult:
         query = queries[query_id]
         meta = dict(query.meta)
-        meta["_prompt_fn"] = lambda question, context, meta=meta: dataset.build_rag_prompt(
-            question, context, dataset.task_type, args.split, meta=meta
+        meta["_prompt_fn"] = lambda question, context, meta=meta: (
+            dataset.build_rag_prompt(
+                question, context, dataset.task_type, args.split, meta=meta
+            )
         )
         answer = answer_mode.answer_from_context(
             query.query,
@@ -333,17 +399,34 @@ def main() -> int:
             judge_reason="",
             meta=meta,
         )
-        result.score = _median_judgement(
-            dataset, result, judge_llm, args.judge_repeats
-        )
+        result.score = _median_judgement(dataset, result, judge_llm, args.judge_repeats)
         result.correct = (result.score or 0) >= 0.5
         return result
 
+    def select_arm_result(results: list[QueryResult]) -> QueryResult:
+        selected = _median_scored_result(results)
+        selected.meta["answer_repeats"] = args.answer_repeats
+        selected.meta["answer_repeat_scores"] = [
+            float(result.score or 0.0) for result in results
+        ]
+        selected.meta["answer_candidates"] = [
+            {
+                "answer": result.answer,
+                "reasoning": result.reasoning,
+                "score": float(result.score or 0.0),
+                "judge_votes": list(result.meta.get("judge_votes") or []),
+            }
+            for result in results
+        ]
+        return selected
+
     def evaluate_pair(query_id: str) -> dict | None:
-        results = {}
+        samples = {"a": [], "b": []}
+        arm_orders = _answer_arm_orders(query_id, args.seed, args.answer_repeats)
         try:
-            for arm in _stable_arm_order(query_id, args.seed):
-                results[arm] = evaluate_arm(query_id, arm)
+            for arm_order in arm_orders:
+                for arm in arm_order:
+                    samples[arm].append(evaluate_answer(query_id, arm))
         except Exception as error:
             print(
                 f"  {query_id}: pair failed {type(error).__name__}: {str(error)[:120]}",
@@ -351,14 +434,20 @@ def main() -> int:
                 flush=True,
             )
             return None
+        results = {
+            arm: select_arm_result(arm_results) for arm, arm_results in samples.items()
+        }
         score_a = float(results["a"].score or 0)
         score_b = float(results["b"].score or 0)
+        repeat_comparison = _answer_repeat_comparison(samples)
         return {
             "query_id": query_id,
             "arm_order": list(_stable_arm_order(query_id, args.seed)),
+            "answer_arm_orders": [list(order) for order in arm_orders],
             "score_a": score_a,
             "score_b": score_b,
             "delta_b_minus_a": score_b - score_a,
+            "answer_repeat_comparison": repeat_comparison,
             "result_a": results["a"].__dict__,
             "result_b": results["b"].__dict__,
         }
@@ -392,6 +481,21 @@ def main() -> int:
     deltas = [pair["delta_b_minus_a"] for pair in pairs]
     scores_a = [pair["score_a"] for pair in pairs]
     scores_b = [pair["score_b"] for pair in pairs]
+    answer_repeat_scores_a = [
+        score
+        for pair in pairs
+        for score in pair["answer_repeat_comparison"]["scores_a"]
+    ]
+    answer_repeat_scores_b = [
+        score
+        for pair in pairs
+        for score in pair["answer_repeat_comparison"]["scores_b"]
+    ]
+    answer_repeat_deltas = [
+        delta
+        for pair in pairs
+        for delta in pair["answer_repeat_comparison"]["deltas_b_minus_a"]
+    ]
     lower, upper = _paired_bootstrap_interval(deltas, args.seed)
     summary = {
         "n": len(pairs),
@@ -402,6 +506,29 @@ def main() -> int:
         "wins_b": sum(delta > 0 for delta in deltas),
         "ties": sum(delta == 0 for delta in deltas),
         "wins_a": sum(delta < 0 for delta in deltas),
+        "answer_draws_per_arm": len(pairs) * args.answer_repeats,
+        "mean_answer_repeat_score_a": (
+            statistics.fmean(answer_repeat_scores_a) if answer_repeat_scores_a else 0.0
+        ),
+        "mean_answer_repeat_score_b": (
+            statistics.fmean(answer_repeat_scores_b) if answer_repeat_scores_b else 0.0
+        ),
+        "answer_repeat_score_range_a": (
+            [min(answer_repeat_scores_a), max(answer_repeat_scores_a)]
+            if answer_repeat_scores_a
+            else [0.0, 0.0]
+        ),
+        "answer_repeat_score_range_b": (
+            [min(answer_repeat_scores_b), max(answer_repeat_scores_b)]
+            if answer_repeat_scores_b
+            else [0.0, 0.0]
+        ),
+        "mean_answer_repeat_delta_b_minus_a": (
+            statistics.fmean(answer_repeat_deltas) if answer_repeat_deltas else 0.0
+        ),
+        "answer_repeat_wins_b": sum(delta > 0 for delta in answer_repeat_deltas),
+        "answer_repeat_ties": sum(delta == 0 for delta in answer_repeat_deltas),
+        "answer_repeat_wins_a": sum(delta < 0 for delta in answer_repeat_deltas),
         "elapsed_seconds": time.perf_counter() - started,
     }
     output = {
@@ -410,6 +537,7 @@ def main() -> int:
         "label_a": args.label_a,
         "label_b": args.label_b,
         "model": args.model,
+        "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "seed": args.seed,
         "summary": summary,

--- a/benchmarks/amb/prepare_contextual_synthesis_pair.py
+++ b/benchmarks/amb/prepare_contextual_synthesis_pair.py
@@ -523,6 +523,7 @@ def main() -> int:
         action="store_true",
         help="mark the pinned answer/judge model as comparable to the target line",
     )
+    parser.add_argument("--answer-repeats", type=int, default=1)
     parser.add_argument("--judge-repeats", type=int, default=3)
     parser.add_argument(
         "--context-mode",
@@ -552,6 +553,8 @@ def main() -> int:
     args = parser.parse_args()
     if args.judge_repeats < 1 or args.judge_repeats % 2 == 0:
         parser.error("--judge-repeats must be a positive odd number")
+    if args.answer_repeats < 1 or args.answer_repeats % 2 == 0:
+        parser.error("--answer-repeats must be a positive odd number")
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
     modes = (
@@ -585,9 +588,10 @@ def main() -> int:
         "model": args.model,
         "judge_model": args.model,
         "is_line_comparable": args.line_comparable,
+        "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
-        "answer_calls": 2,
-        "judge_calls": 2 * args.judge_repeats,
+        "answer_calls": 2 * args.answer_repeats,
+        "judge_calls": 2 * args.answer_repeats * args.judge_repeats,
         "total_context_tokens": sum(
             arm["context_tokens"] for arm in arms
         ),

--- a/benchmarks/amb/prepare_paired_category_contexts.py
+++ b/benchmarks/amb/prepare_paired_category_contexts.py
@@ -59,10 +59,13 @@ def main() -> int:
     parser.add_argument("--label-a", required=True)
     parser.add_argument("--label-b", required=True)
     parser.add_argument("--model", default="deepseek-v4-flash:0731-cloud")
+    parser.add_argument("--answer-repeats", type=int, default=1)
     parser.add_argument("--judge-repeats", type=int, default=1)
     args = parser.parse_args()
     if args.judge_repeats < 1 or args.judge_repeats % 2 == 0:
         parser.error("--judge-repeats must be a positive odd number")
+    if args.answer_repeats < 1 or args.answer_repeats % 2 == 0:
+        parser.error("--answer-repeats must be a positive odd number")
 
     arm_a, arm_b = select_common_rows(
         _rows(args.contexts_a), _rows(args.contexts_b), args.category
@@ -95,10 +98,11 @@ def main() -> int:
         "synthetic_benchmark_data_only": True,
         "real_companion_memories_included": False,
         "model": args.model,
+        "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "total_context_tokens": sum(arm["context_tokens"] for arm in arms),
-        "answer_calls": row_count * 2,
-        "judge_calls": row_count * 2 * args.judge_repeats,
+        "answer_calls": row_count * 2 * args.answer_repeats,
+        "judge_calls": row_count * 2 * args.answer_repeats * args.judge_repeats,
         "category": args.category,
         "labels": [args.label_a, args.label_b],
         "source_files": [str(args.contexts_a), str(args.contexts_b)],

--- a/benchmarks/amb/prepare_paired_intent_contexts.py
+++ b/benchmarks/amb/prepare_paired_intent_contexts.py
@@ -78,10 +78,13 @@ def main() -> int:
     parser.add_argument("--label-a", required=True)
     parser.add_argument("--label-b", required=True)
     parser.add_argument("--model", default="deepseek-v4-flash:0731-cloud")
+    parser.add_argument("--answer-repeats", type=int, default=1)
     parser.add_argument("--judge-repeats", type=int, default=3)
     args = parser.parse_args()
     if args.judge_repeats < 1 or args.judge_repeats % 2 == 0:
         parser.error("--judge-repeats must be a positive odd number")
+    if args.answer_repeats < 1 or args.answer_repeats % 2 == 0:
+        parser.error("--answer-repeats must be a positive odd number")
 
     arm_a, arm_b = select_common_rows(
         _rows(args.contexts_a), _rows(args.contexts_b)
@@ -114,10 +117,11 @@ def main() -> int:
         "synthetic_benchmark_data_only": True,
         "real_companion_memories_included": False,
         "model": args.model,
+        "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "total_context_tokens": sum(arm["context_tokens"] for arm in arms),
-        "answer_calls": row_count * 2,
-        "judge_calls": row_count * 2 * args.judge_repeats,
+        "answer_calls": row_count * 2 * args.answer_repeats,
+        "judge_calls": row_count * 2 * args.answer_repeats * args.judge_repeats,
         "intent": INTENT_NAME,
         "selection_fields": ["query", "meta.question_category"],
         "query_pattern": COUNT_SET_QUERY.pattern,

--- a/benchmarks/amb/prepare_temporal_endpoint_contexts.py
+++ b/benchmarks/amb/prepare_temporal_endpoint_contexts.py
@@ -67,12 +67,15 @@ def main() -> int:
         help="Use endpoint lanes alone or prepend them to unchanged baseline context.",
     )
     parser.add_argument("--model", default="deepseek-v4-flash:0731-cloud")
+    parser.add_argument("--answer-repeats", type=int, default=1)
     parser.add_argument("--judge-repeats", type=int, default=1)
     args = parser.parse_args()
     if args.hits_per_endpoint < 1:
         parser.error("--hits-per-endpoint must be positive")
     if args.judge_repeats < 1 or args.judge_repeats % 2 == 0:
         parser.error("--judge-repeats must be a positive odd number")
+    if args.answer_repeats < 1 or args.answer_repeats % 2 == 0:
+        parser.error("--answer-repeats must be a positive odd number")
 
     baseline_payload = json.loads(args.baseline.read_text(encoding="utf-8-sig"))
     baseline_rows = {
@@ -138,10 +141,11 @@ def main() -> int:
         "synthetic_benchmark_data_only": True,
         "real_companion_memories_included": False,
         "model": args.model,
+        "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "total_context_tokens": sum(arm["context_tokens"] for arm in arms),
-        "answer_calls": row_count * 2,
-        "judge_calls": row_count * 2 * args.judge_repeats,
+        "answer_calls": row_count * 2 * args.answer_repeats,
+        "judge_calls": row_count * 2 * args.answer_repeats * args.judge_repeats,
         "arms": arms,
         "decomposition_file": str(args.decomposition),
         "hits_per_endpoint": args.hits_per_endpoint,

--- a/tests/test_paired_frozen_context_eval.py
+++ b/tests/test_paired_frozen_context_eval.py
@@ -3,7 +3,10 @@ import json
 import pytest
 
 from benchmarks.amb.paired_frozen_context_eval import (
+    _answer_arm_orders,
+    _answer_repeat_comparison,
     _load_resume_checkpoint,
+    _median_scored_result,
     _ordered_query_ids_sha256,
     _run_fingerprint,
     _sha256_file,
@@ -73,6 +76,85 @@ def test_manifest_preflight_pins_payload_and_call_budget(tmp_path):
             1,
             len,
         )
+
+
+def test_manifest_preflight_pins_repeated_answer_budget(tmp_path):
+    rows = [{"query_id": "q1", "context": "alpha"}]
+    paths = (tmp_path / "a.json", tmp_path / "b.json")
+    for path in paths:
+        _write_json(path, rows)
+    query_ids_sha256 = _ordered_query_ids_sha256(["q1"])
+    manifest = {
+        "model": "test-model",
+        "answer_repeats": 3,
+        "judge_repeats": 3,
+        "answer_calls": 6,
+        "judge_calls": 18,
+        "total_context_tokens": 10,
+        "query_ids_encoding": "utf8-json-compact-ordered-v1",
+        "synthetic_benchmark_data_only": True,
+        "real_companion_memories_included": False,
+        "arms": [
+            {
+                "file": path.name,
+                "sha256": _sha256_file(path),
+                "rows": 1,
+                "context_tokens": 5,
+                "query_ids_sha256": query_ids_sha256,
+            }
+            for path in paths
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    _write_json(manifest_path, manifest)
+
+    report = validate_manifest(
+        manifest_path,
+        paths,
+        "test-model",
+        3,
+        len,
+        3,
+    )
+
+    assert report["answer_repeats"] == 3
+    assert report["answer_calls"] == 6
+    assert report["judge_calls"] == 18
+
+
+def test_repeated_answers_interleave_arms_and_select_median_score():
+    orders = _answer_arm_orders("q1", seed=7, repeats=3)
+    assert orders[1] == orders[0][::-1]
+    assert orders[2] == orders[0]
+
+    class Result:
+        def __init__(self, score):
+            self.score = score
+
+    selected = _median_scored_result([Result(0.8), Result(0.2), Result(0.5)])
+    assert selected.score == 0.5
+
+    comparison = _answer_repeat_comparison(
+        {
+            "a": [Result(0.2), Result(0.5), Result(0.8)],
+            "b": [Result(0.4), Result(0.5), Result(0.6)],
+        }
+    )
+    assert comparison == {
+        "scores_a": [0.2, 0.5, 0.8],
+        "scores_b": [0.4, 0.5, 0.6],
+        "mean_a": 0.5,
+        "mean_b": 0.5,
+        "median_a": 0.5,
+        "median_b": 0.5,
+        "range_a": [0.2, 0.8],
+        "range_b": [0.4, 0.6],
+        "deltas_b_minus_a": [0.2, 0.0, -0.20000000000000007],
+        "mean_delta_b_minus_a": -1.850371707708594e-17,
+        "wins_b": 1,
+        "ties": 1,
+        "wins_a": 1,
+    }
 
 
 def test_resume_checkpoint_is_bound_to_run_fingerprint(tmp_path):


### PR DESCRIPTION
## Summary
- add odd answer-repeat draws to paired frozen-context evaluation
- alternate arm order per draw and retain every answer, judge vote, score distribution, and paired sign
- bind answer repeats into manifests, call budgets, run fingerprints, and all paired context generators
- preserve one-answer manifest compatibility

## Calibration
Byte-identical frozen Q7 control, 5 answers per arm, median-of-3 judges:
- A: 0.3, 0.4, 0.5, 0.6, 0.6
- B: 0.5, 0.3, 0.7, 0.5, 0.5
- selected medians: 0.5 vs 0.5
- paired signs: B 2 / tie 0 / A 3

The 0.3-0.7 range reproduces the prior cross-run spread. Judge votes were nearly always unanimous, locating the instability in answer generation.

## Verification
- 17 focused and neighboring tests passed
- Ruff clean
- old one-answer manifest preflight passed
- repeated-answer manifest preflight pinned 10 answer + 30 judge calls