### PR TITLE
fix(organize): route conservative count sets to items

### DIFF
--- a/src/yantrikdb/organize.py
+++ b/src/yantrikdb/organize.py
@@ -67,6 +67,30 @@ _ITEM_QUERY_RE = re.compile(
     r"\bwalk\s+me\s+through\b",
     re.IGNORECASE,
 )
+_COUNT_TOKEN = (
+    r"\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|"
+    r"twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|"
+    r"nineteen|twenty"
+)
+_EXPLICIT_SET_TOKEN = (
+    r"two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|"
+    r"thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty"
+)
+_EXPLICIT_SET_COUNT_RE = re.compile(
+    rf"\b(?:what|which)\s+(?:(?:are|were)\s+)?(?:the\s+)?"
+    rf"({_EXPLICIT_SET_TOKEN})\b",
+    re.IGNORECASE,
+)
+_HOW_MANY_SET_RE = re.compile(
+    r"\bhow\s+many\s+(?:(?:total|new)\s+)?(?:different|unique|distinct)\b|"
+    r"\bhow\s+many\s+(?:(?:total|new|different|unique|distinct)\s+)?"
+    r"(?:[^?\W]+\s+){0,3}(?:types?|kinds?|ways?|features?|concerns?|areas?)\b",
+    re.IGNORECASE,
+)
+_MENTION_FREQUENCY_RE = re.compile(
+    r"\bhow\s+many\s+times\b.*\b(?:say|said|mention|mentioned|ask|asked)\b",
+    re.IGNORECASE,
+)
 _ROLLUP_QUERY_RE = re.compile(
     r"\b(summarize|summarise|summary|overview|recap|themes?|patterns?|overall|"
     r"broadly)\b",
@@ -78,11 +102,10 @@ _CONVERSATION_ORDER_RE = re.compile(
 )
 _ITEM_COUNT_RE = re.compile(
     r"\b(?:only(?:\s+and\s+only)?|exactly)\s+"
-    r"(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|"
-    r"twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|"
-    r"nineteen|twenty)\b",
+    rf"({_COUNT_TOKEN})\b",
     re.IGNORECASE,
 )
+_MAX_REQUESTED_ITEM_COUNT = 20
 _COUNT_WORDS = {
     "one": 1,
     "two": 2,
@@ -482,8 +505,18 @@ def _occurrence_key(occurrence: Mapping) -> tuple:
     )
 
 
+def _asks_for_countable_items(query: str) -> bool:
+    if _MENTION_FREQUENCY_RE.search(query):
+        return False
+    return bool(
+        _HOW_MANY_SET_RE.search(query) or _EXPLICIT_SET_COUNT_RE.search(query)
+    )
+
+
 def _organization_query_mode(query: str) -> str | None:
-    asks_for_items = bool(_ITEM_QUERY_RE.search(query))
+    asks_for_items = bool(_ITEM_QUERY_RE.search(query)) or _asks_for_countable_items(
+        query
+    )
     asks_for_rollup = bool(_ROLLUP_QUERY_RE.search(query))
     if asks_for_items == asks_for_rollup:
         return None
@@ -589,17 +622,19 @@ def _entity_focus_source(
 
 
 def _requested_item_count(query: str) -> int | None:
-    match = _ITEM_COUNT_RE.search(query)
+    match = _ITEM_COUNT_RE.search(query) or _EXPLICIT_SET_COUNT_RE.search(query)
     if match is None:
         return None
     value = match.group(1).casefold()
-    return int(value) if value.isdigit() else _COUNT_WORDS[value]
+    count = int(value) if value.isdigit() else _COUNT_WORDS[value]
+    # Expansion is deliberately bounded even when a query requests a huge list.
+    return min(count, _MAX_REQUESTED_ITEM_COUNT)
 
 
 def _rollup_query_shape(query: str) -> str:
     if _ROLLUP_QUERY_RE.search(query):
         return "summary"
-    if _ITEM_QUERY_RE.search(query):
+    if _ITEM_QUERY_RE.search(query) or _asks_for_countable_items(query):
         if _CONVERSATION_ORDER_RE.search(query) or re.search(
             r"\b(order|ordered|sequence|timeline|stages)\b|"
             r"\bwalk\s+me\s+through\b",

--- a/tests/test_organize.py
+++ b/tests/test_organize.py
@@ -4,7 +4,9 @@ import pytest
 
 from yantrikdb import YantrikDB
 from yantrikdb.organize import (
+    _organization_query_mode,
     _requested_item_count,
+    _rollup_query_shape,
     ConcernItem,
     ConcernPlan,
     OrganizationPlan,
@@ -856,6 +858,62 @@ def test_named_entity_focus_deduplicates_repeated_concern_wording():
 def test_named_entity_focus_parses_exact_count_through_twenty():
     assert _requested_item_count("List exactly twelve items about Carla") == 12
     assert _requested_item_count("Mention only twenty items about Carla") == 20
+
+
+def test_count_set_queries_route_to_atomic_items_conservatively():
+    assert _organization_query_mode("How many different shoe sizes did I mention?") == "items"
+    assert _organization_query_mode("How many total ways did I mention across sessions?") == "items"
+    assert _organization_query_mode("What are the two patent deadlines?") == "items"
+    assert _organization_query_mode("Which three events did David plan?") == "items"
+    assert _rollup_query_shape("How many different shoe sizes did I mention?") == "list"
+
+
+def test_count_set_auto_routing_selects_concerns_without_rerouting_duration():
+    raw = _recall_hit("raw", 0.9)
+    concern = _recall_hit(
+        "concern",
+        0.8,
+        metadata={"organizer_kind": "query_independent_concern"},
+    )
+    db = RecallDB([raw, concern])
+
+    count_results = recall_organized(
+        db,
+        "How many different shoe sizes did I mention?",
+        top_k=1,
+        candidate_pool=10,
+    )
+    duration_results = recall_organized(
+        db,
+        "How many days passed between the two deadlines?",
+        top_k=1,
+        candidate_pool=10,
+    )
+
+    assert [result["rid"] for result in count_results] == ["concern"]
+    assert [result["rid"] for result in duration_results] == ["raw"]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "How many times did I mention revising my cover letter?",
+        "What are the reasons I changed projects?",
+        "How much did my accuracy improve?",
+        "How many days passed between the two deadlines?",
+        "How many commits have merged into main?",
+        "Which one is currently faster?",
+        "How many themes appear in my history summary?",
+    ],
+)
+def test_count_set_queries_abstain_on_ambiguous_forms(query):
+    assert _organization_query_mode(query) != "items"
+
+
+def test_requested_item_count_parses_explicit_sets_and_caps_expansion():
+    assert _requested_item_count("What are the two patent deadlines?") == 2
+    assert _requested_item_count("Which three events did David plan?") == 3
+    assert _requested_item_count("List exactly 999 items") == 20
 
 
 def test_organized_recall_focuses_a_multi_token_concern():


### PR DESCRIPTION
## Summary
- route conservative distinct-count and explicitly numbered set queries to organized atomic items
- keep mention-frequency, duration arithmetic, How much, unnumbered sets, and summary ambiguities off the item route
- cap explicit requested item expansion at 20

This is routing plumbing for the atomic-facet organizer work; it is not sufficient by itself to claim a multi-session benchmark lift.

## Verification
- 	ests/test_organize.py: 46 passed
- Ruff: clean
- query-only audit over 400 frozen BEAM prompts: 13 new item-route fires, all in multi_session_reasoning; zero cross-category fires