### PR TITLE
bench(amb): verify standing-instruction facet rollout

### DIFF
--- a/benchmarks/amb/STANDING_INSTRUCTION_FULL400_PREREGISTRATION.md
+++ b/benchmarks/amb/STANDING_INSTRUCTION_FULL400_PREREGISTRATION.md
@@ -1,0 +1,62 @@
+# AMB Standing-Instruction Full-400 Preregistration
+
+Status: frozen preflight only. No external calls have been made for this arm.
+Run only after the product persistence and recall replay reproduces the frozen
+treatment contract.
+
+## Question
+
+Does exposing the complete, authoritative standing-instruction set improve its
+target category without degrading unrelated BEAM behavior when applied across
+the entire benchmark?
+
+## Frozen Arm
+
+- Cohort: all 400 rows from frozen `ydb-0151`.
+- Control: unchanged `ydb-0151` contexts.
+- Treatment: every user-authored turn beginning with `Always` from the same
+  conversation unit, in source-turn order, before ordinary memories.
+- Extraction is query-independent and does not inspect gold, rubrics, answers,
+  or scores.
+- Each treatment row is capped independently to its control token budget using
+  complete memory blocks. The instruction panel is never truncated.
+- Model: `deepseek-v4-flash:0731-cloud`.
+- Evaluation: one answer and one judge per arm per row.
+- Synthetic benchmark data only; no real companion memories.
+
+## Frozen Hashes And Budget
+
+- Source result SHA-256: `43b8eb888adeb524caba70b013a8ca510c639bbf5312216e9b453d60185bcb8e`.
+- Source documents SHA-256: `fc0e64bac38fcde26eece776e818f70374338d4591ecc75346cb27b613d4c128`.
+- Treatment artifact SHA-256: `5ae03eade3a39c1fbaa3cf84eb9e0a2b64d50f179d6270eb8d9b5a645f051236`.
+- Manifest SHA-256: `a08be2ed0c8f07c5224350717af8bbceaa3ea1e20da815059532f6ccf97cdbce`.
+- Ordered query-ID SHA-256: `08b325da5c5a9830bdc94cb25fc09a74c5e4dc06b70e433911b27c5352901b52`.
+- Control arm: 400 rows, 5,913,445 tokens, SHA-256
+  `918f572927b75ab1bb2ae3edf5656eada132cf9a644953f31bf693c695d46863`.
+- Treatment arm: 400 rows, 5,782,046 tokens, SHA-256
+  `551662988effa63397928146b73775eac653fc0c37cf29ea23b018aded6838e3`.
+- Projected calls: 800 answers and 800 judges.
+
+## Gates
+
+All gates must pass for default-on promotion:
+
+1. `instruction_following` treatment minus control is at least `+0.05`, with
+   more wins than losses.
+2. Overall treatment minus control is non-negative, and its paired bootstrap
+   95% lower bound is at least `-0.01`.
+3. The pooled mean delta across the other nine categories is at least `-0.01`.
+4. No non-instruction category mean delta is below `-0.025`.
+
+Every category mean, paired win/tie/loss count, and bootstrap interval is
+reported regardless of outcome. A failure keeps the feature opt-in and does not
+authorize tuning the detector or thresholds against these results.
+
+## Product Replay Requirement
+
+Before model calls, an implementation-backed replay must prove that persisted
+`standing_instruction` facets reconstruct the same ordered instruction panels
+for all 400 query IDs, use only verified user evidence, stay within each frozen
+token budget, and preserve the manifest hashes above. If product behavior
+intentionally differs, it requires a new artifact and preregistration rather
+than silently reusing this arm.

--- a/benchmarks/amb/STANDING_INSTRUCTION_FULL400_PREREGISTRATION.md
+++ b/benchmarks/amb/STANDING_INSTRUCTION_FULL400_PREREGISTRATION.md
@@ -1,8 +1,8 @@
 # AMB Standing-Instruction Full-400 Preregistration
 
-Status: frozen preflight only. No external calls have been made for this arm.
-Run only after the product persistence and recall replay reproduces the frozen
-treatment contract.
+Status: completed. Product replay passed, but the external acceptance run
+failed two of four preregistered gates. Global default-on promotion is rejected;
+the standing-instruction lane remains opt-in.
 
 ## Question
 
@@ -60,3 +60,58 @@ for all 400 query IDs, use only verified user evidence, stay within each frozen
 token budget, and preserve the manifest hashes above. If product behavior
 intentionally differs, it requires a new artifact and preregistration rather
 than silently reusing this arm.
+
+## Product Replay Result
+
+The requirement passed before any external calls. A database containing all
+5,732 raw turns from the 20 benchmark conversations persisted 90 source-keyed
+standing-instruction facets. The store was closed and reopened, then the public
+`recall_facets` lane reconstructed and whole-block-capped all 400 treatment
+contexts without query, gold, rubric, answer, or score access during
+extraction.
+
+All 400 contexts matched the frozen treatment byte for byte, with zero panel or
+context mismatches and identical ordered query IDs. The reconstructed artifact
+SHA-256 was
+`551662988effa63397928146b73775eac653fc0c37cf29ea23b018aded6838e3`,
+exactly matching the preregistered treatment arm. The replay made no model or
+network calls, so it did not consume or alter the external acceptance run.
+
+## Full-400 Acceptance Result
+
+The frozen run completed all 400 pairs in 7,020.5 seconds with no failed pairs.
+Its result SHA-256 is
+`0b30ebe5fbf045785a8c3dcbd33fbb4b1d117b456954a983eb208024a4948b64`.
+
+| cohort | control | treatment | delta | paired 95% CI | W/T/L |
+|---|---:|---:|---:|---:|---:|
+| all 400 | 0.62967 | 0.63182 | +0.00215 | [-0.02316, +0.02731] | 60/275/65 |
+| instruction following | 0.78750 | 0.86250 | +0.07500 | [+0.01250, +0.15000] | 5/34/1 |
+| other nine pooled | 0.61213 | 0.60619 | -0.00595 | [-0.03340, +0.02140] | 55/241/64 |
+
+The complete category result was:
+
+| category | control | treatment | delta | paired 95% CI | W/T/L |
+|---|---:|---:|---:|---:|---:|
+| abstention | 0.67500 | 0.65000 | -0.02500 | [-0.15000, +0.10000] | 3/33/4 |
+| contradiction resolution | 0.85313 | 0.85313 | +0.00000 | [-0.04063, +0.04375] | 5/29/6 |
+| event ordering | 0.27069 | 0.24997 | -0.02072 | [-0.06572, +0.02110] | 12/13/15 |
+| information extraction | 0.75677 | 0.74271 | -0.01406 | [-0.11198, +0.09063] | 7/25/8 |
+| instruction following | 0.78750 | 0.86250 | +0.07500 | [+0.01250, +0.15000] | 5/34/1 |
+| knowledge update | 0.51875 | 0.58125 | +0.06250 | [-0.03750, +0.17500] | 5/33/2 |
+| multi-session reasoning | 0.56458 | 0.55062 | -0.01396 | [-0.07792, +0.05208] | 5/26/9 |
+| preference following | 0.88750 | 0.86250 | -0.02500 | [-0.07500, +0.02500] | 2/34/4 |
+| summarization | 0.57025 | 0.54049 | -0.02976 | [-0.09223, +0.02545] | 11/16/13 |
+| temporal reasoning | 0.41250 | 0.42500 | +0.01250 | [-0.07500, +0.08750] | 5/32/3 |
+
+Gate 1 passed: instruction following improved by `+0.075`, with five wins
+against one loss. Gate 2 failed: the overall mean was non-negative, but the
+confidence-interval lower bound (`-0.02316`) was below the `-0.01` floor. Gate
+3 passed: the other-nine pooled delta was `-0.00595`. Gate 4 failed:
+summarization fell by `-0.02976`, below its `-0.025` floor.
+
+Per the frozen decision rule, the authoritative standing-instruction facet is
+validated for its target behavior but must not be globally injected by
+default. Product rollout remains explicit or query-scoped until a separately
+preregistered mechanism can preserve the instruction lift without paying the
+unrelated-category context cost.

--- a/benchmarks/amb/STANDING_INSTRUCTION_FULL400_PREREGISTRATION.md
+++ b/benchmarks/amb/STANDING_INSTRUCTION_FULL400_PREREGISTRATION.md
@@ -115,3 +115,32 @@ validated for its target behavior but must not be globally injected by
 default. Product rollout remains explicit or query-scoped until a separately
 preregistered mechanism can preserve the instruction lift without paying the
 unrelated-category context cost.
+
+## Post-Run Displacement Diagnosis
+
+This section is diagnostic only. It was written after the frozen acceptance
+result, makes no causal or promotion claim, and does not authorize threshold
+tuning against the full-400 scores.
+
+The equal-budget transform inserted one instruction panel and retained a
+prefix of the original memory blocks. A deterministic audit verified that
+relationship for every row and found that all 400 treatments displaced at
+least one original block: `1.155` blocks and `434.54` tokens per row on
+average. The target instruction cohort displaced `453.75` tokens per row but
+had no rows where a conservative gold-answer bigram appeared only in removed
+context. Summarization displaced `433.43` tokens per row and contained four of
+the seven such lexical source-loss cases across the full cohort.
+
+The lexical overlap is only a proxy: it neither proves that displacement
+caused a score change nor captures paraphrased evidence. Its value is that it
+confirms the proposed failure mechanism is reachable, including in the one
+category that crossed the preregistered harm floor. A post-hoc category oracle
+that uses treatment only for `instruction_following` and control everywhere
+else would score `0.63717`, or `+0.00750` over control, while preserving the
+observed `+0.075` target lift. That oracle is not deployable or fresh evidence;
+it identifies query-gated composition as the next mechanism to preregister.
+
+The reproducible audit is
+`benchmarks/amb/analyze_standing_instruction_displacement.py`; its full local
+row-level artifact is excluded from version control with the other model-run
+outputs.

--- a/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
+++ b/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
@@ -87,3 +87,32 @@ Replication passes only if treatment minus control is at least `+0.05` and its
 paired bootstrap 95% interval excludes zero. The result is reported regardless
 of outcome. This design tests category-level replication across model sessions;
 it does not claim stable verdicts for individual rows.
+
+## Replication Result
+
+The fresh-process replication passed both gates:
+
+| arm | discovery | replication |
+|---|---:|---:|
+| frozen `ydb-0151` control | 0.80000 | 0.75000 |
+| standing-instruction treatment | 0.90000 | 0.89375 |
+| treatment minus control | +0.10000 | +0.14375 |
+
+Replication produced 9 wins, 30 ties, and 1 loss. Its paired bootstrap 95%
+interval was `[+0.05625, +0.24375]`; all 40 pairs completed in 512.5 seconds.
+The replication result SHA-256 is
+`f7d2a4b507337148fb0ef81cb0326ba7eeffbf783c37e448589748aa7ffc8237`.
+
+Four treatment wins repeated across both runs, while neither losing row did.
+Two rows reversed direction between sessions. That is consistent with the
+known row-level generation variance and supports the category-level replication
+design: the treatment mean stayed nearly fixed (`0.90000` to `0.89375`) while
+the control moved by `-0.05000`. Mean treatment lift across the two independent
+runs was `+0.121875`.
+
+The two-of-two result promotes authoritative standing instructions from a
+benchmark hypothesis to a product candidate. Product behavior should preserve
+the tested mechanism: user-authored provenance, typed `standing_instruction`
+records, source turn/evidence links, namespace isolation, and recall-time
+salience ahead of ordinary memories. It must not promote assistant
+acknowledgements or infer general preferences from this narrow detector.

--- a/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
+++ b/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
@@ -116,3 +116,33 @@ the tested mechanism: user-authored provenance, typed `standing_instruction`
 records, source turn/evidence links, namespace isolation, and recall-time
 salience ahead of ordinary memories. It must not promote assistant
 acknowledgements or infer general preferences from this narrow detector.
+
+## Product Replay Result
+
+The product-backed replay passed the final equivalence gate. The reviewed
+`standing_instruction` facet implementation was built as a Python wheel, then
+the frozen source histories were replayed through the public product surfaces:
+
+1. All 5,732 raw user and assistant turns from the 20 relevant conversations
+   were recorded with source role, namespace, source-turn metadata, and
+   deterministic historical ordering.
+2. `extract_standing_instructions` persisted 90 source-keyed facets and their
+   evidence dependencies at write time.
+3. The database was closed and reopened before `recall_facets`, proving the
+   result came from persisted product state rather than process-local objects.
+4. Facet source RIDs were mapped back to source turns, rendered with the frozen
+   panel format, and capped with the unchanged whole-block budget rule.
+
+All 40 treatment contexts matched the evaluated frozen contexts byte for byte,
+with zero panel or context mismatches. The reconstructed paired artifact's
+SHA-256 was
+`c3d7f8799cefcdd25b0b499de31b0ef4531b92e5881333b1153e868f6196aa87`,
+exactly matching the artifact used by both scored runs. Extraction did not
+receive queries, gold answers, rubrics, or scores, and the replay made no model
+or network calls.
+
+This closes the product-equivalence condition: the replicated category lift is
+reachable through persisted YantrikDB facets, not only through the original
+benchmark-side transform. It does not close the separately deferred typed
+submission API, turn-native recall metadata, auditable hit fields, or mounted
+pack support described by the product contract.

--- a/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
+++ b/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
@@ -1,0 +1,49 @@
+# AMB Standing-Instruction Salience Preregistration
+
+## Hypothesis
+
+Explicit user turns beginning with `Always` are authoritative standing
+instructions. Persisting them as typed records and presenting the complete
+unit-level set before ordinary memories will improve instruction-following
+without inferring preferences from assistant prose.
+
+## Frozen Arm
+
+- Cohort: all 40 `instruction_following` rows from frozen `ydb-0151`.
+- Control: frozen `ydb-0151` context.
+- Treatment: every user-authored `Always ...` turn from the same conversation
+  unit, in source-turn order, prepended as a standing-instruction panel.
+- Extraction is query-independent and does not inspect gold, rubrics, answers,
+  or scores.
+- Treatment is capped to each control row's exact token budget using whole
+  memory blocks. The standing-instruction panel is never truncated.
+- Model: `deepseek-v4-flash:0731-cloud`.
+- Discovery: one answer and one judge per arm per row.
+
+## Frozen Preflight
+
+- Source result SHA-256: `43b8eb888adeb524caba70b013a8ca510c639bbf5312216e9b453d60185bcb8e`.
+- Source documents SHA-256: `fc0e64bac38fcde26eece776e818f70374338d4591ecc75346cb27b613d4c128`.
+- Treatment artifact SHA-256: `96801afa6279cf93ddfa3cb14f81e2a2b9cb790cbf2a46fb2f9c90d35a00ea02`.
+- Frozen manifest SHA-256: `a538f141c8e38b97293eac7b2b0e9e36973d39449ea793126c04d902ac04520c`.
+- Ordered query-ID SHA-256: `5f97b2b76b8cff240e628724c74135179ecae343114da80ef94661e9a9fa7f15`.
+- Control arm: 40 rows, 605,929 context tokens, SHA-256
+  `2565f428ce52090e935cd7c7f73d4370ea97850c38fe83274be41f42245f840b`.
+- Treatment arm: 40 rows, 592,006 context tokens, SHA-256
+  `c3d7f8799cefcdd25b0b499de31b0ef4531b92e5881333b1153e868f6196aa87`.
+- Each unit contains either three instructions (10 rows) or five instructions
+  (30 rows). Whole-block capping removes one trailing block in 37 rows and two
+  trailing blocks in three rows.
+- Canonical instruction-target retention rises from a mean of `0.9284`
+  (`36/40` rows at or above `0.75`) to `1.0000` (`40/40`).
+- Projected external calls: 80 answers and 80 judges over synthetic benchmark
+  data only. No real companion memories are included.
+
+## Gate
+
+The arm proceeds to repeated-answer confirmation only if treatment improves the
+40-row category mean by at least `+0.05` and treatment wins outnumber losses.
+The point floor is below the prior `+0.075` discovery gate because the audited
+retrieval-owned category headroom is `0.0875`. Failure leaves product behavior
+unchanged. This arm tests standing-instruction storage and salience; it does not
+authorize heuristic preference extraction.

--- a/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
+++ b/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
@@ -47,3 +47,30 @@ The point floor is below the prior `+0.075` discovery gate because the audited
 retrieval-owned category headroom is `0.0875`. Failure leaves product behavior
 unchanged. This arm tests standing-instruction storage and salience; it does not
 authorize heuristic preference extraction.
+
+## Discovery Result
+
+The frozen discovery run passed both gates:
+
+| arm | mean rubric score |
+|---|---:|
+| frozen `ydb-0151` control | 0.800 |
+| standing-instruction treatment | 0.900 |
+
+Treatment minus control was `+0.100`, with 7 wins, 32 ties, and 1 loss. The
+paired bootstrap 95% interval was `[+0.01875, +0.20000]`. The run completed all
+40 pairs in 533.7 seconds. Its result SHA-256 is
+`431497ec889e8ff5e33c7a601072323537b527d8ea518d87df227d1064b9b178`.
+
+Five of the seven winning rows lacked the exact canonical instruction in the
+control context. The other two already contained the user instruction, so
+their improvements are consistent with a salience benefit rather than
+retrieval repair. The sole losing row also lacked its canonical instruction in
+control, but treatment still failed to follow it; repeated answers are needed
+to distinguish generation variance from a stable regression.
+
+This is a successful discovery result, not yet a production score claim. The
+next stage must freeze its confirmation cohort and interpretation before making
+more model calls. In particular, an outcome-selected discordant subset may test
+whether row-level direction persists, but must not be used to re-estimate the
+40-row category mean.

--- a/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
+++ b/benchmarks/amb/STANDING_INSTRUCTION_PREREGISTRATION.md
@@ -74,3 +74,16 @@ next stage must freeze its confirmation cohort and interpretation before making
 more model calls. In particular, an outcome-selected discordant subset may test
 whether row-level direction persists, but must not be used to re-estimate the
 40-row category mean.
+
+## Replication Preregistration
+
+The confirmation is one independent, fresh-process replication over the same
+full 40-row cohort and unchanged manifest
+`a538f141c8e38b97293eac7b2b0e9e36973d39449ea793126c04d902ac04520c`.
+It uses one answer and one judge per arm per row, with a new output file and no
+resume checkpoint from discovery. This costs another 80 answers and 80 judges.
+
+Replication passes only if treatment minus control is at least `+0.05` and its
+paired bootstrap 95% interval excludes zero. The result is reported regardless
+of outcome. This design tests category-level replication across model sessions;
+it does not claim stable verdicts for individual rows.

--- a/benchmarks/amb/analyze_standing_instruction_displacement.py
+++ b/benchmarks/amb/analyze_standing_instruction_displacement.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Diagnose whole-block displacement in the standing-instruction full-400 arm."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+
+try:
+    from .reorder_speaker_first_contexts import split_memory_blocks
+except ImportError:  # pragma: no cover - direct script execution
+    from reorder_speaker_first_contexts import split_memory_blocks
+
+
+INSTRUCTION_CATEGORY = "instruction_following"
+WORD_RE = re.compile(r"[a-z0-9]+")
+STOPWORDS = {
+    "again",
+    "along",
+    "already",
+    "always",
+    "another",
+    "about",
+    "after",
+    "against",
+    "around",
+    "also",
+    "because",
+    "based",
+    "before",
+    "being",
+    "between",
+    "both",
+    "came",
+    "comes",
+    "could",
+    "during",
+    "each",
+    "first",
+    "from",
+    "have",
+    "having",
+    "however",
+    "into",
+    "later",
+    "more",
+    "most",
+    "next",
+    "only",
+    "other",
+    "overall",
+    "same",
+    "should",
+    "some",
+    "that",
+    "their",
+    "there",
+    "these",
+    "they",
+    "this",
+    "through",
+    "under",
+    "user",
+    "using",
+    "were",
+    "what",
+    "when",
+    "where",
+    "which",
+    "with",
+    "would",
+    "your",
+}
+
+
+def _tokens(text: str) -> list[str]:
+    return WORD_RE.findall(text.casefold())
+
+
+def _significant_terms(text: str) -> set[str]:
+    return {word for word in _tokens(text) if len(word) >= 4 and word not in STOPWORDS}
+
+
+def _significant_bigrams(text: str) -> set[str]:
+    words = _tokens(text)
+    return {
+        f"{left} {right}"
+        for left, right in zip(words, words[1:])
+        if left not in STOPWORDS
+        and right not in STOPWORDS
+        and len(left) >= 4
+        and len(right) >= 4
+    }
+
+
+def _mean(values: list[float]) -> float:
+    return statistics.fmean(values) if values else 0.0
+
+
+def _summary(rows: list[dict]) -> dict:
+    deltas = [float(row["score_delta_b_minus_a"]) for row in rows]
+    return {
+        "n": len(rows),
+        "mean_score_delta_b_minus_a": _mean(deltas),
+        "wins_b": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "wins_a": sum(delta < 0 for delta in deltas),
+        "mean_displaced_blocks": _mean(
+            [float(row["displaced_blocks"]) for row in rows]
+        ),
+        "mean_displaced_tokens": _mean(
+            [float(row["displaced_tokens"]) for row in rows]
+        ),
+        "rows_with_removed_only_gold_terms": sum(
+            bool(row["removed_only_gold_terms"]) for row in rows
+        ),
+        "rows_with_removed_only_gold_bigrams": sum(
+            bool(row["removed_only_gold_bigrams"]) for row in rows
+        ),
+    }
+
+
+def analyze(
+    source_rows: list[dict],
+    treatment_rows: list[dict],
+    result: dict,
+    token_counter: Callable[[str], int],
+) -> dict:
+    """Join frozen artifacts and quantify the source context evicted per row."""
+    source_by_id = {str(row["query_id"]): row for row in source_rows}
+    treatment_by_id = {str(row["query_id"]): row for row in treatment_rows}
+    pairs_by_id = {str(pair["query_id"]): pair for pair in result.get("pairs") or []}
+    query_ids = set(source_by_id)
+    if not query_ids or query_ids != set(treatment_by_id) or query_ids != set(pairs_by_id):
+        raise ValueError("source, treatment, and paired-result query IDs must match")
+
+    audits = []
+    for query_id in sorted(query_ids):
+        source = source_by_id[query_id]
+        treatment = treatment_by_id[query_id]
+        pair = pairs_by_id[query_id]
+        source_blocks = split_memory_blocks(str(source.get("context") or ""))
+        treatment_blocks = split_memory_blocks(str(treatment.get("context") or ""))
+        if not treatment_blocks or not treatment_blocks[0].startswith("## Memory 0\n"):
+            raise ValueError(f"{query_id}: treatment is missing the instruction panel")
+
+        retained_blocks = treatment_blocks[1:]
+        if retained_blocks != source_blocks[: len(retained_blocks)]:
+            raise ValueError(f"{query_id}: treatment is not panel + source prefix")
+        removed_blocks = source_blocks[len(retained_blocks) :]
+        if not removed_blocks:
+            raise ValueError(f"{query_id}: expected at least one displaced source block")
+
+        retained_text = "".join(retained_blocks).casefold()
+        removed_text = "".join(removed_blocks).casefold()
+        gold_parts = [str(value) for value in source.get("gold_answers") or []]
+        gold_parts.extend(str(value) for value in (source.get("meta") or {}).get("rubric") or [])
+        gold_text = " ".join(gold_parts)
+        gold_terms = _significant_terms(gold_text)
+        gold_bigrams = _significant_bigrams(gold_text)
+        retained_terms = _significant_terms(retained_text)
+        removed_terms = _significant_terms(removed_text)
+        retained_bigrams = _significant_bigrams(retained_text)
+        removed_bigrams = _significant_bigrams(removed_text)
+        audit = treatment.get("standing_instruction_audit") or {}
+
+        audits.append(
+            {
+                "query_id": query_id,
+                "category": str(
+                    (source.get("meta") or {}).get("question_category") or "unknown"
+                ),
+                "score_a": float(pair["score_a"]),
+                "score_b": float(pair["score_b"]),
+                "score_delta_b_minus_a": float(pair["score_b"])
+                - float(pair["score_a"]),
+                "source_blocks": len(source_blocks),
+                "retained_source_blocks": len(retained_blocks),
+                "displaced_blocks": len(removed_blocks),
+                "panel_tokens": token_counter(treatment_blocks[0]),
+                "displaced_tokens": token_counter(removed_text),
+                "budget_slack_tokens": int(audit.get("reference_tokens", 0))
+                - int(audit.get("treatment_tokens", 0)),
+                "removed_only_gold_terms": sorted(
+                    (gold_terms & removed_terms) - retained_terms
+                ),
+                "removed_only_gold_bigrams": sorted(
+                    (gold_bigrams & removed_bigrams) - retained_bigrams
+                ),
+            }
+        )
+
+    by_category: dict[str, list[dict]] = {}
+    for audit in audits:
+        by_category.setdefault(audit["category"], []).append(audit)
+
+    lexical_displacement = [row for row in audits if row["removed_only_gold_bigrams"]]
+    no_lexical_displacement = [
+        row for row in audits if not row["removed_only_gold_bigrams"]
+    ]
+    selective_scores = [
+        row["score_b"]
+        if row["category"] == INSTRUCTION_CATEGORY
+        else row["score_a"]
+        for row in audits
+    ]
+    control_scores = [row["score_a"] for row in audits]
+
+    return {
+        "protocol": "standing-instruction-displacement-diagnostic-v1",
+        "interpretation": {
+            "causal_claim": False,
+            "promotion_evidence": False,
+            "gold_overlap_is_lexical_proxy_only": True,
+            "selective_composition_is_posthoc_category_oracle": True,
+        },
+        "overall": _summary(audits),
+        "categories": {
+            category: _summary(category_rows)
+            for category, category_rows in sorted(by_category.items())
+        },
+        "gold_bigram_displacement_cohorts": {
+            "removed_only_gold_bigram": _summary(lexical_displacement),
+            "no_removed_only_gold_bigram": _summary(no_lexical_displacement),
+        },
+        "category_oracle_selective_composition": {
+            "policy": "treatment for instruction_following; control otherwise",
+            "n": len(audits),
+            "mean_control": _mean(control_scores),
+            "mean_selective": _mean(selective_scores),
+            "mean_delta_selective_minus_control": _mean(selective_scores)
+            - _mean(control_scores),
+        },
+        "rows": audits,
+    }
+
+
+def _load_rows(path: Path) -> list[dict]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    return payload if isinstance(payload, list) else payload.get("results") or []
+
+
+def main() -> int:
+    from memory_bench.utils import count_tokens
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--treatment", type=Path, required=True)
+    parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    report = analyze(
+        _load_rows(args.source),
+        _load_rows(args.treatment),
+        json.loads(args.result.read_text(encoding="utf-8")),
+        count_tokens,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps({key: value for key, value in report.items() if key != "rows"}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/analyze_standing_instruction_full400.py
+++ b/benchmarks/amb/analyze_standing_instruction_full400.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Apply the preregistered standing-instruction full-400 promotion gates."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+from pathlib import Path
+
+try:
+    from .paired_frozen_context_eval import _paired_bootstrap_interval, load_rows
+except ImportError:  # pragma: no cover - direct script execution
+    from paired_frozen_context_eval import _paired_bootstrap_interval, load_rows
+
+
+INSTRUCTION_CATEGORY = "instruction_following"
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _summarize(pairs: list[dict], seed: int) -> dict:
+    deltas = [float(pair["score_b"]) - float(pair["score_a"]) for pair in pairs]
+    scores_a = [float(pair["score_a"]) for pair in pairs]
+    scores_b = [float(pair["score_b"]) for pair in pairs]
+    lower, upper = _paired_bootstrap_interval(deltas, seed)
+    return {
+        "n": len(pairs),
+        "mean_a": statistics.fmean(scores_a),
+        "mean_b": statistics.fmean(scores_b),
+        "mean_delta_b_minus_a": statistics.fmean(deltas),
+        "paired_bootstrap_95_ci": [lower, upper],
+        "wins_b": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "wins_a": sum(delta < 0 for delta in deltas),
+    }
+
+
+def analyze(result: dict, source_rows: list[dict], seed: int) -> dict:
+    category_by_id = {
+        str(row["query_id"]): str(
+            (row.get("meta") or {}).get("question_category") or "unknown"
+        )
+        for row in source_rows
+    }
+    pairs = result.get("pairs") or []
+    if len(pairs) != 400:
+        raise ValueError(f"expected 400 completed pairs, found {len(pairs)}")
+    missing = [
+        pair["query_id"] for pair in pairs if pair["query_id"] not in category_by_id
+    ]
+    if missing:
+        raise ValueError(f"missing source categories for {len(missing)} query IDs")
+
+    by_category: dict[str, list[dict]] = {}
+    for pair in pairs:
+        category = category_by_id[pair["query_id"]]
+        by_category.setdefault(category, []).append(pair)
+    category_summaries = {
+        category: _summarize(category_pairs, seed)
+        for category, category_pairs in sorted(by_category.items())
+    }
+    instruction = category_summaries[INSTRUCTION_CATEGORY]
+    other_pairs = [
+        pair
+        for pair in pairs
+        if category_by_id[pair["query_id"]] != INSTRUCTION_CATEGORY
+    ]
+    overall = _summarize(pairs, seed)
+    other_nine = _summarize(other_pairs, seed)
+
+    gate_1 = (
+        instruction["mean_delta_b_minus_a"] >= 0.05
+        and instruction["wins_b"] > instruction["wins_a"]
+    )
+    gate_2 = (
+        overall["mean_delta_b_minus_a"] >= 0.0
+        and overall["paired_bootstrap_95_ci"][0] >= -0.01
+    )
+    gate_3 = other_nine["mean_delta_b_minus_a"] >= -0.01
+    gate_4 = all(
+        summary["mean_delta_b_minus_a"] >= -0.025
+        for category, summary in category_summaries.items()
+        if category != INSTRUCTION_CATEGORY
+    )
+    gates = {
+        "instruction_lift_and_wins": gate_1,
+        "overall_nonnegative_ci_floor": gate_2,
+        "other_nine_pooled_floor": gate_3,
+        "no_other_category_below_floor": gate_4,
+    }
+    return {
+        "protocol": "standing-instruction-full400-preregistered-analysis-v1",
+        "seed": seed,
+        "overall": overall,
+        "instruction_following": instruction,
+        "other_nine_pooled": other_nine,
+        "categories": category_summaries,
+        "gates": gates,
+        "promotion_passed": all(gates.values()),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=20260820)
+    args = parser.parse_args()
+
+    result = json.loads(args.result.read_text(encoding="utf-8"))
+    report = analyze(result, load_rows(args.source), args.seed)
+    report["result_sha256"] = _sha256_file(args.result)
+    report["source_sha256"] = _sha256_file(args.source)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/build_standing_instruction_contexts.py
+++ b/benchmarks/amb/build_standing_instruction_contexts.py
@@ -79,14 +79,14 @@ def build_contexts(
     rows: list[dict],
     conversations: dict[str, dict],
     token_counter: Callable[[str], int],
-    category: str = "instruction_following",
+    category: str | None = "instruction_following",
 ) -> dict:
     output = []
     total_reference_tokens = 0
     total_treatment_tokens = 0
     for row in rows:
         metadata = row.get("meta") or {}
-        if metadata.get("question_category") != category:
+        if category is not None and metadata.get("question_category") != category:
             continue
         query_id = str(row.get("query_id") or "")
         conversation_id = str(metadata.get("conversation_id") or "")
@@ -124,7 +124,7 @@ def build_contexts(
     return {
         "protocol": "standing-user-instruction-context-v1",
         "artifact_transform": {
-            "category": category,
+            "category": category or "all",
             "rows": len(output),
             "selection_changed": True,
             "query_or_gold_used_for_instruction_extraction": False,
@@ -153,9 +153,17 @@ def main() -> int:
     parser.add_argument("results", type=Path)
     parser.add_argument("documents", type=Path)
     parser.add_argument("output", type=Path)
+    parser.add_argument(
+        "--category",
+        default="instruction_following",
+        help="question category to transform, or 'all' for the full cohort",
+    )
     args = parser.parse_args()
     payload = build_contexts(
-        load_rows(args.results), load_conversations(args.documents), count_tokens
+        load_rows(args.results),
+        load_conversations(args.documents),
+        count_tokens,
+        None if args.category == "all" else args.category,
     )
     payload["artifact_transform"].update(
         {

--- a/benchmarks/amb/build_standing_instruction_contexts.py
+++ b/benchmarks/amb/build_standing_instruction_contexts.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Build equal-budget contexts with authoritative standing instructions first."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+try:
+    from .audit_knowledge_update_gold import iter_turns, load_conversations
+    from .reorder_speaker_first_contexts import split_memory_blocks
+except ImportError:  # pragma: no cover - direct script execution
+    from audit_knowledge_update_gold import iter_turns, load_conversations
+    from reorder_speaker_first_contexts import split_memory_blocks
+
+
+STANDING_INSTRUCTION_RE = re.compile(r"^Always\b", re.IGNORECASE)
+TRAILING_LINK_RE = re.compile(r"\s*->->.*$")
+
+
+def load_rows(path: Path) -> list[dict]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    return payload if isinstance(payload, list) else payload.get("results") or []
+
+
+def extract_standing_instructions(conversation: dict) -> list[dict]:
+    """Return explicit user-authored `Always ...` instructions in turn order."""
+    records = []
+    for turn in iter_turns(conversation.get("chat") or []):
+        if str(turn.get("role") or "").casefold() != "user":
+            continue
+        text = TRAILING_LINK_RE.sub("", str(turn.get("content") or "")).strip()
+        if STANDING_INSTRUCTION_RE.match(text):
+            records.append({"turn": turn.get("id"), "text": text})
+    return records
+
+
+def render_instruction_panel(records: list[dict]) -> str:
+    lines = [
+        f"- [Turn {record['turn']}] User: {record['text']}" for record in records
+    ]
+    return (
+        "## Memory 0\n"
+        "Standing user instructions (authoritative user statements):\n"
+        + "\n".join(lines)
+        + "\n\n"
+    )
+
+
+def cap_whole_blocks(
+    context: str,
+    token_budget: int,
+    token_counter: Callable[[str], int],
+) -> tuple[str, int, int]:
+    blocks = split_memory_blocks(context)
+    low, high = 1, len(blocks)
+    selected_count = 0
+    selected_tokens = 0
+    while low <= high:
+        middle = (low + high) // 2
+        candidate = "".join(blocks[:middle])
+        candidate_tokens = token_counter(candidate)
+        if candidate_tokens <= token_budget:
+            selected_count = middle
+            selected_tokens = candidate_tokens
+            low = middle + 1
+        else:
+            high = middle - 1
+    if selected_count == 0:
+        raise ValueError("standing-instruction panel exceeds the reference budget")
+    return "".join(blocks[:selected_count]), selected_count, selected_tokens
+
+
+def build_contexts(
+    rows: list[dict],
+    conversations: dict[str, dict],
+    token_counter: Callable[[str], int],
+    category: str = "instruction_following",
+) -> dict:
+    output = []
+    total_reference_tokens = 0
+    total_treatment_tokens = 0
+    for row in rows:
+        metadata = row.get("meta") or {}
+        if metadata.get("question_category") != category:
+            continue
+        query_id = str(row.get("query_id") or "")
+        conversation_id = str(metadata.get("conversation_id") or "")
+        conversation = conversations.get(conversation_id)
+        if conversation is None:
+            raise ValueError(f"missing conversation {conversation_id!r}")
+        records = extract_standing_instructions(conversation)
+        if not records:
+            raise ValueError(f"no standing instructions for query {query_id!r}")
+        reference_context = str(row.get("context") or "")
+        reference_tokens = token_counter(reference_context)
+        treatment_before = render_instruction_panel(records) + reference_context
+        treatment_context, blocks_after, treatment_tokens = cap_whole_blocks(
+            treatment_before, reference_tokens, token_counter
+        )
+        if not treatment_context.startswith("## Memory 0\nStanding user instructions"):
+            raise AssertionError("standing-instruction panel was not preserved")
+        transformed = dict(row)
+        transformed["context"] = treatment_context
+        transformed["standing_instruction_audit"] = {
+            "conversation_id": conversation_id,
+            "instruction_count": len(records),
+            "instruction_turns": [record["turn"] for record in records],
+            "reference_tokens": reference_tokens,
+            "treatment_tokens": treatment_tokens,
+            "blocks_before_cap": len(split_memory_blocks(treatment_before)),
+            "blocks_after_cap": blocks_after,
+            "whole_blocks_only": True,
+        }
+        output.append(transformed)
+        total_reference_tokens += reference_tokens
+        total_treatment_tokens += treatment_tokens
+    if not output:
+        raise ValueError(f"no rows found for category {category!r}")
+    return {
+        "protocol": "standing-user-instruction-context-v1",
+        "artifact_transform": {
+            "category": category,
+            "rows": len(output),
+            "selection_changed": True,
+            "query_or_gold_used_for_instruction_extraction": False,
+            "authoritative_user_turns_only": True,
+            "reference_context_tokens": total_reference_tokens,
+            "treatment_context_tokens": total_treatment_tokens,
+            "treatment_within_reference_budget": (
+                total_treatment_tokens <= total_reference_tokens
+            ),
+            "external_calls": 0,
+            "synthetic_benchmark_data_only": True,
+            "real_companion_memories_included": False,
+        },
+        "results": output,
+    }
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    from memory_bench.utils import count_tokens
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results", type=Path)
+    parser.add_argument("documents", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    payload = build_contexts(
+        load_rows(args.results), load_conversations(args.documents), count_tokens
+    )
+    payload["artifact_transform"].update(
+        {
+            "results_sha256": _sha256_file(args.results),
+            "documents_sha256": _sha256_file(args.documents),
+        }
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(payload["artifact_transform"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/prepare_paired_category_contexts.py
+++ b/benchmarks/amb/prepare_paired_category_contexts.py
@@ -21,7 +21,11 @@ def select_common_rows(
     for row_a in rows_a:
         query_id = str(row_a.get("query_id") or "")
         row_category = (row_a.get("meta") or {}).get("question_category")
-        if row_category != category and marker not in query_id:
+        if (
+            category != "all"
+            and row_category != category
+            and marker not in query_id
+        ):
             continue
         row_b = by_id_b.get(query_id)
         if row_b is None:

--- a/benchmarks/amb/replay_standing_instruction_product.py
+++ b/benchmarks/amb/replay_standing_instruction_product.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Replay the frozen standing-instruction arm through persisted facets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+try:
+    from .audit_knowledge_update_gold import iter_turns, load_conversations
+    from .build_standing_instruction_contexts import (
+        TRAILING_LINK_RE,
+        cap_whole_blocks,
+        load_rows,
+        render_instruction_panel,
+    )
+    from .reorder_speaker_first_contexts import split_memory_blocks
+except ImportError:  # pragma: no cover - direct script execution
+    from audit_knowledge_update_gold import iter_turns, load_conversations
+    from build_standing_instruction_contexts import (
+        TRAILING_LINK_RE,
+        cap_whole_blocks,
+        load_rows,
+        render_instruction_panel,
+    )
+    from reorder_speaker_first_contexts import split_memory_blocks
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _json_bytes(value: object, newline: str = "\n") -> bytes:
+    text = json.dumps(value, indent=2)
+    if newline != "\n":
+        text = text.replace("\n", newline)
+    return text.encode("utf-8")
+
+
+def _first_block(context: str) -> str:
+    blocks = split_memory_blocks(context)
+    return blocks[0] if blocks else ""
+
+
+def _remove_store(path: Path) -> None:
+    for suffix in ("", "-shm", "-wal"):
+        candidate = Path(f"{path}{suffix}")
+        if candidate.exists():
+            candidate.unlink()
+
+
+def _selected_rows(rows: list[dict], category: str) -> list[dict]:
+    if category == "all":
+        return rows
+    return [
+        row
+        for row in rows
+        if (row.get("meta") or {}).get("question_category") == category
+    ]
+
+
+def _ingest_and_extract(
+    db: object,
+    conversations: dict[str, dict],
+    conversation_ids: list[str],
+) -> tuple[dict[str, dict[str, object]], dict[str, dict], int]:
+    """Use raw turns only; queries, gold answers, and reference panels stay out."""
+    source_by_rid: dict[str, dict[str, object]] = {}
+    audits: dict[str, dict] = {}
+    ingested = 0
+    for conversation_id in conversation_ids:
+        conversation = conversations.get(conversation_id)
+        if conversation is None:
+            raise ValueError(f"missing conversation {conversation_id!r}")
+        for position, turn in enumerate(
+            iter_turns(conversation.get("chat") or []), start=1
+        ):
+            text = TRAILING_LINK_RE.sub("", str(turn.get("content") or "")).strip()
+            if not text:
+                continue
+            role = str(turn.get("role") or "unknown").casefold()
+            # The benchmark provider supplies embeddings at ingestion time.
+            # A fixed valid vector is sufficient here because facet detection
+            # reads text/provenance, while newly synthesized facets still use
+            # the engine's configured embedder through record_synthesis.
+            rid = db.record(
+                text,
+                embedding=[1.0] + [0.0] * 255,
+                metadata={
+                    "conversation_id": conversation_id,
+                    "source_turn": turn.get("id"),
+                },
+                namespace=conversation_id,
+                source=role,
+                created_at=1_700_000_000.0 + position,
+            )
+            source_by_rid[rid] = {
+                "conversation_id": conversation_id,
+                "turn": turn.get("id"),
+                "role": role,
+            }
+            ingested += 1
+        audits[conversation_id] = db.extract_standing_instructions(
+            namespace=conversation_id,
+            dry_run=False,
+        )
+    return source_by_rid, audits, ingested
+
+
+def _source_map_from_store(path: Path) -> tuple[dict[str, dict[str, object]], int, int]:
+    """Recover the ingestion manifest for a recall-only verification pass."""
+    connection = sqlite3.connect(path)
+    try:
+        rows = connection.execute(
+            "SELECT rid, namespace, source, metadata FROM memories "
+            "WHERE synthesis_axis IS NULL"
+        ).fetchall()
+        accepted_facets = int(
+            connection.execute(
+                "SELECT COUNT(*) FROM memories "
+                "WHERE synthesis_axis = 'standing_instruction'"
+            ).fetchone()[0]
+        )
+    finally:
+        connection.close()
+    source_by_rid = {}
+    for rid, namespace, source, raw_metadata in rows:
+        metadata = json.loads(raw_metadata or "{}")
+        source_by_rid[rid] = {
+            "conversation_id": str(metadata.get("conversation_id") or namespace),
+            "turn": metadata.get("source_turn"),
+            "role": source,
+        }
+    return source_by_rid, len(rows), accepted_facets
+
+
+def _records_from_lane(
+    lane: dict,
+    source_by_rid: dict[str, dict[str, object]],
+) -> list[dict]:
+    if lane.get("omitted") != 0:
+        raise AssertionError(f"facet lane unexpectedly omitted rows: {lane!r}")
+    records = []
+    for facet in lane.get("facets") or []:
+        sources = [source_by_rid[rid] for rid in facet.get("source_rids") or []]
+        if not sources:
+            raise AssertionError(f"facet has no resolvable source: {facet!r}")
+        if any(source["role"] != "user" for source in sources):
+            raise AssertionError(f"facet has non-user evidence: {facet!r}")
+        records.append(
+            {
+                "turn": min(source["turn"] for source in sources),
+                "text": facet["text"],
+            }
+        )
+    return records
+
+
+def replay(args: argparse.Namespace) -> tuple[dict, bytes]:
+    sys.path.insert(0, str(args.yantrikdb_python.resolve()))
+    from memory_bench.utils import count_tokens
+    from yantrikdb import YantrikDB
+
+    control_rows = _selected_rows(load_rows(args.results), args.category)
+    reference_rows = load_rows(args.reference_treatment)
+    reference_by_id = {str(row["query_id"]): row for row in reference_rows}
+    query_ids = [str(row["query_id"]) for row in control_rows]
+    if query_ids != [str(row["query_id"]) for row in reference_rows]:
+        raise ValueError("control and frozen treatment query order differs")
+
+    conversation_ids = list(
+        dict.fromkeys(
+            str((row.get("meta") or {}).get("conversation_id") or "")
+            for row in control_rows
+        )
+    )
+    if any(not conversation_id for conversation_id in conversation_ids):
+        raise ValueError("control row lacks conversation_id")
+
+    if args.reuse_store and not args.db.exists():
+        raise FileNotFoundError(f"store does not exist: {args.db}")
+    if not args.reuse_store and args.db.exists() and not args.overwrite:
+        raise FileExistsError(f"store already exists: {args.db}")
+    if not args.reuse_store and args.overwrite:
+        _remove_store(args.db)
+    args.db.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.reuse_store:
+        source_by_rid, ingested, accepted_facets = _source_map_from_store(args.db)
+    else:
+        conversations = load_conversations(args.documents)
+        db = YantrikDB.with_default(str(args.db))
+        try:
+            source_by_rid, audits, ingested = _ingest_and_extract(
+                db, conversations, conversation_ids
+            )
+        finally:
+            db.close()
+        accepted_facets = sum(int(audit["accepted"]) for audit in audits.values())
+
+    # This reopen is deliberate: the acceptance claim is about persisted
+    # product facets, not objects still resident in the extraction process.
+    db = YantrikDB.with_default(str(args.db))
+    product_rows = []
+    mismatches = []
+    try:
+        for row in control_rows:
+            query_id = str(row["query_id"])
+            conversation_id = str((row.get("meta") or {})["conversation_id"])
+            lane = db.recall_facets(namespace=conversation_id, limit=10_000)
+            records = _records_from_lane(lane, source_by_rid)
+            reference_context = str(row.get("context") or "")
+            reference_tokens = count_tokens(reference_context)
+            candidate = render_instruction_panel(records) + reference_context
+            product_context, _, _ = cap_whole_blocks(
+                candidate, reference_tokens, count_tokens
+            )
+            product_rows.append({"query_id": query_id, "context": product_context})
+
+            expected_context = str(reference_by_id[query_id].get("context") or "")
+            expected_panel = _first_block(expected_context)
+            actual_panel = _first_block(product_context)
+            if expected_context != product_context:
+                mismatches.append(
+                    {
+                        "query_id": query_id,
+                        "conversation_id": conversation_id,
+                        "expected_panel_sha256": _sha256_bytes(
+                            expected_panel.encode("utf-8")
+                        ),
+                        "actual_panel_sha256": _sha256_bytes(
+                            actual_panel.encode("utf-8")
+                        ),
+                        "panel_exact": expected_panel == actual_panel,
+                        "context_exact": False,
+                        "facet_count": len(records),
+                    }
+                )
+    finally:
+        db.close()
+
+    paired_payload = {"results": product_rows}
+    reference_paired_bytes = args.reference_paired.read_bytes()
+    newline = "\r\n" if b"\r\n" in reference_paired_bytes else "\n"
+    paired_bytes = _json_bytes(paired_payload, newline)
+    reference_paired_sha = _sha256_bytes(reference_paired_bytes)
+    product_paired_sha = _sha256_bytes(paired_bytes)
+    report = {
+        "protocol": "standing-user-instruction-product-replay-v1",
+        "product_path": {
+            "raw_turn_ingestion": True,
+            "persisted_facet_extraction": True,
+            "store_reopened_before_recall": True,
+            "recall_facets_used": True,
+            "query_or_gold_used_during_extraction": False,
+            "external_calls": 0,
+        },
+        "category": args.category,
+        "rows": len(product_rows),
+        "conversations": len(conversation_ids),
+        "ingested_turns": ingested,
+        "accepted_facets": accepted_facets,
+        "ordered_query_ids_exact": query_ids
+        == [row["query_id"] for row in product_rows],
+        "exact_contexts": len(product_rows) - len(mismatches),
+        "mismatch_count": len(mismatches),
+        "paired_artifact_sha256": product_paired_sha,
+        "reference_paired_sha256": reference_paired_sha,
+        "paired_artifact_exact": product_paired_sha == reference_paired_sha,
+        "source_sha256": {
+            "results": _sha256_file(args.results),
+            "documents": _sha256_file(args.documents),
+            "reference_treatment": _sha256_file(args.reference_treatment),
+        },
+        "mismatches": mismatches,
+    }
+    return report, paired_bytes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--documents", type=Path, required=True)
+    parser.add_argument("--reference-treatment", type=Path, required=True)
+    parser.add_argument("--reference-paired", type=Path, required=True)
+    parser.add_argument("--yantrikdb-python", type=Path, required=True)
+    parser.add_argument("--db", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--paired-output", type=Path, required=True)
+    parser.add_argument("--category", default="instruction_following")
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--reuse-store", action="store_true")
+    args = parser.parse_args()
+
+    report, paired_bytes = replay(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.paired_output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    args.paired_output.write_bytes(paired_bytes)
+    print(json.dumps(report, indent=2))
+    return 0 if report["paired_artifact_exact"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/standing_instruction_facet_design.md
+++ b/docs/standing_instruction_facet_design.md
@@ -1,0 +1,206 @@
+# Standing-Instruction Facet Design
+
+Status: requirements approved by two independent frozen 40-row AMB runs.
+Implementation remains gated on a product replay and a full-400 no-regression
+evaluation.
+
+## Evidence
+
+A query-independent transform extracted only user-authored turns beginning with
+`Always`, persisted their source turn identity, and placed the complete
+conversation-level set before ordinary memories under a lower total token
+budget than control. Canonical instruction retention moved from `0.9284`
+(`36/40`) to `1.0000` (`40/40`).
+
+The frozen `instruction_following` arm passed in two fresh model sessions:
+
+| run | control | treatment | delta | wins/ties/losses | bootstrap 95% CI |
+|---|---:|---:|---:|---:|---:|
+| discovery | 0.80000 | 0.90000 | +0.10000 | 7/32/1 | [+0.01875, +0.20000] |
+| replication | 0.75000 | 0.89375 | +0.14375 | 9/30/1 | [+0.05625, +0.24375] |
+
+This promotes the mechanism, not the benchmark fixture. The product must retain
+authoritative provenance and explicitness; it must not turn every inferred
+preference or assistant acknowledgement into an instruction.
+
+## Record Contract
+
+A standing instruction is an answer-sized, source-backed facet with this
+logical shape:
+
+```text
+facet_type       = standing_instruction
+text             = exact user-authored directive
+evidence_ids     = one or more engine-resolved source RIDs
+source_actor     = user
+detector_version = explicit_always_v1
+first_mention_at = earliest source occurrence time
+first_mention_turn = earliest source turn when available
+created_at       = newest evidence availability time
+namespace        = namespace shared by every source
+```
+
+The minimal implementation may use the existing synthesis descriptor with
+`synthesis_axis = "standing_instruction"` and
+`synthesis_granularity = "atomic"`. If a generic typed `facet_type` column is
+introduced for later facet kinds, it must remain nullable and NULL must preserve
+ordinary-record behavior bit for bit. Recall-critical type information cannot
+exist only in encrypted JSON metadata.
+
+`evidence_ids` are resolved through `synthesis_dependencies`, never trusted
+from caller metadata. Correction or forget of any evidence invalidates the
+facet through the existing lifecycle. A facet with missing, cross-namespace,
+inactive, assistant-authored, or revision-mismatched evidence is unverified and
+recall-ineligible.
+
+### Time Semantics
+
+Standing instructions normally describe no real-world event date. Their
+ordering clock is therefore the source record's historical occurrence time:
+
+- `first_mention_at` is the earliest source occurrence time;
+- `created_at` is the newest source availability time, as for every synthesis;
+- `first_mention_turn` is used for conversation ordering when present;
+- ingestion time is used only when the source genuinely has no historical
+  timestamp.
+
+The detector must never invent a date from the directive text. For a
+single-source instruction with no explicit historical timestamp,
+`first_mention_at` and `created_at` both fall back to that source record's
+creation time. This is the same fallback contract used by organized concerns.
+
+## Write-Time Detection
+
+Version 1 is deliberately narrow:
+
+1. Inspect only a complete direct user turn. Speaker provenance must be
+   verified by the ingestion boundary, not guessed from text.
+2. Ignore leading whitespace and require the first lexical token to be
+   `Always`, case-insensitively.
+3. Store the complete directive without paraphrasing. Transport annotations
+   are excluded before detection; ordinary punctuation is preserved.
+4. Reject assistant/system/tool turns, quoted or embedded occurrences, empty
+   directives, titles such as `Always Sunny`, and prose such as
+   `I do not always ...`.
+5. Emit at most one facet per normalized directive and source revision. The
+   idempotency key includes the source RID, normalized directive, and detector
+   version.
+
+The detector is an admission candidate generator, not an authority oracle. A
+record is eligible only after the provenance and dependency checks above pass.
+The API must also permit an application to submit an explicit typed standing
+instruction without relying on English detection, subject to the same
+user-provenance rules.
+
+Version 1 does not detect `Never`, `Stop`, preference-like statements, or
+assistant summaries. Those need separate evidence and contradiction semantics.
+
+## False-Fire Audit
+
+The implementation must expose a dry-run audit with these counts, scoped by
+namespace and detector version:
+
+```text
+user_turns_scanned
+candidates
+accepted
+rejected_unverified_provenance
+rejected_non_directive
+duplicate_candidates
+would_write
+```
+
+Dry-run never writes records, dependencies, idempotency claims, or cursor
+progress. The test corpus must include positive directives and adversarial
+negatives for assistant acknowledgements, quoted instructions, titles,
+negation, mid-sentence `always`, empty suffixes, and cross-namespace evidence.
+False-fire examples become permanent regression tests before default-on.
+
+## Recall Salience
+
+Standing instructions use a dedicated facet lane before ordinary context
+assembly. They do not compete invisibly as ordinary vector hits.
+
+- Only active, verified, same-namespace facets are eligible.
+- User-authored directives outrank assistant acknowledgements categorically.
+- When the eligible set fits the configured facet budget, return the complete
+  set in first-mention order. This preserves the tested 3-5 item mechanism.
+- When it exceeds the budget, relevance may select a bounded subset, with a
+  deterministic recency/diversity fallback. The response must expose omitted
+  facet count; silent truncation is not acceptable.
+- Facets consume a separately reported context budget. If the caller requests
+  a fixed total budget, ordinary low-ranked blocks are removed only after the
+  facet set is frozen, matching the evaluated transform.
+- Existing `recall` behavior remains unchanged unless facet inclusion is
+  explicitly enabled. Default-on requires the acceptance gates below.
+
+The returned record remains an ordinary auditable result: RID, text, score,
+`why_retrieved`, clocks, source actor, and evidence links are visible. The lane
+does not inject hidden prompt text.
+
+## Supersession And Conflicts
+
+An `Always` directive does not automatically expire. A later explicit directive
+may coexist until the application or a future contradiction policy links or
+supersedes it. Version 1 must not silently deactivate an older instruction from
+embedding similarity alone. `correct` and `forget` retain their existing
+revision and invalidation semantics.
+
+This conservative rule can surface conflicting instructions, which is safer
+than permanently choosing the wrong one at write time. Conflict resolution is
+a separate typed-facet capability and requires its own benchmark gate.
+
+## Persistence And Compatibility
+
+- New descriptor fields are additive and nullable/defaulted.
+- Old databases migrate without rewriting ordinary records or embeddings.
+- Oplog payloads carry the typed facet descriptor and complete dependency
+  closure; followers fail closed as `unverified` when evidence is absent.
+- Packs and replication preserve facet type, detector version, provenance,
+  clocks, lifecycle state, and evidence links.
+- Namespace filters apply at admission, replication, audit, and recall.
+- Idempotent replay returns the same RID for the same source revision and
+  detector output; changed output for the same generation conflicts.
+
+## Product API
+
+Names are illustrative; behavior is normative:
+
+```python
+db.extract_facets(
+    source_rids,
+    facet_types=["standing_instruction"],
+    dry_run=False,
+)
+
+db.recall(
+    query,
+    include_facets=["standing_instruction"],
+    facet_limit=8,
+    facet_token_budget=2048,
+)
+```
+
+The extraction call is bounded, resumable, and safe to retry. The recall call
+reports selected and omitted facet counts. Language-specific automatic
+detection is replaceable; the persistence and recall contracts are not.
+
+## Acceptance Gates
+
+1. Unit and integration tests prove detector false-fire behavior, provenance
+   rejection, namespace isolation, idempotency, correction/forget invalidation,
+   replication, encrypted-metadata operation, and date fallback.
+2. A product replay over the frozen 40 contexts reconstructs the evaluated
+   panels from persisted facets with exact ordered query IDs and no gold/query
+   access during extraction.
+3. The frozen instruction category retains at least `+0.05` mean lift with more
+   wins than losses in a fresh session.
+4. Before default-on, a preregistered full-400 paired run must show no overall
+   regression and no material category regression outside instruction
+   following. Exact thresholds and artifact hashes are frozen before calls.
+5. Automatic background extraction remains opt-in until real, consented corpus
+   false-fire rates and write amplification are measured. Real companion
+   memories are never sent to an external benchmark model.
+
+Failure at a gate leaves the feature opt-in and records the result. It does not
+authorize broadening the detector.

--- a/tests/test_amb_analyze_standing_instruction_displacement.py
+++ b/tests/test_amb_analyze_standing_instruction_displacement.py
@@ -1,0 +1,62 @@
+from benchmarks.amb.analyze_standing_instruction_displacement import analyze
+
+
+def _row(query_id, category, context, gold):
+    return {
+        "query_id": query_id,
+        "context": context,
+        "gold_answers": [gold],
+        "meta": {"question_category": category, "rubric": [gold]},
+    }
+
+
+def test_analyze_finds_evicted_gold_evidence_and_labels_oracle():
+    kept = "## Memory 1\nThe project uses SQLite.\n\n"
+    removed = "## Memory 2\nThe launch date is Friday morning.\n\n"
+    source = [
+        _row("instruction", "instruction_following", kept + removed, "launch date Friday"),
+        _row("summary", "summarization", kept + removed, "launch date Friday"),
+    ]
+    treatment = []
+    for row in source:
+        transformed = dict(row)
+        transformed["context"] = "## Memory 0\nAlways be concise.\n\n" + kept
+        transformed["standing_instruction_audit"] = {
+            "reference_tokens": 20,
+            "treatment_tokens": 18,
+        }
+        treatment.append(transformed)
+    result = {
+        "pairs": [
+            {"query_id": "instruction", "score_a": 0.5, "score_b": 1.0},
+            {"query_id": "summary", "score_a": 1.0, "score_b": 0.0},
+        ]
+    }
+
+    report = analyze(source, treatment, result, lambda text: len(text.split()))
+
+    assert report["overall"]["mean_displaced_blocks"] == 1
+    assert report["overall"]["rows_with_removed_only_gold_bigrams"] == 2
+    assert report["rows"][0]["removed_only_gold_bigrams"] == ["launch date"]
+    assert report["category_oracle_selective_composition"][
+        "mean_delta_selective_minus_control"
+    ] == 0.25
+    assert report["interpretation"]["promotion_evidence"] is False
+
+
+def test_analyze_rejects_a_treatment_that_is_not_a_source_prefix():
+    source = [_row("q", "summarization", "## Memory 1\nA\n\n## Memory 2\nB\n", "B")]
+    treatment = [
+        {
+            **source[0],
+            "context": "## Memory 0\nAlways concise.\n\n## Memory 2\nB\n",
+        }
+    ]
+    result = {"pairs": [{"query_id": "q", "score_a": 0.0, "score_b": 0.0}]}
+
+    try:
+        analyze(source, treatment, result, len)
+    except ValueError as error:
+        assert "panel + source prefix" in str(error)
+    else:
+        raise AssertionError("expected source-prefix validation to fail")

--- a/tests/test_amb_analyze_standing_instruction_full400.py
+++ b/tests/test_amb_analyze_standing_instruction_full400.py
@@ -1,0 +1,52 @@
+from benchmarks.amb.analyze_standing_instruction_full400 import analyze
+
+
+CATEGORIES = [
+    "instruction_following",
+    "event_ordering",
+    "knowledge_update",
+    "multi_session",
+    "preference",
+    "summarization",
+    "temporal_reasoning",
+    "entity_recall",
+    "speaker_identification",
+    "other",
+]
+
+
+def _fixture(category_deltas=None):
+    category_deltas = category_deltas or {"instruction_following": 0.1}
+    pairs = []
+    rows = []
+    for category in CATEGORIES:
+        for index in range(40):
+            query_id = f"{category}-{index}"
+            delta = category_deltas.get(category, 0.0)
+            pairs.append({"query_id": query_id, "score_a": 0.5, "score_b": 0.5 + delta})
+            rows.append(
+                {
+                    "query_id": query_id,
+                    "meta": {"question_category": category},
+                }
+            )
+    return {"pairs": pairs}, rows
+
+
+def test_analyze_passes_when_all_preregistered_gates_pass():
+    result, rows = _fixture()
+
+    report = analyze(result, rows, seed=7)
+
+    assert report["promotion_passed"] is True
+    assert all(report["gates"].values())
+    assert report["instruction_following"]["mean_delta_b_minus_a"] >= 0.05
+
+
+def test_analyze_rejects_a_harmful_non_instruction_category():
+    result, rows = _fixture({"instruction_following": 0.1, "event_ordering": -0.05})
+
+    report = analyze(result, rows, seed=7)
+
+    assert report["gates"]["no_other_category_below_floor"] is False
+    assert report["promotion_passed"] is False

--- a/tests/test_amb_build_standing_instruction_contexts.py
+++ b/tests/test_amb_build_standing_instruction_contexts.py
@@ -72,3 +72,43 @@ def test_build_contexts_rejects_units_without_standing_instructions():
             {"1": {"chat": [{"id": 1, "role": "user", "content": "Fact"}]}},
             lambda value: len(value.split()),
         )
+
+
+def test_build_contexts_can_transform_all_categories():
+    context = (
+        "## Memory 1\nfirst raw memory with several words\n\n"
+        "## Memory 2\nsecond raw memory with several words\n\n"
+        "## Memory 3\nthird raw memory with several words\n\n"
+        "## Memory 4\nfourth raw memory with several words\n\n"
+    )
+    rows = [
+        {
+            "query_id": "1_instruction_following_0",
+            "context": context,
+            "meta": {
+                "question_category": "instruction_following",
+                "conversation_id": "1",
+            },
+        },
+        {
+            "query_id": "1_temporal_reasoning_0",
+            "context": context,
+            "meta": {
+                "question_category": "temporal_reasoning",
+                "conversation_id": "1",
+            },
+        },
+    ]
+
+    payload = build_contexts(
+        rows,
+        {"1": _conversation()},
+        lambda value: len(value.split()),
+        category=None,
+    )
+
+    assert payload["artifact_transform"]["category"] == "all"
+    assert [row["query_id"] for row in payload["results"]] == [
+        "1_instruction_following_0",
+        "1_temporal_reasoning_0",
+    ]

--- a/tests/test_amb_build_standing_instruction_contexts.py
+++ b/tests/test_amb_build_standing_instruction_contexts.py
@@ -1,0 +1,74 @@
+import pytest
+
+from benchmarks.amb.build_standing_instruction_contexts import (
+    build_contexts,
+    extract_standing_instructions,
+)
+
+
+def _conversation():
+    return {
+        "chat": [
+            {"id": 1, "role": "user", "content": "Ordinary fact."},
+            {
+                "id": 2,
+                "role": "user",
+                "content": "Always use APA citations. ->-> 1,2",
+            },
+            {"id": 3, "role": "assistant", "content": "Always be concise."},
+            {"id": 4, "role": "user", "content": "Always include dates."},
+        ]
+    }
+
+
+def test_extract_standing_instructions_is_user_authoritative_and_ordered():
+    assert extract_standing_instructions(_conversation()) == [
+        {"turn": 2, "text": "Always use APA citations."},
+        {"turn": 4, "text": "Always include dates."},
+    ]
+
+
+def test_build_contexts_prepends_panel_and_caps_whole_blocks():
+    context = (
+        "## Memory 1\nfirst raw memory with several words\n\n"
+        "## Memory 2\nsecond raw memory with several words\n\n"
+        "## Memory 3\nthird raw memory with several words\n\n"
+    )
+    row = {
+        "query_id": "1_instruction_following_0",
+        "context": context,
+        "meta": {
+            "question_category": "instruction_following",
+            "conversation_id": "1",
+        },
+    }
+
+    payload = build_contexts(
+        [row], {"1": _conversation()}, lambda value: len(value.split())
+    )
+    result = payload["results"][0]
+
+    assert result["context"].startswith(
+        "## Memory 0\nStanding user instructions (authoritative user statements):"
+    )
+    assert "Assistant: Always be concise" not in result["context"]
+    assert result["standing_instruction_audit"]["instruction_turns"] == [2, 4]
+    assert result["standing_instruction_audit"]["blocks_after_cap"] < 4
+    assert payload["artifact_transform"]["treatment_within_reference_budget"] is True
+
+
+def test_build_contexts_rejects_units_without_standing_instructions():
+    row = {
+        "query_id": "1_instruction_following_0",
+        "context": "## Memory 1\nraw memory",
+        "meta": {
+            "question_category": "instruction_following",
+            "conversation_id": "1",
+        },
+    }
+    with pytest.raises(ValueError, match="no standing instructions"):
+        build_contexts(
+            [row],
+            {"1": {"chat": [{"id": 1, "role": "user", "content": "Fact"}]}},
+            lambda value: len(value.split()),
+        )

--- a/tests/test_amb_prepare_paired_category_contexts.py
+++ b/tests/test_amb_prepare_paired_category_contexts.py
@@ -48,3 +48,30 @@ def test_select_common_rows_preserves_arm_a_order_and_category():
         "1_multi_session_reasoning_0",
     ]
     assert [row["context"] for row in arm_b] == ["B2", "B1"]
+
+
+def test_select_common_rows_accepts_full_cohort():
+    rows_a = [
+        {
+            "query_id": "1_instruction_following_0",
+            "context": "A1",
+            "meta": {"question_category": "instruction_following"},
+        },
+        {
+            "query_id": "1_temporal_reasoning_0",
+            "context": "A2",
+            "meta": {"question_category": "temporal_reasoning"},
+        },
+    ]
+    rows_b = [
+        {"query_id": "1_instruction_following_0", "context": "B1"},
+        {"query_id": "1_temporal_reasoning_0", "context": "B2"},
+    ]
+
+    arm_a, arm_b = _MODULE.select_common_rows(rows_a, rows_b, "all")
+
+    assert [row["query_id"] for row in arm_a] == [
+        "1_instruction_following_0",
+        "1_temporal_reasoning_0",
+    ]
+    assert [row["context"] for row in arm_b] == ["B1", "B2"]

--- a/tests/test_amb_replay_standing_instruction_product.py
+++ b/tests/test_amb_replay_standing_instruction_product.py
@@ -1,0 +1,58 @@
+import pytest
+
+from benchmarks.amb.replay_standing_instruction_product import (
+    _json_bytes,
+    _records_from_lane,
+    _selected_rows,
+)
+
+
+def test_json_bytes_preserves_requested_frozen_newlines():
+    payload = {"results": [{"query_id": "q", "context": "line\nline"}]}
+
+    encoded = _json_bytes(payload, "\r\n")
+
+    assert b"\r\n" in encoded
+    assert b"\n" not in encoded.replace(b"\r\n", b"")
+
+
+def test_selected_rows_accepts_the_preregistered_all_category():
+    rows = [
+        {"meta": {"question_category": "instruction_following"}},
+        {"meta": {"question_category": "temporal_reasoning"}},
+    ]
+
+    assert _selected_rows(rows, "all") == rows
+
+
+def test_records_from_lane_uses_earliest_user_evidence_turn():
+    lane = {
+        "facets": [
+            {
+                "text": "Always cite sources.",
+                "source_rids": ["later", "earlier"],
+            }
+        ],
+        "omitted": 0,
+    }
+    sources = {
+        "later": {"turn": 12, "role": "user"},
+        "earlier": {"turn": 4, "role": "user"},
+    }
+
+    assert _records_from_lane(lane, sources) == [
+        {"turn": 4, "text": "Always cite sources."}
+    ]
+
+
+def test_records_from_lane_rejects_non_user_evidence():
+    lane = {
+        "facets": [{"text": "Always cite sources.", "source_rids": ["assistant"]}],
+        "omitted": 0,
+    }
+
+    with pytest.raises(AssertionError, match="non-user evidence"):
+        _records_from_lane(
+            lane,
+            {"assistant": {"turn": 4, "role": "assistant"}},
+        )


### PR DESCRIPTION
## Summary
- freeze and replicate a query-independent standing-instruction salience arm
- verify the evaluated panels through persisted YantrikDB facets after store reopen
- run the preregistered full-400 safety evaluation and apply its frozen promotion gates
- record the decision: the explicit facet lane is validated, while global composition remains closed

## Target-category evidence
- canonical instruction retention: 0.9284 (36/40) -> 1.0000 (40/40)
- discovery: 0.8000 -> 0.9000, delta +0.1000, 7/32/1, CI [+0.01875, +0.20000]
- fresh replication: 0.7500 -> 0.89375, delta +0.14375, 9/30/1, CI [+0.05625, +0.24375]
- full-400 run instruction slice: 0.7875 -> 0.8625, delta +0.0750, 5/34/1, CI [+0.0125, +0.1500]

## Product replay
- ingested 5,732 raw user and assistant turns across 20 conversations
- persisted 90 source-keyed facets, closed and reopened the database, then read `recall_facets`
- 40/40 target contexts exact; evaluated artifact SHA `c3d7f8799cefcdd25b0b499de31b0ef4531b92e5881333b1153e868f6196aa87`
- 400/400 full contexts exact; evaluated artifact SHA `551662988effa63397928146b73775eac653fc0c37cf29ea23b018aded6838e3`
- no query, gold, rubric, answer, or score access during extraction; zero model calls in replay

## Full-400 verdict
Result SHA: `0b30ebe5fbf045785a8c3dcbd33fbb4b1d117b456954a983eb208024a4948b64`

- instruction gate: PASS (+0.0750, 5 wins / 1 loss)
- overall safety gate: FAIL (+0.00215, CI [-0.02316, +0.02731]; lower bound below -0.01)
- pooled other-nine gate: PASS (-0.00595)
- per-category floor: FAIL (summarization -0.02976 below -0.025)

Per the frozen rule, `recall_facets` remains an explicit opt-in product surface. This PR does not authorize globally prepending standing instructions to every query.

## Verification
- `ruff check` on the standing-instruction builder, replay, analyzer, and tests
- `pytest -q -p no:cacheprovider tests/test_amb_build_standing_instruction_contexts.py tests/test_amb_replay_standing_instruction_product.py tests/test_amb_analyze_standing_instruction_full400.py` (10 passed)
- synthetic benchmark data only; no companion memories