### PR TITLE
migrations: the splitter must not cut trigger bodies (#146)

### DIFF
--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1587,72 +1587,49 @@ impl YantrikDB {
     /// Diagnosed via yantrikdb-server v0.8.13 cluster upgrade incident
     /// (swarm msg 3467c556 → response fa070846, v0.7.3 commit a5de0f2) and
     /// extended for issue #10 view case in v0.7.8.
-    /// Split a migration batch into executable statements WITHOUT cutting
-    /// trigger bodies.
+    /// Split a migration batch into executable statements using SQLite's
+    /// own grammar — `sqlite3_complete()` — instead of a hand-rolled lexer.
     ///
-    /// **Issue #146, root cause.** The previous `batch.split(';')` truncated
-    /// `CREATE TRIGGER ... BEGIN stmt; stmt; END` at the first body
-    /// semicolon, handing SQLite an incomplete statement — the literal
-    /// `incomplete input` the stage instrumentation finally caught in CI.
-    /// The runner's doc had flagged `;`-inside-string-literals as the
-    /// hazard; trigger bodies were the unnamed case.
+    /// **Issue #146, both generations of the bug.** The original
+    /// `batch.split(';')` truncated trigger bodies (`BEGIN stmt; stmt; END`),
+    /// producing the `incomplete input` the stage instrumentation caught in
+    /// CI. The first fix was a depth-tracking scanner — and cold review
+    /// reproduced two holes in it within the hour: a quoted identifier
+    /// `"begin"` counted as a keyword and jammed the depth counter (grouping
+    /// statements so a swallowed already-exists SILENTLY DROPPED the rest of
+    /// the group — migration loss), and `"semi;colon"` identifiers split
+    /// mid-name. A partial SQL lexer is the original sin repeated: every
+    /// unnamed case is a future #146.
     ///
-    /// The splitter is a small scanner, not a SQL parser:
-    /// - single-quoted strings are skipped verbatim (with `''` escapes), so
-    ///   a semicolon or keyword inside a literal never counts;
-    /// - `BEGIN` and `CASE` push a depth counter, `END` pops it (trigger
-    ///   bodies contain `CASE ... END`, so plain begin-flag tracking would
-    ///   close the trigger too early — our own LWW migration SQL has CASE);
-    /// - a `;` splits only at depth zero.
-    /// Line comments are already stripped by the caller.
+    /// `sqlite3_complete` is the engine's own answer to "is this a complete
+    /// statement?" — it understands triggers, CASE/END, every string and
+    /// identifier quoting form, and comments, because it IS SQLite. We scan
+    /// forward and emit a statement at each `;` where the accumulated prefix
+    /// is complete; anything trailing without a terminator is emitted as-is
+    /// (execute_batch surfaces its error, which is correct for a malformed
+    /// migration).
     fn split_sql_statements(batch: &str) -> Vec<String> {
         let mut out = Vec::new();
-        let mut current = String::new();
-        let mut depth: u32 = 0;
-        let mut chars = batch.chars().peekable();
-        let mut word = String::new();
-
-        fn flush_word(word: &mut String, depth: &mut u32) {
-            match word.to_ascii_uppercase().as_str() {
-                "BEGIN" | "CASE" => *depth += 1,
-                "END" => *depth = depth.saturating_sub(1),
-                _ => {}
-            }
-            word.clear();
-        }
-
-        while let Some(c) = chars.next() {
-            if c == '\'' {
-                // String literal: copy through, honoring '' escapes.
-                flush_word(&mut word, &mut depth);
-                current.push(c);
-                while let Some(sc) = chars.next() {
-                    current.push(sc);
-                    if sc == '\'' {
-                        if chars.peek() == Some(&'\'') {
-                            current.push(chars.next().unwrap());
-                        } else {
-                            break;
-                        }
+        let mut start = 0usize;
+        let bytes = batch.as_bytes();
+        for i in 0..bytes.len() {
+            if bytes[i] == b';' {
+                let candidate = &batch[start..=i];
+                // sqlite3_complete needs a NUL-terminated C string; a
+                // candidate containing an interior NUL cannot be a valid
+                // migration statement, so treat it as incomplete.
+                if let Ok(c) = std::ffi::CString::new(candidate) {
+                    let complete = unsafe { rusqlite::ffi::sqlite3_complete(c.as_ptr()) } != 0;
+                    if complete {
+                        out.push(candidate.to_string());
+                        start = i + 1;
                     }
                 }
-                continue;
             }
-            if c.is_alphanumeric() || c == '_' {
-                word.push(c);
-                current.push(c);
-                continue;
-            }
-            flush_word(&mut word, &mut depth);
-            if c == ';' && depth == 0 {
-                out.push(std::mem::take(&mut current));
-                continue;
-            }
-            current.push(c);
         }
-        flush_word(&mut word, &mut depth);
-        if !current.trim().is_empty() {
-            out.push(current);
+        let tail = batch[start..].trim();
+        if !tail.is_empty() {
+            out.push(tail.to_string());
         }
         out
     }

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1587,6 +1587,76 @@ impl YantrikDB {
     /// Diagnosed via yantrikdb-server v0.8.13 cluster upgrade incident
     /// (swarm msg 3467c556 → response fa070846, v0.7.3 commit a5de0f2) and
     /// extended for issue #10 view case in v0.7.8.
+    /// Split a migration batch into executable statements WITHOUT cutting
+    /// trigger bodies.
+    ///
+    /// **Issue #146, root cause.** The previous `batch.split(';')` truncated
+    /// `CREATE TRIGGER ... BEGIN stmt; stmt; END` at the first body
+    /// semicolon, handing SQLite an incomplete statement — the literal
+    /// `incomplete input` the stage instrumentation finally caught in CI.
+    /// The runner's doc had flagged `;`-inside-string-literals as the
+    /// hazard; trigger bodies were the unnamed case.
+    ///
+    /// The splitter is a small scanner, not a SQL parser:
+    /// - single-quoted strings are skipped verbatim (with `''` escapes), so
+    ///   a semicolon or keyword inside a literal never counts;
+    /// - `BEGIN` and `CASE` push a depth counter, `END` pops it (trigger
+    ///   bodies contain `CASE ... END`, so plain begin-flag tracking would
+    ///   close the trigger too early — our own LWW migration SQL has CASE);
+    /// - a `;` splits only at depth zero.
+    /// Line comments are already stripped by the caller.
+    fn split_sql_statements(batch: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut current = String::new();
+        let mut depth: u32 = 0;
+        let mut chars = batch.chars().peekable();
+        let mut word = String::new();
+
+        fn flush_word(word: &mut String, depth: &mut u32) {
+            match word.to_ascii_uppercase().as_str() {
+                "BEGIN" | "CASE" => *depth += 1,
+                "END" => *depth = depth.saturating_sub(1),
+                _ => {}
+            }
+            word.clear();
+        }
+
+        while let Some(c) = chars.next() {
+            if c == '\'' {
+                // String literal: copy through, honoring '' escapes.
+                flush_word(&mut word, &mut depth);
+                current.push(c);
+                while let Some(sc) = chars.next() {
+                    current.push(sc);
+                    if sc == '\'' {
+                        if chars.peek() == Some(&'\'') {
+                            current.push(chars.next().unwrap());
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                continue;
+            }
+            if c.is_alphanumeric() || c == '_' {
+                word.push(c);
+                current.push(c);
+                continue;
+            }
+            flush_word(&mut word, &mut depth);
+            if c == ';' && depth == 0 {
+                out.push(std::mem::take(&mut current));
+                continue;
+            }
+            current.push(c);
+        }
+        flush_word(&mut word, &mut depth);
+        if !current.trim().is_empty() {
+            out.push(current);
+        }
+        out
+    }
+
     fn run_migration_idempotent(conn: &Connection, batch: &str) -> Result<()> {
         // Strip `-- ... \n` line comments before splitting on `;`. The
         // naive split otherwise breaks on comment text containing
@@ -1604,7 +1674,7 @@ impl YantrikDB {
             .collect::<Vec<_>>()
             .join("\n");
 
-        for raw in stripped.split(';') {
+        for raw in Self::split_sql_statements(&stripped) {
             let stmt = raw.trim();
             if stmt.is_empty() {
                 continue;

--- a/crates/yantrikdb-core/src/engine/tests/migrations.rs
+++ b/crates/yantrikdb-core/src/engine/tests/migrations.rs
@@ -742,3 +742,71 @@ fn migration_splitter_keeps_trigger_bodies_intact() {
     YantrikDB::run_migration_idempotent(&conn, batch)
         .expect("replay of a trigger-bearing batch must stay idempotent");
 }
+
+// =====================================================================
+// #160 cold-review adversarials (found by Codex, empirically reproduced
+// against the first depth-scanner fix — both failed it). A quoted
+// identifier `"begin"` jammed the scanner's depth counter, grouping
+// statements so that a swallowed already-exists SILENTLY DROPPED the
+// rest of the group; and an identifier containing a semicolon split
+// mid-name. sqlite3_complete understands both because it is SQLite.
+// =====================================================================
+
+#[test]
+fn quoted_begin_identifier_does_not_group_statements() {
+    use rusqlite::Connection;
+    let conn = Connection::open_in_memory().unwrap();
+    // Precreate "begin" so the first statement hits already-exists and the
+    // swallow list eats it — the second statement must STILL run alone.
+    conn.execute("CREATE TABLE \"begin\" (id INTEGER)", [])
+        .unwrap();
+    let batch =
+        "CREATE TABLE \"begin\" (id INTEGER); CREATE TABLE applied_after_replay (id INTEGER);";
+    YantrikDB::run_migration_idempotent(&conn, batch).unwrap();
+    let n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name = 'applied_after_replay'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        n, 1,
+        "statement after a swallowed error must not be silently lost"
+    );
+}
+
+#[test]
+fn semicolon_inside_quoted_identifier_does_not_split() {
+    use rusqlite::Connection;
+    let conn = Connection::open_in_memory().unwrap();
+    let batch = "CREATE TABLE \"semi;colon\" (id INTEGER); CREATE TABLE after_semi (id INTEGER);";
+    YantrikDB::run_migration_idempotent(&conn, batch).unwrap();
+    for t in ["semi;colon", "after_semi"] {
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name = ?1",
+                rusqlite::params![t],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 1, "table {t:?} must exist");
+    }
+}
+
+#[test]
+fn block_comments_with_semicolons_do_not_split() {
+    use rusqlite::Connection;
+    let conn = Connection::open_in_memory().unwrap();
+    let batch =
+        "CREATE TABLE c1 (id INTEGER) /* note; with; semis */; CREATE TABLE c2 (id INTEGER);";
+    YantrikDB::run_migration_idempotent(&conn, batch).unwrap();
+    let n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name IN ('c1','c2')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(n, 2);
+}

--- a/crates/yantrikdb-core/src/engine/tests/migrations.rs
+++ b/crates/yantrikdb-core/src/engine/tests/migrations.rs
@@ -701,3 +701,44 @@ fn swallowed_replay_errors_still_do_not_leak_a_stage_error() {
     YantrikDB::run_migration_idempotent(&conn, "DROP TABLE definitely_not_a_table;")
         .expect("swallowed replay errors must not become failures");
 }
+
+// =====================================================================
+// Issue #146, SOLVED HALF — the migration splitter must not cut trigger
+// bodies. The first stage-tagged recurrence (PR #159 CI) named the exact
+// statement: `CREATE TRIGGER ... BEGIN INSERT ...` truncated before its
+// `; END` because run_migration_idempotent splits batches on bare `;`.
+// The runner's own doc flagged `;`-in-string-literals as the hazard;
+// trigger bodies were the case the caveat didn't name. Until this fix,
+// ANY migration replay crossing a trigger-bearing migration failed.
+// =====================================================================
+
+#[test]
+fn migration_splitter_keeps_trigger_bodies_intact() {
+    use rusqlite::Connection;
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, txt TEXT)", [])
+        .unwrap();
+    conn.execute("CREATE TABLE t_log (txt TEXT)", []).unwrap();
+    // A batch in exactly the shape that failed in CI: statements before and
+    // after a trigger whose body contains its own semicolons.
+    let batch = "
+        CREATE INDEX IF NOT EXISTS idx_t_txt ON t(txt);
+        CREATE TRIGGER IF NOT EXISTS t_insert AFTER INSERT ON t BEGIN
+            INSERT INTO t_log(txt) VALUES (new.txt);
+            UPDATE t SET txt = txt WHERE id = new.id;
+        END;
+        CREATE INDEX IF NOT EXISTS idx_t_id ON t(id);
+    ";
+    YantrikDB::run_migration_idempotent(&conn, batch)
+        .expect("a trigger body must survive the splitter");
+    // The trigger must actually work — not merely have parsed.
+    conn.execute("INSERT INTO t (txt) VALUES ('hello')", [])
+        .unwrap();
+    let logged: String = conn
+        .query_row("SELECT txt FROM t_log LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(logged, "hello");
+    // Replay safety unchanged: running the same batch again succeeds.
+    YantrikDB::run_migration_idempotent(&conn, batch)
+        .expect("replay of a trigger-bearing batch must stay idempotent");
+}


### PR DESCRIPTION
The deterministic half of #146, diagnosed by the #147 stage instrumentation on its first live recurrence (PR #159 CI) and fixed with the failing direction proven. Details in the commit message and on the issue.

- Depth-aware statement splitter (BEGIN/CASE push, END pops, string literals skipped) replaces the bare `;` split
- Regression test reproduces CI's exact truncation, verifies the trigger fires, and confirms replay idempotency
- 2018 rust tests pass; fmt clean
- The intermittent half (why the migration path runs on a fresh v46 store) stays open on #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)