### PR TITLE
bench(amb): audit category loss funnels

### DIFF
--- a/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
+++ b/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
@@ -53,6 +53,14 @@ The audit now emits a loss-conserving `ceiling_estimate` over all ten frozen
 categories. The `ydb-0151` baseline is `65.1485`, so the line loses `34.8515`
 points and needs `24.8515` points, not 28.9, to reach 90.
 
+`ydb-0151` is the canonical anchor because every row-level attribution in this
+audit comes from that exact result (SHA-256 `43b8eb888adeb524caba70b013a8ca510c639bbf5312216e9b453d60185bcb8e`).
+The separate `ydb-final` run scored `61.0689` (SHA-256
+`048b38bd9a285ab788677d60815ec6533268a3fddf0a4d31e60fbf53a5b8b601`).
+That `4.0796`-point cross-run gap is replication evidence, not part of the
+anchor arithmetic. A future claim of reaching 90 means 90 on the declared
+anchor configuration and should use a repeated full-line median.
+
 | Mutually exclusive bucket | Points |
 |---|---:|
 | Dead or benchmark integrity | 3.092 |
@@ -77,6 +85,22 @@ optimistic recovery assumption, not a causal finding; the temporal audit found
 reader arithmetic, revision ambiguity, and invalid gold calculations as well.
 The residual bucket prevents those uncertain and overlapping cases from being
 silently assigned twice.
+
+The machine-readable sensitivity table varies only reader-shaping recovery and
+optimistically recovers every other non-dead bucket:
+
+| Reader-attributed loss recovered | Projected score |
+|---:|---:|
+| 0% | 89.755 |
+| 50% | 93.332 |
+| 70% | 94.762 |
+| 100% | 96.908 |
+
+This is not a forecast: 50% and 70% are scenario parameters, while the evidence
+currently includes one context-shaping win and one abstention arm that missed
+its gate. The Q7 A/A calibration also observed about `0.02` answer-generation
+standard error within a 40-query category. Threshold claims therefore require
+replication even when a single full run crosses 90.
 
 ## Decision
 

--- a/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
+++ b/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
@@ -1,0 +1,68 @@
+# BEAM Category Loss Funnel
+
+## Scope
+
+This judge-free audit examines the four largest non-temporal loss buckets in
+the frozen `ydb-0151` BEAM-100K run. It measures distinctive reference-token
+support in the source conversation, retention in retrieved context, retention
+in the final answer, exact knowledge-update value chronology, and answer tokens
+supported only by explicitly assistant-authored memory blocks.
+
+The input hashes are:
+
+- Results: `43b8eb888adeb524caba70b013a8ca510c639bbf5312216e9b453d60185bcb8e`
+- Source documents: `fc0e64bac38fcde26eece776e818f70374338d4591ecc75346cb27b613d4c128`
+
+No model or judge calls are made. Lexical coverage is a diagnostic proxy, not
+a replacement benchmark score.
+
+## Results
+
+| Category | Mean score | Source support | Context retention | Answer retention | Dominant finding |
+|---|---:|---:|---:|---:|---|
+| summarization | 0.593 | 0.944 | 0.869 | 0.555 | 131/195 reference items fail mainly after retrieval |
+| knowledge update | 0.631 | 0.988 | 0.988 | 0.608 | 11/14 zeroes are stale-label or absent-gold cases |
+| multi-session reasoning | 0.611 | 0.921 | 0.908 | 0.427 | 30/40 answers lose source-supported content |
+| abstention | 0.675 | n/a | n/a | n/a | 7/13 zeroes are dominated by assistant-only support |
+
+Summarization has 22 retrieval-loss items, 131 answer-loss items, 41 covered
+items, and one source/label mismatch. Multi-session reasoning has 30
+answer-loss items, eight covered items, and two derived-count items whose gold
+form is not stated directly in source. These categories are primarily reader
+selection and synthesis problems at the current context budget, not evidence
+reachability failures.
+
+For the 14 zero-score knowledge-update rows, six gold values precede a later
+distinct value returned by the answerer, five gold values have no exact
+user-turn match, and only three remain ordinary review cases. Product
+supersession policy must not be tuned to the eleven benchmark-integrity cases.
+
+Across all abstention rows, 58.2% of explicitly speaker-supported factual answer
+tokens occur only in assistant-authored blocks. Seven of the thirteen zeroes
+meet the stricter assistant-only-dominance rule. The retrieved contexts already
+label these blocks as assistant suggestions, but the reader often promotes them
+to user facts.
+
+## Decision
+
+Do not spend the next product cycle increasing generic top-k for summarization,
+multi-session reasoning, or knowledge update. Their context reachability is
+already high, and the knowledge-update zero cohort is mostly unsuitable for
+product tuning.
+
+The next product-shaped experiment is an equal-budget abstention comparison:
+current mixed-speaker context versus role-aware user-authoritative context on
+all 40 abstention queries. The treatment must not receive more context tokens.
+Because a complete 40-query cohort averages answer variance, use one answer per
+arm for the discovery pass; require at least `+0.075` mean lift and more wins
+than losses before a repeated-answer confirmation. A failed or merely neutral
+arm leaves mixed-speaker retrieval unchanged.
+
+## Reproduction
+
+```powershell
+python benchmarks/amb/audit_category_loss_funnel.py `
+  C:/path/to/ydb-0151/rag/100k.json `
+  C:/path/to/beam/100k/documents.json.gz `
+  --out C:/path/to/category-loss-funnel.json
+```

--- a/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
+++ b/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
@@ -47,6 +47,37 @@ meet the stricter assistant-only-dominance rule. The retrieved contexts already
 label these blocks as assistant suggestions, but the reader often promotes them
 to user facts.
 
+## Ceiling And Recovery Budget
+
+The audit now emits a loss-conserving `ceiling_estimate` over all ten frozen
+categories. The `ydb-0151` baseline is `65.1485`, so the line loses `34.8515`
+points and needs `24.8515` points, not 28.9, to reach 90.
+
+| Mutually exclusive bucket | Points |
+|---|---:|
+| Dead or benchmark integrity | 3.092 |
+| Reader, potentially reachable through context shaping | 7.153 |
+| Direct engine mechanisms | 15.177 |
+| Undiagnosed four-category tail | 6.984 |
+| Residual inside audited categories | 2.445 |
+| **Total frozen loss** | **34.851** |
+
+The conservation delta is exactly zero. The optimistic ceiling is `96.9081`:
+it removes only the 11/14 knowledge-update zero-row label share and the 2/40
+multi-session answers whose derived gold form is unstated. Reaching 90 requires
+recovering `78.25%` of the remaining `31.7596` potentially recoverable points.
+It therefore requires broad success, but not literally every non-dead point.
+
+The conversion rules are explicit in the JSON. Reader points are the audited
+reader-count share of category loss for summarization, multi-session reasoning,
+and abstention. Direct-engine points include all event-ordering and temporal
+loss, plus the audited retrieval share of summarization and provenance share of
+abstention. Treating all temporal loss as directly product-addressable is an
+optimistic recovery assumption, not a causal finding; the temporal audit found
+reader arithmetic, revision ambiguity, and invalid gold calculations as well.
+The residual bucket prevents those uncertain and overlapping cases from being
+silently assigned twice.
+
 ## Decision
 
 Do not spend the next product cycle increasing generic top-k for summarization,

--- a/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
+++ b/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
@@ -18,12 +18,16 @@ a replacement benchmark score.
 
 ## Results
 
-| Category | Mean score | Source support | Context retention | Answer retention | Dominant finding |
+| Category | Mean score | Overall points lost | Context retention | Answer retention | Primary attribution |
 |---|---:|---:|---:|---:|---|
-| summarization | 0.593 | 0.944 | 0.869 | 0.555 | 131/195 reference items fail mainly after retrieval |
-| knowledge update | 0.631 | 0.988 | 0.988 | 0.608 | 11/14 zeroes are stale-label or absent-gold cases |
-| multi-session reasoning | 0.611 | 0.921 | 0.908 | 0.427 | 30/40 answers lose source-supported content |
-| abstention | 0.675 | n/a | n/a | n/a | 7/13 zeroes are dominated by assistant-only support |
+| summarization | 0.593 | 4.07 | 0.869 | 0.555 | reader compression |
+| knowledge update | 0.631 | 3.69 | 0.988 | 0.608 | benchmark labels |
+| multi-session reasoning | 0.611 | 3.89 | 0.908 | 0.427 | reader set assembly |
+| abstention | 0.675 | 3.25 | n/a | n/a | provenance rendering |
+
+`Overall points lost` assumes BEAM's ten equally weighted 40-query categories:
+`10 * (1 - category mean)`. It makes the rows additive with the full-line loss
+ledger without pretending that every lost point is product-recoverable.
 
 Summarization has 22 retrieval-loss items, 131 answer-loss items, 41 covered
 items, and one source/label mismatch. Multi-session reasoning has 30

--- a/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
+++ b/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
@@ -58,6 +58,31 @@ arm for the discovery pass; require at least `+0.075` mean lift and more wins
 than losses before a repeated-answer confirmation. A failed or merely neutral
 arm leaves mixed-speaker retrieval unchanged.
 
+## Equal-Budget Abstention Result
+
+The discovery arm completed all 40 pairs under manifest SHA-256
+`394d074ee3b6316409c90196d14d224fd404fc8b81346f75123b2190a65844f1`.
+The role-aware treatment used `553,969` context tokens versus `583,816` for the
+baseline. Each arm used one answer and one judge call per query with
+`deepseek-v4-flash:0731-cloud`.
+
+| Context arm | Mean rubric |
+|---|---:|
+| frozen `ydb-0151` | 0.650 |
+| equal-budget role-aware | 0.700 |
+
+The paired delta was `+0.050`, with four treatment wins, 34 ties, and two
+baseline wins. The paired bootstrap 95% interval was `[-0.075, +0.175]`.
+This misses the preregistered `+0.075` lift gate, so no repeated-answer
+confirmation or product-default change is authorized.
+
+The six discordant rows also reinforce the answer-variance finding. Two rows
+that scored `1.0` in the original frozen line scored `0.0` when the identical
+baseline context was re-answered, while one original zero scored `1.0`.
+Role-aware retrieval fixed three abstention failures in units 4 and 5 but
+introduced failures in units 1 and 9. The split is not identifiable from query
+wording alone and must not become a post-hoc routing rule.
+
 ## Reproduction
 
 ```powershell

--- a/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
+++ b/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
@@ -2,8 +2,8 @@
 
 ## Scope
 
-This judge-free audit examines the four largest non-temporal loss buckets in
-the frozen `ydb-0151` BEAM-100K run. It measures distinctive reference-token
+This judge-free audit examines all eight non-temporal categories in the frozen
+`ydb-0151` BEAM-100K run. It measures distinctive reference-token
 support in the source conversation, retention in retrieved context, retention
 in the final answer, exact knowledge-update value chronology, and answer tokens
 supported only by explicitly assistant-authored memory blocks.
@@ -24,6 +24,10 @@ a replacement benchmark score.
 | knowledge update | 0.631 | 3.69 | 0.988 | 0.608 | benchmark labels |
 | multi-session reasoning | 0.611 | 3.89 | 0.908 | 0.427 | reader set assembly |
 | abstention | 0.675 | 3.25 | n/a | n/a | provenance rendering |
+| contradiction resolution | 0.828 | 1.72 | 0.978 | 0.733 | reader conflict resolution |
+| information extraction | 0.773 | 2.27 | 0.948 | 0.697 | reader fact selection |
+| instruction following | 0.788 | 2.13 | 0.794 | 0.259 | standing-instruction salience |
+| preference following | 0.913 | 0.88 | 0.824 | 0.378 | preference salience |
 
 `Overall points lost` assumes BEAM's ten equally weighted 40-query categories:
 `10 * (1 - category mean)`. It makes the rows additive with the full-line loss
@@ -47,6 +51,20 @@ meet the stricter assistant-only-dominance rule. The retrieved contexts already
 label these blocks as assistant suggestions, but the reader often promotes them
 to user facts.
 
+For contradiction resolution, only the two conflicting evidence claims are
+treated as retrieval targets; the rubric's conflict-acknowledgement and verdict
+directives are reader requirements. Of 80 evidence claims, 46 are covered, 32
+are lost in the answer, one is lost in retrieval, and one is a source mismatch.
+Information extraction is similarly reader-heavy: only 4/92 claims are lost in
+retrieval, versus 41 answer losses and 45 covered claims.
+
+Instruction and preference rows expose their canonical standing behavior in
+`instruction_being_tested` and `preference_being_tested`. The exact instruction
+is source-backed in all 40 rows and retrieved in 36; the exact preference is
+retrieved in 36/40. Partitioning actual row-score deficits assigns `3.5/8.5`
+instruction deficit units and `1.0/3.5` preference deficit units to retrieval;
+the remaining `5.0` and `2.5` units occur after the target is already present.
+
 ## Ceiling And Recovery Budget
 
 The audit now emits a loss-conserving `ceiling_estimate` over all ten frozen
@@ -64,10 +82,10 @@ anchor configuration and should use a repeated full-line median.
 | Mutually exclusive bucket | Points |
 |---|---:|
 | Dead or benchmark integrity | 3.092 |
-| Reader, potentially reachable through context shaping | 7.153 |
-| Direct engine mechanisms | 15.177 |
-| Undiagnosed four-category tail | 6.984 |
-| Residual inside audited categories | 2.445 |
+| Reader, potentially reachable through context shaping | 10.725 |
+| Direct engine mechanisms | 16.422 |
+| Undiagnosed category tail | 0.000 |
+| Residual inside audited categories | 4.612 |
 | **Total frozen loss** | **34.851** |
 
 The conservation delta is exactly zero. The optimistic ceiling is `96.9081`:
@@ -76,24 +94,24 @@ multi-session answers whose derived gold form is unstated. Reaching 90 requires
 recovering `78.25%` of the remaining `31.7596` potentially recoverable points.
 It therefore requires broad success, but not literally every non-dead point.
 
-The conversion rules are explicit in the JSON. Reader points are the audited
-reader-count share of category loss for summarization, multi-session reasoning,
-and abstention. Direct-engine points include all event-ordering and temporal
-loss, plus the audited retrieval share of summarization and provenance share of
-abstention. Treating all temporal loss as directly product-addressable is an
-optimistic recovery assumption, not a causal finding; the temporal audit found
-reader arithmetic, revision ambiguity, and invalid gold calculations as well.
-The residual bucket prevents those uncertain and overlapping cases from being
-silently assigned twice.
+The conversion rules are explicit in the JSON. Reader points use audited shares
+in all eight categories. Instruction and preference shares use actual row-score
+deficits; fact-selection and conflict shares use reference-item counts. Direct
+engine points include all event-ordering and temporal loss plus every audited
+retrieval or provenance share. Treating all temporal loss as directly
+product-addressable is an optimistic recovery assumption, not a causal finding;
+the temporal audit found reader arithmetic, revision ambiguity, and invalid
+gold calculations as well. The residual bucket prevents uncertain and
+overlapping cases from being silently assigned twice.
 
 The machine-readable sensitivity table varies only reader-shaping recovery and
 optimistically recovers every other non-dead bucket:
 
 | Reader-attributed loss recovered | Projected score |
 |---:|---:|
-| 0% | 89.755 |
-| 50% | 93.332 |
-| 70% | 94.762 |
+| 0% | 86.183 |
+| 50% | 91.545 |
+| 70% | 93.691 |
 | 100% | 96.908 |
 
 This is not a forecast: 50% and 70% are scenario parameters, while the evidence

--- a/benchmarks/amb/CONTEXTUAL_CANDIDATE_BANK.md
+++ b/benchmarks/amb/CONTEXTUAL_CANDIDATE_BANK.md
@@ -95,7 +95,7 @@ parent links, and stored source provenance. It selected Robert, retained eight
 source rows across five `source_doc_id` groups, and preserved all `5/5` source
 turns. It did not generate, merge, or rewrite any memory.
 
-| Frozen arm | Rows / groups | Context tokens | Median score | Judge votes |
+| Frozen arm | Rows / groups | Context tokens | Observed single-answer score | Judge votes |
 | --- | ---: | ---: | ---: | --- |
 | Raw bridge bank | 44 rows | 3007 | `0.00` | `0.00, 0.00, 0.00` |
 | Relationship thread | 8 rows / 5 groups | 624 | `0.70` | `0.70, 0.70, 0.70` |
@@ -107,8 +107,32 @@ from the prior null run. The grouped arm SHA-256 was
 the paired manifest SHA-256 was
 `290e576b007665e32ac23258db52cb4477dc51a6171e904e6554dba8e1958d70`.
 The model snapshot was `deepseek-v4-flash:0731-cloud` for both answering and
-three repeated judgments. The paired delta is internally comparable, but these
-scores are not line-comparable to runs judged by the rolling `:cloud` tag.
+three repeated judgments. Only the judge was repeated; each arm used one answer
+draw. These scores are not line-comparable to runs judged by the rolling
+`:cloud` tag.
+
+### Answer-variance retro-grade
+
+A later A/A calibration answered the exact same 624-token relationship-thread
+context five times in each arm, with three judge votes per answer. The byte-
+identical arms tied at median `0.50`; their complete answer-score distributions
+were `0.30, 0.40, 0.50, 0.60, 0.60` and
+`0.50, 0.30, 0.70, 0.50, 0.50`. Draw-level signs were three wins for one arm
+and two for the other, while judge votes were nearly always unanimous. The
+`0.30-0.70` spread is answer-generation variance, not judge instability or a
+context effect. The pooled sample standard deviation is about `0.13`; under an
+independent-draw approximation, averaging 40 category queries reduces that term
+to roughly `0.02` standard error. Category-level discovery runs can therefore
+use one draw per query, while any claim about one query still requires repeated
+answers.
+
+Therefore the historical `0.70` above is one observed draw, not the value of
+the relationship-thread arm. Its calibrated center is about `0.50`, with an
+observed range of `0.30-0.70`. The replicated raw-bank zero versus a nonzero
+distribution centered near `0.50` still supports query-dependent thread
+selection. Fine-grained deltas between nonzero Q7 variants do not support a
+verdict unless they use at least five answer draws per arm and compare both
+median score and paired signs.
 
 This is evidence for query-dependent thread selection, not for write-time
 cross-session synthesis. The treatment still chose two early distractors from
@@ -144,28 +168,28 @@ The six-row treatment keeps turns `14, 64, 124, 170, 212, 214`, drops only
 The paired manifest SHA-256 is
 `3fdd24417b933d8c5938026ceb6ffff6e68d6e4b05269fb5a76368d5c77fb2f8`.
 
-The preregistered hypothesis is that removing the two same-source distractors
-raises Q7 above the control's unanimous `0.70`. The null is a median paired
-delta of `0.00`; any negative delta is a failed arm. Answering and three repeated
-judgments use the pinned `deepseek-v4-flash:0731-cloud` snapshot. The result is
-internally paired but not line-comparable to the rolling `:cloud` benchmark.
-No other query will be judged for this residual.
+The preregistered hypothesis was that removing the two same-source distractors
+would raise Q7 above the control's observed `0.70` draw. The original protocol
+repeated the judge but not the answer, so its negative-delta rule predates the
+answer-variance calibration. The result is not line-comparable to the rolling
+`:cloud` benchmark.
 
-The frozen run rejected the hypothesis:
+The frozen run produced this single-answer observation:
 
-| Frozen arm | Rows | Context tokens | Median score | Judge votes |
+| Frozen arm | Rows | Context tokens | Observed single-answer score | Judge votes |
 | --- | ---: | ---: | ---: | --- |
 | Relationship thread control | 8 | 624 | `0.70` | `0.70, 0.70, 0.70` |
 | Within-source representatives | 6 | 489 | `0.50` | `0.40, 0.50, 0.50` |
 
-The paired delta was `-0.20`, a preregistered failed arm. No rerun was made.
+The observed single-draw delta was `-0.20`; no rerun was made. The protocol at
+the time labeled this a failed arm, but the later A/A calibration shows that the
+numeric delta is not a reliable effect estimate.
 The treatment answer identified the five broad stages, but compressed away exact
 rubric details such as the Zoom-call context, improving the essay before the
-conference paper, and follow-up Zoom/conference planning. This result rejects
-raw-row deletion as the residual fix. It points back to representation: a source
-stage needs an answer-sized synthesized item that preserves its distinguishing
-detail. The representative selector remains opt-in experimental harness code
-and must not be promoted to a product default.
+conference paper, and follow-up Zoom/conference planning. The observed failure
+mode motivated the representation probe, but does not by itself prove that
+raw-row deletion lowers expected score. The representative selector remains
+opt-in experimental harness code and must not be promoted to a product default.
 
 ### Global stage-record result
 
@@ -190,25 +214,26 @@ and
 The paired manifest SHA-256 was
 `a7aab531232e2be20bf60d05b8e32ba838b15458c8c06d167e851a6e2a8d0c49`.
 
-The frozen run rejected compact prose stage records:
+The frozen run produced this single-answer observation:
 
-| Frozen arm | Rows | Context tokens | Median score | Judge votes |
+| Frozen arm | Rows | Context tokens | Observed single-answer score | Judge votes |
 | --- | ---: | ---: | ---: | --- |
 | Relationship thread control | 8 | 624 | `0.60` | `0.60, 0.60, 0.70` |
 | Global stage records | 5 | 331 | `0.20` | `0.20, 0.20, 0.20` |
 
-The paired delta was `-0.40`; no rerun was made. The model converted the
-first-person concern about meeting Robert and making a good impression into a
-third-person fact. The answerer then explicitly excluded that record as not an
-academic-work aspect and split the June record into separate journal and
-conference items. The synthesis also omitted the central June decision to
-strengthen the essay before the conference paper and compressed the July
-confidence and conference-planning details into generic next steps.
+The observed single-draw delta was `-0.40`; no rerun was made. It is retained as
+a mechanism observation, not a calibrated score-effect estimate. The model
+converted the first-person concern about meeting Robert and making a good
+impression into a third-person fact. The answerer then explicitly excluded that
+record as not an academic-work aspect and split the June record into separate
+journal and conference items. The synthesis also omitted the central June
+decision to strengthen the essay before the conference paper and compressed
+the July confidence and conference-planning details into generic next steps.
 
-This rejects untyped compact prose for this arm and motivates a subsequent
-hypothesis that preserves speaker perspective and separately encodes the
-user's goal/concern/decision, event facts, and outcome or follow-up. Q7 is now
-a development case for that schema, not untouched validation.
+This keeps untyped compact prose out of the product path and motivates a
+subsequent hypothesis that preserves speaker perspective and separately encodes
+the user's goal/concern/decision, event facts, and outcome or follow-up. Q7 is
+now a development case for that schema, not untouched validation.
 
 ### Untouched holdout
 

--- a/benchmarks/amb/MULTI_SESSION_REASONING_AUDIT.md
+++ b/benchmarks/amb/MULTI_SESSION_REASONING_AUDIT.md
@@ -62,6 +62,33 @@ support. Because the split was selected after seeing results and remains
 uncertain, it must be pre-registered and tested on an independent cohort before
 it controls production retrieval.
 
+## Query-Independent Topic-Card Transfer
+
+A judge-free preflight tested whether existing query-independent dated topic
+cards could provide the missing set-assembly structure. For each of the 20
+conversation units, it transplanted the exact same card set from both
+summarization questions onto both multi-session questions. Context generation
+did not inspect multi-session queries, answers, scores, or gold text.
+
+- Topic-card artifact SHA-256:
+  `5070ff22bfff81141f8329c0dad867384b42855b1fe61b1ef575a8600ac881c1`
+- Frozen baseline SHA-256:
+  `43b8eb888adeb524caba70b013a8ca510c639bbf5312216e9b453d60185bcb8e`
+- Source-document SHA-256:
+  `fc0e64bac38fcde26eece776e818f70374338d4591ecc75346cb27b613d4c128`
+- Context tokens: `604,906` baseline versus `613,482` topic cards
+- Source-normalized reference retention: `0.9078` versus `0.6068`
+- Per-query retention outcomes: 3 topic-card wins, 5 ties, 32 losses
+- Funnel stages: 8 covered, 30 answer-loss, and 2 synthesis-required became
+  4 covered, 9 answer-loss, 2 synthesis-required, and 25 retrieval-loss items
+
+The 22 query-only count/set rows show the same failure: retention falls from
+`0.8844` to `0.6099`, with one win, four ties, and 17 losses. This is a decisive
+pre-model stop. Concern-level topic summaries are too coarse to preserve the
+distinct values, examples, and events needed for counting and set assembly.
+Future organizer work must expose grounded answer-sized concern items with
+evidence IDs; rendering broader topic labels and summaries is not a substitute.
+
 ## Decision
 
 Do not replace mixed-speaker retrieval with user-only evidence, and do not
@@ -71,3 +98,8 @@ count/set intent before retrieval, use stable user-first presentation only for
 that intent, and evaluate on an independent frozen cohort with repeated
 judging. Until that lifts, the current relevance-first presentation remains
 the evidence-backed default.
+
+The independent count/set confirmation later returned an exact null, and the
+topic-card transfer failed its deterministic retention preflight. The remaining
+product-shaped path is atomic concern-item construction and routing, not speaker
+ordering or concern-level summary cards.

--- a/benchmarks/amb/audit_category_loss_funnel.py
+++ b/benchmarks/amb/audit_category_loss_funnel.py
@@ -51,6 +51,7 @@ DEFAULT_CATEGORIES = (
 RUBRIC_PREFIX = re.compile(r"^LLM response should contain:\s*", re.IGNORECASE)
 SOURCE_SUPPORT_THRESHOLD = 0.75
 RETENTION_THRESHOLD = 0.75
+BEAM_CATEGORY_WEIGHT = 0.1
 
 
 def reference_items(row: dict) -> list[str]:
@@ -186,6 +187,64 @@ def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def category_attribution(
+    category: str,
+    rows: list[dict],
+    items: list[dict],
+    stages: Counter,
+    knowledge_verdicts: Counter,
+) -> dict:
+    zero_rows = [row for row in rows if row["score"] == 0.0]
+    assistant_dominant = sum(
+        row["speaker_provenance"]["assistant_only_dominant"] for row in zero_rows
+    )
+    label_defects = (
+        knowledge_verdicts["gold_precedes_later_prediction"]
+        + knowledge_verdicts["gold_value_not_exact_in_user"]
+    )
+    if category == "summarization":
+        primary = "reader_compression"
+    elif category == "knowledge_update":
+        primary = "benchmark_label"
+    elif category == "multi_session_reasoning":
+        primary = "reader_set_assembly"
+    elif category == "abstention":
+        primary = "provenance_rendering"
+    else:
+        primary = "unclassified"
+    return {
+        "primary": primary,
+        "ours": {
+            "count": (
+                assistant_dominant
+                if category == "abstention"
+                else stages["retrieval_loss"]
+            ),
+            "denominator": len(zero_rows) if category == "abstention" else len(items),
+            "unit": "zero_score_rows" if category == "abstention" else "reference_items",
+        },
+        "label": {
+            "count": label_defects,
+            "denominator": len(zero_rows),
+            "unit": "zero_score_rows",
+        },
+        "reader": {
+            "count": (
+                max(len(zero_rows) - assistant_dominant, 0)
+                if category == "abstention"
+                else stages["answer_loss"]
+            ),
+            "denominator": len(zero_rows) if category == "abstention" else len(items),
+            "unit": "zero_score_rows" if category == "abstention" else "reference_items",
+        },
+        "synthesis_required": {
+            "count": stages["synthesis_required"],
+            "denominator": len(items),
+            "unit": "reference_items",
+        },
+    }
+
+
 def analyze(
     result_payload: dict,
     sources: dict[str, str],
@@ -227,9 +286,13 @@ def analyze(
             for row in zero_rows
             if "knowledge_update" in row
         )
+        mean_score = _mean([row["score"] for row in rows])
         summaries[category] = {
             "rows": len(rows),
-            "mean_score": _mean([row["score"] for row in rows]),
+            "mean_score": mean_score,
+            "equal_weight_overall_points_lost": round(
+                100 * BEAM_CATEGORY_WEIGHT * (1.0 - mean_score), 6
+            ),
             "zero_score_rows": len(zero_rows),
             "reference_items": len(items),
             "mean_source_coverage": _mean_or_none(
@@ -253,6 +316,9 @@ def analyze(
                 for row in zero_rows
             ),
             "knowledge_update_zero_verdicts": dict(sorted(knowledge_verdicts.items())),
+            "attribution": category_attribution(
+                category, rows, items, stages, knowledge_verdicts
+            ),
         }
 
     return {

--- a/benchmarks/amb/audit_category_loss_funnel.py
+++ b/benchmarks/amb/audit_category_loss_funnel.py
@@ -47,8 +47,14 @@ DEFAULT_CATEGORIES = (
     "knowledge_update",
     "multi_session_reasoning",
     "abstention",
+    "contradiction_resolution",
+    "information_extraction",
+    "instruction_following",
+    "preference_following",
 )
-RUBRIC_PREFIX = re.compile(r"^LLM response should contain:\s*", re.IGNORECASE)
+RUBRIC_PREFIX = re.compile(
+    r"^LLM response should (?:contain|state|mention):\s*", re.IGNORECASE
+)
 SOURCE_SUPPORT_THRESHOLD = 0.75
 RETENTION_THRESHOLD = 0.75
 BEAM_CATEGORY_WEIGHT = 0.1
@@ -59,6 +65,13 @@ TAIL_CATEGORIES = (
     "instruction_following",
     "preference_following",
 )
+RUBRIC_REFERENCE_CATEGORIES = {
+    "contradiction_resolution",
+    "information_extraction",
+    "instruction_following",
+    "preference_following",
+    "summarization",
+}
 
 
 def reference_items(row: dict) -> list[str]:
@@ -66,11 +79,15 @@ def reference_items(row: dict) -> list[str]:
     category = str((row.get("meta") or {}).get("question_category") or "")
     if category == "abstention":
         return []
-    if category == "summarization":
-        return [
+    if category in RUBRIC_REFERENCE_CATEGORIES:
+        items = [
             RUBRIC_PREFIX.sub("", str(item)).strip()
             for item in (row.get("meta") or {}).get("rubric") or []
+            if str(item).strip()
         ]
+        # The first and fourth contradiction rubrics are response directives;
+        # only the middle pair are claims that should be present in memory.
+        return items[1:3] if category == "contradiction_resolution" else items
     return [str(item).strip() for item in row.get("gold_answers") or [] if str(item).strip()]
 
 
@@ -109,6 +126,41 @@ def lexical_funnel(row: dict, source: str) -> list[dict]:
             }
         )
     return output
+
+
+def behavior_target_funnel(row: dict, source: str) -> dict | None:
+    """Measure retrieval of the canonical standing instruction or preference."""
+    metadata = row.get("meta") or {}
+    category = str(metadata.get("question_category") or "")
+    target_key = {
+        "instruction_following": "instruction_being_tested",
+        "preference_following": "preference_being_tested",
+    }.get(category)
+    if target_key is None:
+        return None
+    target = str(metadata.get(target_key) or "").strip()
+    if not target:
+        return None
+    target_tokens = tokens(target)
+    source_tokens = tokens(source)
+    source_supported = target_tokens & source_tokens
+    source_coverage = token_coverage(target_tokens, source_tokens)
+    context_retention = token_coverage(
+        source_supported, tokens(str(row.get("context") or ""))
+    )
+    if source_coverage < SOURCE_SUPPORT_THRESHOLD:
+        stage = "source_or_label_mismatch"
+    elif context_retention < RETENTION_THRESHOLD:
+        stage = "retrieval_loss"
+    else:
+        stage = "target_retrieved"
+    return {
+        "target_key": target_key,
+        "target": target,
+        "source_coverage": source_coverage,
+        "source_normalized_context_retention": context_retention,
+        "stage": stage,
+    }
 
 
 def speaker_provenance(row: dict) -> dict:
@@ -217,8 +269,44 @@ def category_attribution(
         primary = "reader_set_assembly"
     elif category == "abstention":
         primary = "provenance_rendering"
+    elif category == "contradiction_resolution":
+        primary = "reader_conflict_resolution"
+    elif category == "information_extraction":
+        primary = "reader_fact_selection"
+    elif category == "instruction_following":
+        primary = "standing_instruction_salience"
+    elif category == "preference_following":
+        primary = "preference_salience"
     else:
         primary = "unclassified"
+    if category in {"instruction_following", "preference_following"}:
+        deficits = Counter()
+        for row in rows:
+            deficit = 1.0 - float(row["score"])
+            target = row.get("behavior_target") or {}
+            owner = {
+                "retrieval_loss": "ours",
+                "source_or_label_mismatch": "label",
+                "target_retrieved": "reader",
+            }.get(target.get("stage"), "reader")
+            deficits[owner] += deficit
+        denominator = sum(deficits.values())
+        return {
+            "primary": primary,
+            **{
+                owner: {
+                    "count": round(deficits[owner], 6),
+                    "denominator": round(denominator, 6),
+                    "unit": "row_score_deficit",
+                }
+                for owner in ("ours", "label", "reader")
+            },
+            "synthesis_required": {
+                "count": 0,
+                "denominator": round(denominator, 6),
+                "unit": "row_score_deficit",
+            },
+        }
     return {
         "primary": primary,
         "ours": {
@@ -254,7 +342,7 @@ def category_attribution(
 
 def _attribution_share(summary: dict, owner: str) -> float:
     attribution = (summary.get("attribution") or {}).get(owner) or {}
-    denominator = int(attribution.get("denominator") or 0)
+    denominator = float(attribution.get("denominator") or 0)
     return float(attribution.get("count") or 0) / denominator if denominator else 0.0
 
 
@@ -279,6 +367,9 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
     knowledge_update = summaries.get("knowledge_update") or {}
     multi_session = summaries.get("multi_session_reasoning") or {}
     abstention = summaries.get("abstention") or {}
+    tail_summaries = {
+        category: summaries.get(category) or {} for category in TAIL_CATEGORIES
+    }
 
     dead = (
         loss("knowledge_update") * _attribution_share(knowledge_update, "label")
@@ -290,14 +381,26 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
         + loss("multi_session_reasoning")
         * _attribution_share(multi_session, "reader")
         + loss("abstention") * _attribution_share(abstention, "reader")
+        + sum(
+            loss(category) * _attribution_share(summary, "reader")
+            for category, summary in tail_summaries.items()
+        )
     )
     ours_direct = (
         loss("event_ordering")
         + loss("temporal_reasoning")
         + loss("summarization") * _attribution_share(summarization, "ours")
         + loss("abstention") * _attribution_share(abstention, "ours")
+        + sum(
+            loss(category) * _attribution_share(summary, "ours")
+            for category, summary in tail_summaries.items()
+        )
     )
-    undiagnosed_tail = sum(loss(category) for category in TAIL_CATEGORIES)
+    undiagnosed_tail = sum(
+        loss(category)
+        for category, summary in tail_summaries.items()
+        if not summary
+    )
     total_loss = sum(category_losses.values())
     audited_residual = total_loss - (
         dead + reader_shaping + ours_direct + undiagnosed_tail
@@ -350,11 +453,11 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
                 "unstated-derived-answer share"
             ),
             "reader_via_context_shaping": (
-                "reader-attributed summarization, multi-session, and abstention shares"
+                "reader-attributed shares in every audited category"
             ),
             "ours_direct_engine": (
                 "all event-ordering and temporal loss plus retrieval-attributed "
-                "summarization and provenance-attributed abstention shares"
+                "shares in audited categories"
             ),
             "optimistic_ceiling": "full recovery of every point not classified dead",
             "reader_shaping_sensitivity": (
@@ -389,6 +492,9 @@ def analyze(
             "items": item_funnel,
             "speaker_provenance": speaker_provenance(row),
         }
+        behavior_target = behavior_target_funnel(row, sources[conversation_id])
+        if behavior_target is not None:
+            analyzed["behavior_target"] = behavior_target
         if category == "knowledge_update" and score == 0.0:
             analyzed["knowledge_update"] = knowledge_update_verdict(
                 row, conversations[conversation_id]
@@ -406,6 +512,10 @@ def analyze(
             for row in zero_rows
             if "knowledge_update" in row
         )
+        behavior_targets = [
+            row["behavior_target"] for row in rows if "behavior_target" in row
+        ]
+        behavior_stages = Counter(target["stage"] for target in behavior_targets)
         mean_score = _mean([row["score"] for row in rows])
         summaries[category] = {
             "rows": len(rows),
@@ -436,6 +546,17 @@ def analyze(
                 for row in zero_rows
             ),
             "knowledge_update_zero_verdicts": dict(sorted(knowledge_verdicts.items())),
+            "behavior_target_rows": len(behavior_targets),
+            "mean_behavior_target_source_coverage": _mean_or_none(
+                [target["source_coverage"] for target in behavior_targets]
+            ),
+            "mean_behavior_target_context_retention": _mean_or_none(
+                [
+                    target["source_normalized_context_retention"]
+                    for target in behavior_targets
+                ]
+            ),
+            "behavior_target_stages": dict(sorted(behavior_stages.items())),
             "attribution": category_attribution(
                 category, rows, items, stages, knowledge_verdicts
             ),

--- a/benchmarks/amb/audit_category_loss_funnel.py
+++ b/benchmarks/amb/audit_category_loss_funnel.py
@@ -52,6 +52,13 @@ RUBRIC_PREFIX = re.compile(r"^LLM response should contain:\s*", re.IGNORECASE)
 SOURCE_SUPPORT_THRESHOLD = 0.75
 RETENTION_THRESHOLD = 0.75
 BEAM_CATEGORY_WEIGHT = 0.1
+BEAM_CATEGORY_COUNT = 10
+TAIL_CATEGORIES = (
+    "contradiction_resolution",
+    "information_extraction",
+    "instruction_following",
+    "preference_following",
+)
 
 
 def reference_items(row: dict) -> list[str]:
@@ -245,6 +252,107 @@ def category_attribution(
     }
 
 
+def _attribution_share(summary: dict, owner: str) -> float:
+    attribution = (summary.get("attribution") or {}).get(owner) or {}
+    denominator = int(attribution.get("denominator") or 0)
+    return float(attribution.get("count") or 0) / denominator if denominator else 0.0
+
+
+def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
+    """Build a conservative, loss-conserving recovery budget for the full line."""
+    scores_by_category: dict[str, list[float]] = {}
+    for row in result_payload.get("results") or []:
+        category = str((row.get("meta") or {}).get("question_category") or "")
+        if category:
+            scores_by_category.setdefault(category, []).append(
+                float(row.get("score") or 0.0)
+            )
+    category_losses = {
+        category: 100 * BEAM_CATEGORY_WEIGHT * (1.0 - _mean(scores))
+        for category, scores in scores_by_category.items()
+    }
+
+    def loss(category: str) -> float:
+        return category_losses.get(category, 0.0)
+
+    summarization = summaries.get("summarization") or {}
+    knowledge_update = summaries.get("knowledge_update") or {}
+    multi_session = summaries.get("multi_session_reasoning") or {}
+    abstention = summaries.get("abstention") or {}
+
+    dead = (
+        loss("knowledge_update") * _attribution_share(knowledge_update, "label")
+        + loss("multi_session_reasoning")
+        * _attribution_share(multi_session, "synthesis_required")
+    )
+    reader_shaping = (
+        loss("summarization") * _attribution_share(summarization, "reader")
+        + loss("multi_session_reasoning")
+        * _attribution_share(multi_session, "reader")
+        + loss("abstention") * _attribution_share(abstention, "reader")
+    )
+    ours_direct = (
+        loss("event_ordering")
+        + loss("temporal_reasoning")
+        + loss("summarization") * _attribution_share(summarization, "ours")
+        + loss("abstention") * _attribution_share(abstention, "ours")
+    )
+    undiagnosed_tail = sum(loss(category) for category in TAIL_CATEGORIES)
+    total_loss = sum(category_losses.values())
+    audited_residual = total_loss - (
+        dead + reader_shaping + ours_direct + undiagnosed_tail
+    )
+    if audited_residual < -1e-9:
+        raise ValueError("ceiling attribution double-counts benchmark loss")
+    audited_residual = max(audited_residual, 0.0)
+    buckets = {
+        "dead_or_benchmark_integrity": dead,
+        "reader_via_context_shaping": reader_shaping,
+        "ours_direct_engine": ours_direct,
+        "undiagnosed_tail": undiagnosed_tail,
+        "audited_residual": audited_residual,
+    }
+    bucket_total = sum(buckets.values())
+    complete_line = (
+        len(scores_by_category) == BEAM_CATEGORY_COUNT
+        and len({len(scores) for scores in scores_by_category.values()}) == 1
+    )
+    baseline_percent = 100.0 - total_loss
+    recoverable = total_loss - dead
+    recovery_to_90 = max(90.0 - baseline_percent, 0.0)
+    return {
+        "complete_equal_weight_ten_category_line": complete_line,
+        "baseline_score_percent": round(baseline_percent, 6),
+        "total_points_lost": round(total_loss, 6),
+        "category_points_lost": {
+            category: round(value, 6)
+            for category, value in sorted(category_losses.items())
+        },
+        "buckets": {name: round(value, 6) for name, value in buckets.items()},
+        "bucket_conservation_delta": round(total_loss - bucket_total, 12),
+        "optimistic_ceiling_percent": round(100.0 - dead, 6),
+        "points_required_to_reach_90": round(recovery_to_90, 6),
+        "recoverable_points": round(recoverable, 6),
+        "recoverable_share_required_to_reach_90": (
+            round(recovery_to_90 / recoverable, 6) if recoverable else None
+        ),
+        "assumptions": {
+            "dead": (
+                "knowledge-update label-defect share plus multi-session "
+                "unstated-derived-answer share"
+            ),
+            "reader_via_context_shaping": (
+                "reader-attributed summarization, multi-session, and abstention shares"
+            ),
+            "ours_direct_engine": (
+                "all event-ordering and temporal loss plus retrieval-attributed "
+                "summarization and provenance-attributed abstention shares"
+            ),
+            "optimistic_ceiling": "full recovery of every point not classified dead",
+        },
+    }
+
+
 def analyze(
     result_payload: dict,
     sources: dict[str, str],
@@ -322,12 +430,13 @@ def analyze(
         }
 
     return {
-        "protocol": "beam-category-loss-funnel-v1",
+        "protocol": "beam-category-loss-funnel-v2",
         "thresholds": {
             "source_support": SOURCE_SUPPORT_THRESHOLD,
             "context_and_answer_retention": RETENTION_THRESHOLD,
         },
         "categories": summaries,
+        "ceiling_estimate": ceiling_estimate(result_payload, summaries),
         "results": per_query,
     }
 

--- a/benchmarks/amb/audit_category_loss_funnel.py
+++ b/benchmarks/amb/audit_category_loss_funnel.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Build a judge-free loss funnel for high-impact BEAM categories.
+
+The audit separates lexical source support, source-to-context retention,
+context-to-answer retention, knowledge-update label chronology, and explicit
+speaker-provenance leakage. These are diagnostic proxies, not benchmark scores.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from statistics import fmean
+
+try:
+    from .audit_knowledge_update_gold import (
+        iter_turns,
+        load_conversations,
+        value_tokens,
+    )
+    from .audit_summarization_lexical_funnel import (
+        load_source_documents,
+        token_coverage,
+        tokens,
+    )
+    from .reorder_speaker_first_contexts import speaker_bucket, split_memory_blocks
+except ImportError:  # pragma: no cover - direct script execution
+    from audit_knowledge_update_gold import (
+        iter_turns,
+        load_conversations,
+        value_tokens,
+    )
+    from audit_summarization_lexical_funnel import (
+        load_source_documents,
+        token_coverage,
+        tokens,
+    )
+    from reorder_speaker_first_contexts import speaker_bucket, split_memory_blocks
+
+
+DEFAULT_CATEGORIES = (
+    "summarization",
+    "knowledge_update",
+    "multi_session_reasoning",
+    "abstention",
+)
+RUBRIC_PREFIX = re.compile(r"^LLM response should contain:\s*", re.IGNORECASE)
+SOURCE_SUPPORT_THRESHOLD = 0.75
+RETENTION_THRESHOLD = 0.75
+
+
+def reference_items(row: dict) -> list[str]:
+    """Return benchmark reference claims, excluding abstention boilerplate."""
+    category = str((row.get("meta") or {}).get("question_category") or "")
+    if category == "abstention":
+        return []
+    if category == "summarization":
+        return [
+            RUBRIC_PREFIX.sub("", str(item)).strip()
+            for item in (row.get("meta") or {}).get("rubric") or []
+        ]
+    return [str(item).strip() for item in row.get("gold_answers") or [] if str(item).strip()]
+
+
+def lexical_funnel(row: dict, source: str) -> list[dict]:
+    source_tokens = tokens(source)
+    context_tokens = tokens(str(row.get("context") or ""))
+    answer_tokens = tokens(str(row.get("answer") or ""))
+    category = str((row.get("meta") or {}).get("question_category") or "")
+    output = []
+    for index, item in enumerate(reference_items(row), 1):
+        item_tokens = tokens(item)
+        source_supported = item_tokens & source_tokens
+        source_coverage = token_coverage(item_tokens, source_tokens)
+        context_retention = token_coverage(source_supported, context_tokens)
+        answer_retention = token_coverage(source_supported, answer_tokens)
+        if source_coverage < SOURCE_SUPPORT_THRESHOLD:
+            stage = (
+                "synthesis_required"
+                if category == "multi_session_reasoning"
+                else "source_or_label_mismatch"
+            )
+        elif context_retention < RETENTION_THRESHOLD:
+            stage = "retrieval_loss"
+        elif answer_retention < RETENTION_THRESHOLD:
+            stage = "answer_loss"
+        else:
+            stage = "covered"
+        output.append(
+            {
+                "index": index,
+                "item": item,
+                "source_coverage": source_coverage,
+                "source_normalized_context_retention": context_retention,
+                "source_normalized_answer_retention": answer_retention,
+                "stage": stage,
+            }
+        )
+    return output
+
+
+def speaker_provenance(row: dict) -> dict:
+    """Measure answer tokens supported only by explicitly assistant-authored blocks."""
+    block_tokens = {"user": set(), "assistant": set(), "unknown": set()}
+    counts: Counter[str] = Counter()
+    for block in split_memory_blocks(str(row.get("context") or "")):
+        bucket = speaker_bucket(block)
+        counts[bucket] += 1
+        block_tokens[bucket].update(tokens(block))
+
+    factual_answer_tokens = tokens(str(row.get("answer") or "")) - tokens(
+        str(row.get("query") or "")
+    )
+    explicitly_supported = factual_answer_tokens & (
+        block_tokens["user"] | block_tokens["assistant"]
+    )
+    assistant_only = (
+        factual_answer_tokens
+        & block_tokens["assistant"]
+        - block_tokens["user"]
+    )
+    user_only = factual_answer_tokens & block_tokens["user"] - block_tokens["assistant"]
+    denominator = len(explicitly_supported)
+    assistant_only_ratio = len(assistant_only) / denominator if denominator else 0.0
+    return {
+        "blocks": sum(counts.values()),
+        "user_blocks": counts["user"],
+        "assistant_blocks": counts["assistant"],
+        "unknown_blocks": counts["unknown"],
+        "factual_answer_tokens": len(factual_answer_tokens),
+        "explicitly_supported_answer_tokens": denominator,
+        "assistant_only_answer_tokens": sorted(assistant_only),
+        "user_only_answer_tokens": sorted(user_only),
+        "assistant_only_supported_ratio": assistant_only_ratio,
+        "assistant_only_dominant": (
+            denominator > 0
+            and assistant_only_ratio >= 0.25
+            and len(assistant_only) > len(user_only)
+        ),
+    }
+
+
+def knowledge_update_verdict(row: dict, conversation: dict) -> dict:
+    """Locate exact gold and distinct predicted values in user-authored turns."""
+    gold_values = value_tokens(" ".join(row.get("gold_answers") or []))
+    predicted_values = value_tokens(str(row.get("answer") or "")) - gold_values
+    gold_turns = []
+    predicted_turns = []
+    for turn in iter_turns(conversation.get("chat") or []):
+        if str(turn.get("role") or "").casefold() != "user":
+            continue
+        turn_values = value_tokens(str(turn.get("content") or ""))
+        turn_id = int(turn.get("id") or -1)
+        if turn_values & gold_values:
+            gold_turns.append(turn_id)
+        if turn_values & predicted_values:
+            predicted_turns.append(turn_id)
+    if not gold_turns:
+        verdict = "gold_value_not_exact_in_user"
+    elif predicted_turns and max(predicted_turns) > max(gold_turns):
+        verdict = "gold_precedes_later_prediction"
+    else:
+        verdict = "review"
+    return {
+        "verdict": verdict,
+        "gold_values": sorted(gold_values),
+        "predicted_values": sorted(predicted_values),
+        "gold_turns": gold_turns,
+        "predicted_turns": predicted_turns,
+    }
+
+
+def _mean(values: list[float]) -> float:
+    return fmean(values) if values else 0.0
+
+
+def _mean_or_none(values: list[float]) -> float | None:
+    return fmean(values) if values else None
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def analyze(
+    result_payload: dict,
+    sources: dict[str, str],
+    conversations: dict[str, dict],
+    categories: set[str],
+) -> dict:
+    per_query = []
+    for row in result_payload.get("results") or []:
+        meta = row.get("meta") or {}
+        category = str(meta.get("question_category") or "")
+        if category not in categories:
+            continue
+        conversation_id = str(meta.get("conversation_id") or "")
+        if conversation_id not in sources or conversation_id not in conversations:
+            raise ValueError(f"missing source conversation {conversation_id!r}")
+        score = float(row.get("score") or 0.0)
+        item_funnel = lexical_funnel(row, sources[conversation_id])
+        analyzed = {
+            "query_id": row.get("query_id"),
+            "category": category,
+            "score": score,
+            "items": item_funnel,
+            "speaker_provenance": speaker_provenance(row),
+        }
+        if category == "knowledge_update" and score == 0.0:
+            analyzed["knowledge_update"] = knowledge_update_verdict(
+                row, conversations[conversation_id]
+            )
+        per_query.append(analyzed)
+
+    summaries = {}
+    for category in sorted(categories):
+        rows = [row for row in per_query if row["category"] == category]
+        items = [item for row in rows for item in row["items"]]
+        stages = Counter(item["stage"] for item in items)
+        zero_rows = [row for row in rows if row["score"] == 0.0]
+        knowledge_verdicts = Counter(
+            row["knowledge_update"]["verdict"]
+            for row in zero_rows
+            if "knowledge_update" in row
+        )
+        summaries[category] = {
+            "rows": len(rows),
+            "mean_score": _mean([row["score"] for row in rows]),
+            "zero_score_rows": len(zero_rows),
+            "reference_items": len(items),
+            "mean_source_coverage": _mean_or_none(
+                [item["source_coverage"] for item in items]
+            ),
+            "mean_source_normalized_context_retention": _mean_or_none(
+                [item["source_normalized_context_retention"] for item in items]
+            ),
+            "mean_source_normalized_answer_retention": _mean_or_none(
+                [item["source_normalized_answer_retention"] for item in items]
+            ),
+            "item_stages": dict(sorted(stages.items())),
+            "mean_assistant_only_supported_ratio": _mean(
+                [
+                    row["speaker_provenance"]["assistant_only_supported_ratio"]
+                    for row in rows
+                ]
+            ),
+            "zero_rows_assistant_only_dominant": sum(
+                row["speaker_provenance"]["assistant_only_dominant"]
+                for row in zero_rows
+            ),
+            "knowledge_update_zero_verdicts": dict(sorted(knowledge_verdicts.items())),
+        }
+
+    return {
+        "protocol": "beam-category-loss-funnel-v1",
+        "thresholds": {
+            "source_support": SOURCE_SUPPORT_THRESHOLD,
+            "context_and_answer_retention": RETENTION_THRESHOLD,
+        },
+        "categories": summaries,
+        "results": per_query,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results", type=Path)
+    parser.add_argument("documents", type=Path)
+    parser.add_argument(
+        "--categories",
+        default=",".join(DEFAULT_CATEGORIES),
+        help="Comma-separated BEAM categories.",
+    )
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+
+    categories = {value.strip() for value in args.categories.split(",") if value.strip()}
+    if not categories:
+        parser.error("--categories must contain at least one category")
+    result_payload = json.loads(args.results.read_text(encoding="utf-8-sig"))
+    output = analyze(
+        result_payload,
+        load_source_documents(args.documents),
+        load_conversations(args.documents),
+        categories,
+    )
+    output["run_config"] = {
+        "results": str(args.results),
+        "results_sha256": _sha256_file(args.results),
+        "documents": str(args.documents),
+        "documents_sha256": _sha256_file(args.documents),
+        "categories": sorted(categories),
+        "external_calls": 0,
+        "synthetic_benchmark_data_only": True,
+        "real_companion_memories_included": False,
+    }
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(output, indent=2), encoding="utf-8")
+    print(json.dumps(output["categories"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/audit_category_loss_funnel.py
+++ b/benchmarks/amb/audit_category_loss_funnel.py
@@ -320,6 +320,10 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
     baseline_percent = 100.0 - total_loss
     recoverable = total_loss - dead
     recovery_to_90 = max(90.0 - baseline_percent, 0.0)
+    shaping_sensitivity = {
+        f"{rate:.1f}": 100.0 - dead - reader_shaping * (1.0 - rate)
+        for rate in (0.0, 0.5, 0.7, 1.0)
+    }
     return {
         "complete_equal_weight_ten_category_line": complete_line,
         "baseline_score_percent": round(baseline_percent, 6),
@@ -336,6 +340,10 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
         "recoverable_share_required_to_reach_90": (
             round(recovery_to_90 / recoverable, 6) if recoverable else None
         ),
+        "reader_shaping_recovery_sensitivity": {
+            rate: round(projected, 6)
+            for rate, projected in shaping_sensitivity.items()
+        },
         "assumptions": {
             "dead": (
                 "knowledge-update label-defect share plus multi-session "
@@ -349,6 +357,10 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
                 "summarization and provenance-attributed abstention shares"
             ),
             "optimistic_ceiling": "full recovery of every point not classified dead",
+            "reader_shaping_sensitivity": (
+                "projected score at each reader-loss recovery rate, assuming full "
+                "recovery of every other non-dead bucket"
+            ),
         },
     }
 

--- a/benchmarks/amb/cap_contexts_to_reference_budget.py
+++ b/benchmarks/amb/cap_contexts_to_reference_budget.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Cap treatment contexts to each reference row's token budget."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+try:
+    from .reorder_speaker_first_contexts import split_memory_blocks
+except ImportError:  # pragma: no cover - direct script execution
+    from reorder_speaker_first_contexts import split_memory_blocks
+
+
+def load_rows(path: Path) -> list[dict]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    return payload if isinstance(payload, list) else payload.get("results") or []
+
+
+def cap_context(
+    context: str,
+    token_budget: int,
+    token_counter: Callable[[str], int],
+) -> tuple[str, dict]:
+    if token_budget < 1:
+        raise ValueError("token budget must be positive")
+    blocks = split_memory_blocks(context)
+    treatment_tokens_before = token_counter(context)
+    low = 1
+    high = len(blocks)
+    selected_count = 0
+    selected_tokens = 0
+    while low <= high:
+        middle = (low + high) // 2
+        candidate_tokens = token_counter("".join(blocks[:middle]))
+        if candidate_tokens <= token_budget:
+            selected_count = middle
+            selected_tokens = candidate_tokens
+            low = middle + 1
+        else:
+            high = middle - 1
+    if selected_count == 0:
+        raise ValueError("first treatment memory block exceeds the reference budget")
+    capped = "".join(blocks[:selected_count])
+    return capped, {
+        "reference_token_budget": token_budget,
+        "treatment_tokens_before": treatment_tokens_before,
+        "treatment_tokens_after": selected_tokens,
+        "blocks_before": len(blocks),
+        "blocks_after": selected_count,
+        "prefix_preserved": True,
+    }
+
+
+def transform(
+    reference_rows: list[dict],
+    treatment_rows: list[dict],
+    token_counter: Callable[[str], int],
+) -> dict:
+    treatment_by_id = {
+        str(row.get("query_id") or ""): row
+        for row in treatment_rows
+        if row.get("query_id")
+    }
+    output_rows = []
+    for reference in reference_rows:
+        query_id = str(reference.get("query_id") or "")
+        treatment = treatment_by_id.get(query_id)
+        if treatment is None:
+            raise ValueError(f"treatment is missing query {query_id!r}")
+        reference_context = str(reference.get("context") or "")
+        treatment_context = str(treatment.get("context") or "")
+        if not reference_context.strip() or not treatment_context.strip():
+            raise ValueError(f"empty context for query {query_id!r}")
+        capped, audit = cap_context(
+            treatment_context,
+            token_counter(reference_context),
+            token_counter,
+        )
+        output_rows.append(
+            {
+                "query_id": query_id,
+                "query": treatment.get("query") or reference.get("query"),
+                "gold_answers": treatment.get("gold_answers")
+                or reference.get("gold_answers"),
+                "context": capped,
+                "budget_audit": audit,
+            }
+        )
+    total_reference = sum(
+        token_counter(str(row.get("context") or "")) for row in reference_rows
+    )
+    total_treatment = sum(
+        row["budget_audit"]["treatment_tokens_after"] for row in output_rows
+    )
+    return {
+        "artifact_transform": {
+            "name": "reference-token-budget-prefix-cap-v1",
+            "selection_order_changed": False,
+            "whole_memory_blocks_only": True,
+            "external_calls": 0,
+            "rows": len(output_rows),
+            "reference_context_tokens": total_reference,
+            "treatment_context_tokens": total_treatment,
+            "treatment_within_reference_budget": total_treatment <= total_reference,
+        },
+        "results": output_rows,
+    }
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    from memory_bench.utils import count_tokens
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("reference", type=Path)
+    parser.add_argument("treatment", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    output = transform(
+        load_rows(args.reference),
+        load_rows(args.treatment),
+        count_tokens,
+    )
+    output["artifact_transform"].update(
+        {
+            "reference_sha256": _sha256_file(args.reference),
+            "treatment_sha256": _sha256_file(args.treatment),
+            "synthetic_benchmark_data_only": True,
+            "real_companion_memories_included": False,
+        }
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2), encoding="utf-8")
+    print(json.dumps(output["artifact_transform"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_amb_audit_category_loss_funnel.py
+++ b/tests/test_amb_audit_category_loss_funnel.py
@@ -1,4 +1,4 @@
-from benchmarks.amb.audit_category_loss_funnel import analyze
+from benchmarks.amb.audit_category_loss_funnel import analyze, ceiling_estimate
 
 
 def _row(query_id, category, query, answer, gold, context, rubric=None):
@@ -110,3 +110,58 @@ def test_analyze_separates_retrieval_answer_label_and_provenance_losses():
         "unit": "zero_score_rows",
     }
     assert summaries["abstention"]["equal_weight_overall_points_lost"] == 10.0
+
+
+def test_ceiling_estimate_conserves_full_line_loss():
+    means = {
+        "abstention": 0.675,
+        "contradiction_resolution": 0.828125,
+        "event_ordering": 0.2907143,
+        "information_extraction": 0.7734375,
+        "instruction_following": 0.7875,
+        "knowledge_update": 0.63125,
+        "multi_session_reasoning": 0.6108333,
+        "preference_following": 0.9125,
+        "summarization": 0.5929911,
+        "temporal_reasoning": 0.4125,
+    }
+    payload = {
+        "results": [
+            {"score": score, "meta": {"question_category": category}}
+            for category, score in means.items()
+        ]
+    }
+    summaries = {
+        "summarization": {
+            "attribution": {
+                "ours": {"count": 22, "denominator": 195},
+                "reader": {"count": 131, "denominator": 195},
+            }
+        },
+        "knowledge_update": {
+            "attribution": {"label": {"count": 11, "denominator": 14}}
+        },
+        "multi_session_reasoning": {
+            "attribution": {
+                "reader": {"count": 30, "denominator": 40},
+                "synthesis_required": {"count": 2, "denominator": 40},
+            }
+        },
+        "abstention": {
+            "attribution": {
+                "ours": {"count": 7, "denominator": 13},
+                "reader": {"count": 6, "denominator": 13},
+            }
+        },
+    }
+
+    estimate = ceiling_estimate(payload, summaries)
+
+    assert estimate["complete_equal_weight_ten_category_line"] is True
+    assert estimate["baseline_score_percent"] == 65.148512
+    assert estimate["points_required_to_reach_90"] == 24.851488
+    assert estimate["optimistic_ceiling_percent"] == 96.908095
+    assert estimate["bucket_conservation_delta"] == 0.0
+    assert abs(
+        sum(estimate["buckets"].values()) - estimate["total_points_lost"]
+    ) <= 2e-6

--- a/tests/test_amb_audit_category_loss_funnel.py
+++ b/tests/test_amb_audit_category_loss_funnel.py
@@ -1,4 +1,9 @@
-from benchmarks.amb.audit_category_loss_funnel import analyze, ceiling_estimate
+from benchmarks.amb.audit_category_loss_funnel import (
+    analyze,
+    behavior_target_funnel,
+    ceiling_estimate,
+    reference_items,
+)
 
 
 def _row(query_id, category, query, answer, gold, context, rubric=None):
@@ -15,6 +20,73 @@ def _row(query_id, category, query, answer, gold, context, rubric=None):
             "rubric": rubric or [],
         },
     }
+
+
+def test_reference_items_use_rubric_claims_for_tail_categories():
+    for category in (
+        "information_extraction",
+        "instruction_following",
+        "preference_following",
+    ):
+        row = _row(
+            f"1_{category}_0",
+            category,
+            "Question",
+            "Answer",
+            ["coarse gold"],
+            "context",
+            [
+                "LLM response should contain: first claim",
+                "LLM response should state: second claim",
+                "LLM response should mention: third claim",
+            ],
+        )
+        assert reference_items(row) == [
+            "first claim",
+            "second claim",
+            "third claim",
+        ]
+
+    contradiction = _row(
+        "1_contradiction_resolution_0",
+        "contradiction_resolution",
+        "Question",
+        "Answer",
+        [],
+        "context",
+        [
+            "LLM response should state: conflicting information",
+            "LLM response should mention: first evidence claim",
+            "LLM response should mention: second evidence claim",
+            "LLM response should mention: which statement is correct?",
+        ],
+    )
+    assert reference_items(contradiction) == [
+        "first evidence claim",
+        "second evidence claim",
+    ]
+
+
+def test_behavior_target_funnel_uses_canonical_instruction():
+    row = _row(
+        "1_instruction_following_0",
+        "instruction_following",
+        "Question",
+        "Answer",
+        [],
+        "## Memory 1\nAlways use APA 7th edition citations when formatting references.",
+    )
+    row["meta"]["instruction_being_tested"] = (
+        "Always use APA 7th edition citations when formatting references."
+    )
+
+    target = behavior_target_funnel(
+        row, "User: Always use APA 7th edition citations when formatting references."
+    )
+
+    assert target is not None
+    assert target["stage"] == "target_retrieved"
+    assert target["source_coverage"] == 1.0
 
 
 def test_analyze_separates_retrieval_answer_label_and_provenance_losses():
@@ -171,3 +243,40 @@ def test_ceiling_estimate_conserves_full_line_loss():
     assert abs(
         sum(estimate["buckets"].values()) - estimate["total_points_lost"]
     ) <= 2e-6
+
+    full_summaries = {
+        **summaries,
+        "contradiction_resolution": {
+            "attribution": {
+                "ours": {"count": 1, "denominator": 80},
+                "reader": {"count": 32, "denominator": 80},
+            }
+        },
+        "information_extraction": {
+            "attribution": {
+                "ours": {"count": 4, "denominator": 92},
+                "reader": {"count": 41, "denominator": 92},
+            }
+        },
+        "instruction_following": {
+            "attribution": {
+                "ours": {"count": 3.5, "denominator": 8.5},
+                "reader": {"count": 5.0, "denominator": 8.5},
+            }
+        },
+        "preference_following": {
+            "attribution": {
+                "ours": {"count": 1.0, "denominator": 3.5},
+                "reader": {"count": 2.5, "denominator": 3.5},
+            }
+        },
+    }
+    full_estimate = ceiling_estimate(payload, full_summaries)
+    assert full_estimate["buckets"] == {
+        "dead_or_benchmark_integrity": 3.091905,
+        "reader_via_context_shaping": 10.725196,
+        "ours_direct_engine": 16.422036,
+        "undiagnosed_tail": 0,
+        "audited_residual": 4.612351,
+    }
+    assert full_estimate["reader_shaping_recovery_sensitivity"]["0.5"] == 91.545497

--- a/tests/test_amb_audit_category_loss_funnel.py
+++ b/tests/test_amb_audit_category_loss_funnel.py
@@ -161,6 +161,12 @@ def test_ceiling_estimate_conserves_full_line_loss():
     assert estimate["baseline_score_percent"] == 65.148512
     assert estimate["points_required_to_reach_90"] == 24.851488
     assert estimate["optimistic_ceiling_percent"] == 96.908095
+    assert estimate["reader_shaping_recovery_sensitivity"] == {
+        "0.0": 89.75508,
+        "0.5": 93.331588,
+        "0.7": 94.762191,
+        "1.0": 96.908095,
+    }
     assert estimate["bucket_conservation_delta"] == 0.0
     assert abs(
         sum(estimate["buckets"].values()) - estimate["total_points_lost"]

--- a/tests/test_amb_audit_category_loss_funnel.py
+++ b/tests/test_amb_audit_category_loss_funnel.py
@@ -101,3 +101,12 @@ def test_analyze_separates_retrieval_answer_label_and_provenance_losses():
     assert summaries["knowledge_update"]["knowledge_update_zero_verdicts"] == {
         "gold_precedes_later_prediction": 1
     }
+    assert summaries["knowledge_update"]["attribution"]["primary"] == "benchmark_label"
+    assert summaries["knowledge_update"]["attribution"]["label"]["count"] == 1
+    assert summaries["summarization"]["attribution"]["reader"]["count"] == 0
+    assert summaries["abstention"]["attribution"]["ours"] == {
+        "count": 1,
+        "denominator": 1,
+        "unit": "zero_score_rows",
+    }
+    assert summaries["abstention"]["equal_weight_overall_points_lost"] == 10.0

--- a/tests/test_amb_audit_category_loss_funnel.py
+++ b/tests/test_amb_audit_category_loss_funnel.py
@@ -1,0 +1,103 @@
+from benchmarks.amb.audit_category_loss_funnel import analyze
+
+
+def _row(query_id, category, query, answer, gold, context, rubric=None):
+    return {
+        "query_id": query_id,
+        "query": query,
+        "answer": answer,
+        "gold_answers": gold,
+        "context": context,
+        "score": 0.0,
+        "meta": {
+            "question_category": category,
+            "conversation_id": "1",
+            "rubric": rubric or [],
+        },
+    }
+
+
+def test_analyze_separates_retrieval_answer_label_and_provenance_losses():
+    rows = [
+        _row(
+            "1_summarization_0",
+            "summarization",
+            "Summarize the project",
+            "alpha",
+            [],
+            "## Memory 1\n[Speaker: User] alpha beta",
+            ["LLM response should contain: alpha beta gamma"],
+        ),
+        _row(
+            "1_knowledge_update_0",
+            "knowledge_update",
+            "How long now?",
+            "6-9 months",
+            ["5-7 months"],
+            "## Memory 1\n[Speaker: User] 5-7 months",
+        ),
+        _row(
+            "1_multi_session_reasoning_0",
+            "multi_session_reasoning",
+            "How many areas?",
+            "28",
+            ["Four"],
+            "## Memory 1\n[Speaker: User] alpha beta",
+        ),
+        _row(
+            "1_abstention_0",
+            "abstention",
+            "What techniques did Shawn recommend?",
+            "Authenticity and weaving threads",
+            ["There is no information."],
+            "## Memory 1\n[Speaker: User] Shawn discussed storytelling impact.\n\n"
+            "## Memory 2\n[Speaker: Assistant] Try authenticity and weaving threads.",
+        ),
+    ]
+    sources = {
+        "1": "[Turn 2] User: alpha beta gamma and 5-7 months\n"
+        "[Turn 4] User: the revised estimate is 6-9 months"
+    }
+    conversations = {
+        "1": {
+            "chat": [
+                {"id": 2, "role": "user", "content": "alpha beta gamma and 5-7 months"},
+                {"id": 4, "role": "user", "content": "the revised estimate is 6-9 months"},
+            ]
+        }
+    }
+
+    report = analyze(
+        {"results": rows},
+        sources,
+        conversations,
+        {
+            "summarization",
+            "knowledge_update",
+            "multi_session_reasoning",
+            "abstention",
+        },
+    )
+
+    by_id = {row["query_id"]: row for row in report["results"]}
+    assert by_id["1_summarization_0"]["items"][0]["stage"] == "retrieval_loss"
+    assert (
+        by_id["1_knowledge_update_0"]["knowledge_update"]["verdict"]
+        == "gold_precedes_later_prediction"
+    )
+    assert (
+        by_id["1_multi_session_reasoning_0"]["items"][0]["stage"]
+        == "synthesis_required"
+    )
+    provenance = by_id["1_abstention_0"]["speaker_provenance"]
+    assert provenance["assistant_only_dominant"] is True
+    assert {"authenticity", "weaving"} <= set(provenance["assistant_only_answer_tokens"])
+
+    summaries = report["categories"]
+    assert summaries["summarization"]["item_stages"] == {"retrieval_loss": 1}
+    assert summaries["abstention"]["reference_items"] == 0
+    assert summaries["abstention"]["mean_source_coverage"] is None
+    assert summaries["abstention"]["zero_rows_assistant_only_dominant"] == 1
+    assert summaries["knowledge_update"]["knowledge_update_zero_verdicts"] == {
+        "gold_precedes_later_prediction": 1
+    }

--- a/tests/test_amb_cap_contexts_to_reference_budget.py
+++ b/tests/test_amb_cap_contexts_to_reference_budget.py
@@ -1,0 +1,43 @@
+import pytest
+
+from benchmarks.amb.cap_contexts_to_reference_budget import cap_context, transform
+
+
+def test_cap_context_keeps_a_whole_ordered_prefix_within_budget():
+    context = (
+        "## Memory 1\nalpha\n\n"
+        "## Memory 2\nbeta beta\n\n"
+        "## Memory 3\ngamma gamma gamma"
+    )
+
+    capped, audit = cap_context(context, 46, len)
+
+    assert capped == "## Memory 1\nalpha\n\n## Memory 2\nbeta beta\n\n"
+    assert audit == {
+        "reference_token_budget": 46,
+        "treatment_tokens_before": len(context),
+        "treatment_tokens_after": len(capped),
+        "blocks_before": 3,
+        "blocks_after": 2,
+        "prefix_preserved": True,
+    }
+
+
+def test_transform_matches_reference_order_and_rejects_missing_queries():
+    reference = [
+        {"query_id": "q2", "context": "x" * 25},
+        {"query_id": "q1", "context": "x" * 25},
+    ]
+    treatment = [
+        {"query_id": "q1", "context": "## Memory 1\na\n## Memory 2\nb"},
+        {"query_id": "q2", "context": "## Memory 1\nc\n## Memory 2\nd"},
+    ]
+
+    output = transform(reference, treatment, len)
+
+    assert [row["query_id"] for row in output["results"]] == ["q2", "q1"]
+    assert output["artifact_transform"]["treatment_within_reference_budget"] is True
+    assert output["artifact_transform"]["external_calls"] == 0
+
+    with pytest.raises(ValueError, match="missing query"):
+        transform(reference, treatment[:1], len)


### PR DESCRIPTION
## Summary
- add a judge-free source -> context -> answer funnel for summarization, knowledge update, multi-session reasoning, and abstention
- distinguish knowledge-update chronology/label defects from product misses
- quantify answer details supported only by explicitly assistant-authored memory blocks
- add an exact whole-block prefix cap for equal-token-budget context comparisons
- preregister the next abstention discovery arm before scoring it

## Frozen ydb-0151 findings
- summarization: context retention 0.869, answer retention 0.555
- multi-session: context retention 0.908, answer retention 0.427
- knowledge update: context retention 0.988; 11/14 zeros are stale-label or absent-gold cases
- abstention: 7/13 zeros are assistant-only dominant

## Verification
- 15 focused and neighboring tests passed
- Ruff clean
- real report bound to exact result and source-document hashes
- equal-budget transform preserves retrieval order and whole memory blocks