### PR TITLE
feat(engine): recall gains a valid-time filter — filter-first (#149 phase 2)

### DIFF
--- a/crates/yantrikdb-core/benches/engine_bench.rs
+++ b/crates/yantrikdb-core/benches/engine_bench.rs
@@ -166,6 +166,8 @@ fn bench_recall(c: &mut Criterion) {
                     None,
                     None,
                     false,
+                    None, // event_after (#149)
+                    None, // event_before (#149)
                 )
                 .unwrap()
             })
@@ -400,6 +402,8 @@ fn bench_recall_scaled(c: &mut Criterion) {
                     None,
                     None,
                     false,
+                    None, // event_after (#149)
+                    None, // event_before (#149)
                 )
                 .unwrap()
             })
@@ -441,6 +445,8 @@ fn bench_recall_dim_comparison(c: &mut Criterion) {
                             None,
                             None,
                             false,
+                            None, // event_after (#149)
+                            None, // event_before (#149)
                         )
                         .unwrap()
                     })
@@ -483,6 +489,8 @@ fn bench_recall_100k(c: &mut Criterion) {
                     None,
                     None,
                     false,
+                    None, // event_after (#149)
+                    None, // event_before (#149)
                 )
                 .unwrap()
             })
@@ -519,6 +527,8 @@ fn bench_recall_with_graph(c: &mut Criterion) {
                     None,
                     None,
                     false,
+                    None, // event_after (#149)
+                    None, // event_before (#149)
                 )
                 .unwrap()
             })
@@ -541,6 +551,8 @@ fn bench_recall_with_graph(c: &mut Criterion) {
                     None,
                     None,
                     false,
+                    None, // event_after (#149)
+                    None, // event_before (#149)
                 )
                 .unwrap()
             })
@@ -580,6 +592,8 @@ fn bench_reinforce_overhead(c: &mut Criterion) {
                     None,
                     None,
                     false,
+                    None, // event_after (#149)
+                    None, // event_before (#149)
                 )
                 .unwrap()
         })
@@ -603,6 +617,8 @@ fn bench_reinforce_overhead(c: &mut Criterion) {
                     None,
                     None,
                     false,
+                    None, // event_after (#149)
+                    None, // event_before (#149)
                 )
                 .unwrap()
         })
@@ -754,6 +770,8 @@ fn bench_recall_as_of(c: &mut Criterion) {
                     None,
                     None,
                     false,
+                    None, // event_after (#149)
+                    None, // event_before (#149)
                 )
                 .unwrap()
             })

--- a/crates/yantrikdb-core/examples/perf_at_scale.rs
+++ b/crates/yantrikdb-core/examples/perf_at_scale.rs
@@ -193,7 +193,8 @@ fn run_one(n: usize) -> Row {
         let results = db
             .recall(
                 &query, TOP_K, None, None, false, false, None, true, None, None, None, None, None,
-                false,
+                false, None, // event_after (#149)
+                None, // event_before (#149)
             )
             .expect("recall failed");
         let lat_us = q_start.elapsed().as_secs_f64() * 1_000_000.0;

--- a/crates/yantrikdb-core/examples/wedge_repro.rs
+++ b/crates/yantrikdb-core/examples/wedge_repro.rs
@@ -300,7 +300,8 @@ fn run() {
                 let t = Instant::now();
                 let _ = db_c.recall(
                     &query, 10, None, None, false, false, None, false, None, None, None, None,
-                    None, false,
+                    None, false, None, // event_after (#149)
+                    None, // event_before (#149)
                 );
                 let dur_ns = t.elapsed().as_nanos() as u64;
                 let bucket = started.elapsed().as_secs();

--- a/crates/yantrikdb-core/src/distributed/sync.rs
+++ b/crates/yantrikdb-core/src/distributed/sync.rs
@@ -543,7 +543,8 @@ mod tests {
         let a_results = a
             .recall(
                 &emb1, 2, None, None, false, false, None, false, None, None, None, None, None,
-                false,
+                false, None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
         assert!(!a_results.is_empty());

--- a/crates/yantrikdb-core/src/engine/bitemporal.rs
+++ b/crates/yantrikdb-core/src/engine/bitemporal.rs
@@ -82,6 +82,8 @@ impl YantrikDB {
             None, // certainty_min
             None, // order
             true, // include_superseded: the as-of filter decides, not today's
+            None, // event_after (#149)
+            None, // event_before (#149)
         )?;
 
         // 1. Nothing that did not exist yet.

--- a/crates/yantrikdb-core/src/engine/claims_lane.rs
+++ b/crates/yantrikdb-core/src/engine/claims_lane.rs
@@ -190,6 +190,11 @@ impl super::YantrikDB {
         domain: Option<&str>,
         source: Option<&str>,
         certainty_min: Option<f64>,
+        // #149 phase 2: valid-time eligible universe (allow-set). A claim
+        // may be exact while its source record sits outside the caller's
+        // temporal window — membership gating here keeps the lane from
+        // re-admitting it.
+        event_allow: Option<&std::collections::HashSet<String>>,
         learned_weights: &crate::types::LearnedWeights,
         ts: f64,
         query_sentiment: f64,
@@ -260,6 +265,7 @@ impl super::YantrikDB {
         for (rid, claim_why) in new_rids {
             let Some(row) = cache.get(rid) else { continue };
             if !crate::engine::recall::passes_recall_filters(
+                rid,
                 row,
                 include_consolidated,
                 memory_type,
@@ -268,6 +274,7 @@ impl super::YantrikDB {
                 domain,
                 source,
                 certainty_min,
+                event_allow,
             ) {
                 continue;
             }

--- a/crates/yantrikdb-core/src/engine/durable_embeddings.rs
+++ b/crates/yantrikdb-core/src/engine/durable_embeddings.rs
@@ -156,11 +156,20 @@ impl<'a> DurableEmbeddingStore<'a> {
 
         let conn = self.db.read_conn();
         let mut stmt = conn.prepare(&sql)?;
-        let rows: Vec<(String, Vec<u8>, i64)> = stmt
+        // `embedding` is read as Option: a NULL column (e.g. a replication
+        // follower materialized from record ops, whose oplog carries only
+        // the embedding HASH — replication.rs materialize_op note) means
+        // "this rid has no durable vector yet". Before #149 phase 2 that
+        // row was unreachable by every caller of this reader, so the NULL
+        // was never observed; the valid-time universe lane now reads
+        // eligible rows the vector index has never seen, and one NULL must
+        // mean an absent map key (the miss every caller already handles),
+        // not a hard error that fails the whole batched read.
+        let rows: Vec<(String, Option<Vec<u8>>, i64)> = stmt
             .query_map(params_ref.as_slice(), |row| {
                 Ok((
                     row.get::<_, String>(0)?,
-                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, Option<Vec<u8>>>(1)?,
                     row.get::<_, i64>(2)?,
                 ))
             })?
@@ -170,6 +179,9 @@ impl<'a> DurableEmbeddingStore<'a> {
 
         let mut map = HashMap::new();
         for (rid, stored_emb, generation) in rows {
+            let Some(stored_emb) = stored_emb else {
+                continue;
+            };
             // Decrypt under the engine's at-rest encryption (no-op
             // if encryption is disabled). The brainstorm-4 §5
             // contract: this module is the sole caller of

--- a/crates/yantrikdb-core/src/engine/impressions.rs
+++ b/crates/yantrikdb-core/src/engine/impressions.rs
@@ -1354,6 +1354,8 @@ mod tests {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap()
     }
@@ -1408,6 +1410,8 @@ mod tests {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
         let after: i64 = db

--- a/crates/yantrikdb-core/src/engine/learning.rs
+++ b/crates/yantrikdb-core/src/engine/learning.rs
@@ -973,6 +973,8 @@ mod tests {
                 None,
                 None,
                 false,
+                None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
         }

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -908,6 +908,8 @@ impl YantrikDB {
             certainty_min,
             order,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )?;
 
         if expand_links == 0 {
@@ -1577,6 +1579,8 @@ mod tests {
                 None,
                 None,
                 true, // include_superseded — history query
+                None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
         let old_hit = results
@@ -1612,6 +1616,8 @@ mod tests {
             None,
             None,
             include_superseded,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap()
         .into_iter()
@@ -1659,6 +1665,8 @@ mod tests {
                 None,
                 None,
                 true,
+                None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
         let old_hit = results
@@ -1753,6 +1761,8 @@ mod tests {
                 None,
                 None,
                 false,
+                None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
 
@@ -1896,6 +1906,8 @@ mod tests {
                 None,
                 None,
                 include_superseded,
+                None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap()
         };
@@ -2233,7 +2245,8 @@ mod tests {
         let direct = db
             .recall(
                 &query, 5, None, None, false, false, None, true, None, None, None, None, None,
-                false,
+                false, None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
         assert_eq!(

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -2919,6 +2919,8 @@ impl YantrikDB {
             None,  // certainty_min (#46)
             None,  // order (#46) — relevance
             false, // include_superseded (v0.10 Item 1) — policy default
+            None,  // event_after (#149)
+            None,  // event_before (#149)
         )
     }
 
@@ -2954,6 +2956,8 @@ impl YantrikDB {
             None,  // certainty_min
             None,  // order — relevance
             false, // include_superseded
+            None,  // event_after (#149)
+            None,  // event_before (#149)
         )
     }
 
@@ -2985,6 +2989,8 @@ impl YantrikDB {
             None,  // certainty_min (#46)
             None,  // order (#46) — relevance
             false, // include_superseded (v0.10 Item 1) — policy default
+            None,  // event_after (#149)
+            None,  // event_before (#149)
         )
     }
 }

--- a/crates/yantrikdb-core/src/engine/procedural.rs
+++ b/crates/yantrikdb-core/src/engine/procedural.rs
@@ -49,6 +49,8 @@ impl YantrikDB {
             None,  // no certainty_min (#46)
             None,  // default relevance order (#46)
             false, // include_superseded (v0.10 Item 1) — policy default
+            None,  // event_after (#149)
+            None,  // event_before (#149)
         )
     }
 

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -269,8 +269,21 @@ fn irregular_verb_forms(word: &str) -> Option<&'static [&'static str]> {
 ///
 /// Filtering is a property of the REQUEST, not of the lane that happened
 /// to find the row, so there is one predicate and every lane calls it.
+///
+/// # Valid-time bounds (#149 phase 2)
+///
+/// `event_allow` is the ELIGIBLE UNIVERSE for a bounded recall: the rid
+/// set the SQL pre-query over `idx_memories_event_time` returned for the
+/// caller's `event_after`/`event_before` window. `Some(set)` means the
+/// caller set at least one bound — a row is eligible only if its rid is
+/// a member (rows with NULL `event_time_min` are never members, so the
+/// NULL-excluded contract falls out of membership). `None` means no
+/// bound was set and valid time does not constrain anything. Threading
+/// it through THIS predicate (rather than each lane checking) keeps the
+/// 2026-08-13 invariant: no lane can re-admit a row the request excluded.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn passes_recall_filters(
+    rid: &str,
     row: &crate::types::ScoringRow,
     include_consolidated: bool,
     memory_type: Option<&str>,
@@ -279,7 +292,13 @@ pub(crate) fn passes_recall_filters(
     domain: Option<&str>,
     source: Option<&str>,
     certainty_min: Option<f64>,
+    event_allow: Option<&std::collections::HashSet<String>>,
 ) -> bool {
+    if let Some(allow) = event_allow {
+        if !allow.contains(rid) {
+            return false;
+        }
+    }
     if !synthesis_lifecycle_allows(row) {
         return false;
     }
@@ -831,6 +850,13 @@ impl YantrikDB {
         certainty_min: Option<f64>,
         order: Option<&str>,
         include_superseded: bool,
+        // #149 phase 2: valid-time bounds (epoch seconds). When either is
+        // set, the temporal window defines the ELIGIBLE UNIVERSE before
+        // relevance ranking and top_k (filter-first); rows with NULL
+        // event_time_min are excluded; interval overlap is inclusive.
+        // `event_after > event_before` is a typed InvalidInput error.
+        event_after: Option<f64>,
+        event_before: Option<f64>,
     ) -> Result<Vec<RecallResult>> {
         self.recall_with_limits(
             query_embedding,
@@ -847,6 +873,8 @@ impl YantrikDB {
             certainty_min,
             order,
             include_superseded,
+            event_after,
+            event_before,
         )
         .map(|(results, _)| results)
     }
@@ -868,6 +896,8 @@ impl YantrikDB {
         certainty_min: Option<f64>,
         order: Option<&str>,
         include_superseded: bool,
+        event_after: Option<f64>,
+        event_before: Option<f64>,
     ) -> Result<(Vec<RecallResult>, crate::types::RetrievalLimits)> {
         // v0.10 Item 3 seqlock (sol r5): EVERY attempt validates — a result
         // is never returned without a passing epoch recheck (coherence is
@@ -895,6 +925,8 @@ impl YantrikDB {
                 certainty_min,
                 order,
                 include_superseded,
+                event_after,
+                event_before,
                 attempt == 0,
                 epoch0,
                 None,
@@ -934,6 +966,8 @@ impl YantrikDB {
         certainty_min: Option<f64>,
         order: Option<&str>,
         include_superseded: bool,
+        event_after: Option<f64>,
+        event_before: Option<f64>,
     ) -> Result<(Vec<RecallResult>, crate::types::RecallExplain)> {
         const MAX_ATTEMPTS: u32 = 8;
         let mut explain: Option<crate::types::RecallExplain> = None;
@@ -956,6 +990,8 @@ impl YantrikDB {
                 certainty_min,
                 order,
                 include_superseded,
+                event_after,
+                event_before,
                 attempt == 0,
                 epoch0,
                 Some(&mut explain),
@@ -1002,6 +1038,15 @@ impl YantrikDB {
         // On legacy-policy databases this flag is a no-op (everything is
         // already included).
         include_superseded: bool,
+        // #149 phase 2: valid-time bounds. FILTER-FIRST — when either is
+        // set the eligible universe is fetched from the indexed v48
+        // columns up front, every lane is constrained to it (via
+        // `passes_recall_filters`' allow-set), and a dedicated universe
+        // lane direct-scores every eligible row so an in-window record is
+        // reachable even when the unfiltered similarity pool would never
+        // surface it.
+        event_after: Option<f64>,
+        event_before: Option<f64>,
         // Since-boot limit telemetry counts public calls, not discarded
         // seqlock attempts. Only the first attempt increments the counter;
         // every binding attempt still emits its structured trace.
@@ -1019,6 +1064,46 @@ impl YantrikDB {
         // Validate `order` upfront so callers get a clear error rather
         // than silently falling back to relevance when they typo a value.
         let recall_order = parse_recall_order(order)?;
+        // #149 phase 2: an inverted valid-time window is a caller error,
+        // not an empty result — an empty result claims "nothing happened
+        // then", which is a different (and false) statement. Non-finite
+        // bounds are rejected first (repo-wide caller-scalar rule): NaN
+        // makes every comparison false, so it would silently pass the
+        // inversion check AND match nothing.
+        if let Some(after) = event_after {
+            crate::validate::validate_scalars("recall", &[("event_after", after)])?;
+        }
+        if let Some(before) = event_before {
+            crate::validate::validate_scalars("recall", &[("event_before", before)])?;
+        }
+        if let (Some(after), Some(before)) = (event_after, event_before) {
+            if after > before {
+                return Err(YantrikDbError::InvalidInput(format!(
+                    "event_after ({after}) must be <= event_before ({before})"
+                )));
+            }
+        }
+        // #149 phase 2 integration choice, documented per the contract:
+        // of the two robust shapes — (a) restrict the vector search to an
+        // allow-list, (b) direct-score the eligible set — this engine's
+        // HNSW surface has no allow-list parameter, but the importance-
+        // fallback lane already established the direct-scoring pattern
+        // (fetch embeddings by rid, cosine against the query, push into
+        // the pool pre-truncation). So: ONE SQL query over
+        // idx_memories_event_time builds the eligible universe as a rid
+        // set; `passes_recall_filters` gates every lane on membership
+        // (post-filtering a bounded pool is forbidden — that recreates
+        // the bounded-by-today's-top-k false negative this issue fixes);
+        // and the universe lane below direct-scores any eligible row no
+        // other lane admitted. Temporal windows are typically small, so
+        // direct scoring is cheap where it matters.
+        let event_allow_owned: Option<std::collections::HashSet<String>> =
+            if event_after.is_some() || event_before.is_some() {
+                Some(self.event_time_eligible_rids(namespace, event_after, event_before)?)
+            } else {
+                None
+            };
+        let event_allow = event_allow_owned.as_ref();
         let ts = now();
 
         // Load per-database learned weights (falls back to defaults if none learned yet)
@@ -1096,6 +1181,9 @@ impl YantrikDB {
         let explain_on = explain_sink.is_some();
         let mut explain_fallback_rids: std::collections::HashSet<String> = Default::default();
         let mut explain_valence_rids: std::collections::HashSet<String> = Default::default();
+        // #149 phase 2: rows admitted by the valid-time universe lane
+        // (direct-scored because no similarity lane surfaced them).
+        let mut explain_event_universe_rids: std::collections::HashSet<String> = Default::default();
         // Pack rows live in their pack's scoring cache, not the host cache.
         // Track their provenance across the merged-pool lifecycle check; the
         // pack collector has already applied the same lifecycle predicate.
@@ -1116,8 +1204,12 @@ impl YantrikDB {
         // candidate source, which mounting a pack falsifies. Taking it
         // with a pack mounted would make the flagship case — a database
         // with few or no memories of its own mounting a knowledge pack —
-        // return nothing at all.
-        if vec_results.is_empty() && self.packs.read().is_empty() {
+        // return nothing at all. A valid-time-bounded recall (#149
+        // phase 2) falsifies the premise the same way: its universe lane
+        // sources candidates from SQL over the v48 columns, so an empty
+        // vector pool (e.g. a freshly applied replication follower) must
+        // still fall through to the universe lane.
+        if vec_results.is_empty() && self.packs.read().is_empty() && event_allow.is_none() {
             // No candidates → no vector/text pairing to protect. Still
             // validate the epoch (sol r6): a successful recall must never be
             // returned during an unvalidated correction interval, even when
@@ -1219,6 +1311,16 @@ impl YantrikDB {
                     }
                 }
 
+                // Filter: valid-time eligible universe (#149 phase 2).
+                // Membership in the SQL-derived allow-set — NULL event
+                // times are never members, so they are excluded whenever
+                // a bound is set.
+                if let Some(allow) = event_allow {
+                    if !allow.contains(rid.as_str()) {
+                        continue;
+                    }
+                }
+
                 let sim_score = (1.0 - distance).max(0.0);
                 let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
                 let age = ts - row.created_at;
@@ -1303,6 +1405,7 @@ impl YantrikDB {
                         row.importance >= high_imp_threshold
                             && !existing_rids.contains(rid.as_str())
                             && passes_recall_filters(
+                                rid,
                                 row,
                                 include_consolidated,
                                 memory_type,
@@ -1311,6 +1414,7 @@ impl YantrikDB {
                                 domain,
                                 source,
                                 certainty_min,
+                                event_allow,
                             )
                     })
                     .map(|(rid, _)| rid.clone())
@@ -1397,6 +1501,130 @@ impl YantrikDB {
                     .iter()
                     .map(|r| r.rid.clone()),
             );
+        }
+
+        // Step 2.6: valid-time UNIVERSE lane (#149 phase 2).
+        //
+        // When the caller set event_after/event_before, the temporal
+        // window defines the eligible universe — and every member must be
+        // REACHABLE, even one whose similarity rank sits far below the
+        // vector pool's fetch_k. Post-filtering the bounded pool cannot
+        // provide that (the bounded-by-today's-top-k false negative this
+        // issue exists to fix), so any eligible row no lane has admitted
+        // yet is direct-scored here: embed-once query cosine against the
+        // row's stored embedding, same composite scoring as every other
+        // lane, pushed into the pool BEFORE boosting/MMR/top_k
+        // truncation. Ranking then happens strictly WITHIN the universe
+        // (all other lanes are membership-gated on the same allow-set).
+        // Temporal windows are typically small, so the extra embedding
+        // fetch is proportional to the window, not the store.
+        if let Some(allow) = event_allow {
+            let missing_rids: Vec<String> = {
+                let existing_rids: std::collections::HashSet<&str> =
+                    scored.iter().map(|r| r.rid.as_str()).collect();
+                let cache = self.scoring_cache.read();
+                allow
+                    .iter()
+                    .filter(|rid| !existing_rids.contains(rid.as_str()))
+                    .filter(|rid| {
+                        cache.get(rid.as_str()).is_some_and(|row| {
+                            passes_recall_filters(
+                                rid,
+                                row,
+                                include_consolidated,
+                                memory_type,
+                                time_window,
+                                namespace,
+                                domain,
+                                source,
+                                certainty_min,
+                                event_allow,
+                            )
+                        })
+                    })
+                    .cloned()
+                    .collect()
+            };
+            if !missing_rids.is_empty() {
+                let rid_refs: Vec<&str> = missing_rids.iter().map(|r| r.as_str()).collect();
+                let emb_map = self.fetch_embeddings_by_rids(&rid_refs)?;
+                let cache = self.scoring_cache.read();
+                for rid in &missing_rids {
+                    let Some(row) = cache.get(rid) else { continue };
+                    // Deliberately NO similarity floor: eligibility comes
+                    // from the temporal window; similarity only RANKS
+                    // within it. A floor here would silently shrink the
+                    // universe — the exact false-negative class again. The
+                    // same principle covers a row with no readable vector
+                    // (a replication follower before vector sync): it is
+                    // admitted at similarity 0.0 rather than dropped, so
+                    // leader and follower agree on the eligible rid set.
+                    let sim_score = match emb_map.get(rid.as_str()) {
+                        Some(emb_blob) => {
+                            let mem_emb = crate::serde_helpers::deserialize_f32(emb_blob);
+                            crate::consolidate::cosine_similarity(query_embedding, &mem_emb) as f64
+                        }
+                        None => 0.0,
+                    };
+                    let decay = scoring::ranking_decay(row.importance, row.created_at, ts);
+                    let age = ts - row.created_at;
+                    let recency = scoring::recency_score(age);
+                    let composite = scoring::adaptive_composite_score(
+                        sim_score,
+                        decay,
+                        recency,
+                        row.importance,
+                        row.valence,
+                        query_sentiment,
+                        &learned_weights,
+                    );
+                    let mut why = scoring::build_why(sim_score, recency, decay, row.valence);
+                    why.push("event_time_window".to_string());
+                    let contributions = scoring::adaptive_contributions(
+                        sim_score,
+                        decay,
+                        recency,
+                        row.importance,
+                        &learned_weights,
+                    );
+                    let valence_multiplier =
+                        scoring::query_valence_boost(row.valence, query_sentiment);
+
+                    if explain_on {
+                        explain_event_universe_rids.insert(rid.clone());
+                    }
+                    scored.push(RecallResult {
+                        rid: rid.clone(),
+                        memory_type: row.memory_type.clone(),
+                        text: String::new(),
+                        created_at: row.created_at,
+                        importance: row.importance,
+                        valence: row.valence,
+                        score: composite,
+                        scores: ScoreBreakdown {
+                            similarity: sim_score,
+                            decay,
+                            recency,
+                            importance: row.importance,
+                            graph_proximity: 0.0,
+                            contributions,
+                            valence_multiplier,
+                        },
+                        why_retrieved: why,
+                        metadata: serde_json::Value::Null,
+                        namespace: row.namespace.clone(),
+                        certainty: row.certainty,
+                        domain: row.domain.clone(),
+                        source: row.source.clone(),
+                        emotional_state: row.emotional_state.clone(),
+                        current_status: Default::default(),
+                        superseded_by: None,
+                        disputed_with: Vec::new(),
+                        aged_last_verified: None,
+                        best_span: None,
+                    });
+                }
+            }
         }
 
         // rid → per-query lexical strength from FTS5 bm25 ranks (fusion:
@@ -1939,6 +2167,7 @@ impl YantrikDB {
                                 // record the caller excluded by domain, source or
                                 // certainty could be re-admitted here.
                                 if !passes_recall_filters(
+                                    rid,
                                     row,
                                     include_consolidated,
                                     memory_type,
@@ -1947,6 +2176,7 @@ impl YantrikDB {
                                     domain,
                                     source,
                                     certainty_min,
+                                    event_allow,
                                 ) {
                                     continue;
                                 }
@@ -2055,6 +2285,7 @@ impl YantrikDB {
             domain,
             source,
             certainty_min,
+            event_allow,
             &learned_weights,
             ts,
             query_sentiment,
@@ -2092,6 +2323,7 @@ impl YantrikDB {
                             // Same predicate as every other lane: this one
                             // used to omit domain, source and certainty.
                             && passes_recall_filters(
+                                rid,
                                 row,
                                 include_consolidated,
                                 memory_type,
@@ -2100,6 +2332,7 @@ impl YantrikDB {
                                 domain,
                                 source,
                                 certainty_min,
+                                event_allow,
                             )
                     })
                     .map(|(rid, row)| {
@@ -2374,6 +2607,7 @@ impl YantrikDB {
                                 // access_count, type and namespace, so domain,
                                 // source and certainty must be enforced here.
                                 if !passes_recall_filters(
+                                    rid,
                                     row,
                                     include_consolidated,
                                     memory_type,
@@ -2382,6 +2616,7 @@ impl YantrikDB {
                                     domain,
                                     source,
                                     certainty_min,
+                                    event_allow,
                                 ) {
                                     continue;
                                 }
@@ -2676,6 +2911,7 @@ impl YantrikDB {
                             // Graph-only admission used to skip domain,
                             // source and certainty; one predicate now.
                             if !passes_recall_filters(
+                                &rid,
                                 row,
                                 include_consolidated,
                                 memory_type,
@@ -2684,6 +2920,7 @@ impl YantrikDB {
                                 domain,
                                 source,
                                 certainty_min,
+                                event_allow,
                             ) {
                                 return None;
                             }
@@ -2817,7 +3054,15 @@ impl YantrikDB {
         //
         // Pack rows arrive already hydrated: their text lives in the
         // pack file, and step 5 hydrates only from the host.
-        {
+        //
+        // #149 phase 2: bounded recall EXCLUDES all pack candidates.
+        // Pack rows live outside the host's indexed event-time universe
+        // (idx_memories_event_time), so their event time is effectively
+        // unknown — NULL-excluded semantics extend to them. Post-filtering
+        // PackFilters instead would still miss dated pack rows outside
+        // pack_fetch_k, violating filter-first. Full pack event-time
+        // support is a follow-up (the #164 v1.1 pack-lane pattern).
+        if event_allow.is_none() {
             let pack_candidates = self.collect_pack_candidates(
                 query_embedding,
                 top_k,
@@ -2988,6 +3233,9 @@ impl YantrikDB {
                     if explain_valence_rids.contains(&r.rid) {
                         lanes.push("valence_scan".into());
                     }
+                    if explain_event_universe_rids.contains(&r.rid) {
+                        lanes.push("event_time_universe".into());
+                    }
                     if pack_rids.contains(&r.rid) {
                         lanes.push("pack".into());
                     }
@@ -3093,6 +3341,23 @@ impl YantrikDB {
                     None,
                 ),
             );
+            // #149 phase 2: reported only when the caller set a valid-time
+            // bound, so unbounded recalls keep their pre-phase-2 explain
+            // shape byte-for-byte.
+            if let Some(allow) = event_allow {
+                lanes.insert(
+                    "event_time_universe".to_string(),
+                    lane(
+                        if explain_event_universe_rids.is_empty() {
+                            "ran_empty"
+                        } else {
+                            "ran"
+                        },
+                        explain_event_universe_rids.len(),
+                        Some(format!("eligible_universe={}", allow.len())),
+                    ),
+                );
+            }
             lanes.insert(
                 "pack".to_string(),
                 lane(
@@ -3590,6 +3855,8 @@ impl YantrikDB {
             None,  // certainty_min (#46) — recall_with_seq path defers to caller-side filtering
             None,  // order (#46) — default relevance
             false, // include_superseded (v0.10 Item 1) — policy default; use query() builder for history
+            None,  // event_after (#149) — no valid-time bound
+            None,  // event_before (#149)
         )
     }
 
@@ -3618,6 +3885,8 @@ impl YantrikDB {
             q.certainty_min,
             q.order.as_deref(),
             q.include_superseded,
+            None, // event_after (#149) — not yet surfaced on the builder
+            None, // event_before (#149)
         )
     }
 
@@ -3654,6 +3923,8 @@ impl YantrikDB {
             None,  // certainty_min (#46) — recall_with_response defers to caller-side filtering
             None,  // order (#46) — default relevance
             false, // include_superseded (v0.10 Item 1) — policy default; use query() builder for history
+            None,  // event_after (#149) — no valid-time bound
+            None,  // event_before (#149)
         )?;
 
         // Determine which retrieval sources were used
@@ -4371,6 +4642,7 @@ impl YantrikDB {
                         row.importance >= high_imp_threshold
                             && !existing_rids.contains(rid.as_str())
                             && passes_recall_filters(
+                                rid,
                                 row,
                                 include_consolidated,
                                 memory_type,
@@ -4379,6 +4651,7 @@ impl YantrikDB {
                                 domain,
                                 source,
                                 certainty_min,
+                                None,
                             )
                     })
                     .map(|(rid, _)| rid.clone())
@@ -4927,6 +5200,7 @@ impl YantrikDB {
                                 // record the caller excluded by domain, source or
                                 // certainty could be re-admitted here.
                                 if !passes_recall_filters(
+                                    rid,
                                     row,
                                     include_consolidated,
                                     memory_type,
@@ -4935,6 +5209,7 @@ impl YantrikDB {
                                     domain,
                                     source,
                                     certainty_min,
+                                    None,
                                 ) {
                                     continue;
                                 }
@@ -5041,6 +5316,7 @@ impl YantrikDB {
             domain,
             source,
             certainty_min,
+            None, // #149: valid-time bounds are default-lane only (like explain)
             &learned_weights,
             ts,
             query_sentiment,
@@ -5303,6 +5579,7 @@ impl YantrikDB {
                                 // access_count, type and namespace, so domain,
                                 // source and certainty must be enforced here.
                                 if !passes_recall_filters(
+                                    rid,
                                     row,
                                     include_consolidated,
                                     memory_type,
@@ -5311,6 +5588,7 @@ impl YantrikDB {
                                     domain,
                                     source,
                                     certainty_min,
+                                    None,
                                 ) {
                                     continue;
                                 }
@@ -5591,6 +5869,7 @@ impl YantrikDB {
                             // Graph-only admission used to skip domain,
                             // source and certainty; one predicate now.
                             if !passes_recall_filters(
+                                &r,
                                 row,
                                 include_consolidated,
                                 memory_type,
@@ -5599,6 +5878,7 @@ impl YantrikDB {
                                 domain,
                                 source,
                                 certainty_min,
+                                None,
                             ) {
                                 return None;
                             }
@@ -6081,6 +6361,56 @@ impl YantrikDB {
             .into_iter()
             .map(|(rid, entry)| (rid, entry.bytes))
             .collect())
+    }
+
+    /// #149 phase 2 — the ELIGIBLE UNIVERSE for a valid-time-bounded
+    /// recall, fetched from the indexed v48 columns
+    /// (`idx_memories_event_time`), BEFORE any relevance ranking runs.
+    ///
+    /// Semantics (the reviewer-confirmed contract, verbatim):
+    /// - rows with NULL `event_time_min` are EXCLUDED whenever either
+    ///   bound is set (unknown-when is not in-window);
+    /// - inclusive interval overlap against `[event_time_min,
+    ///   event_time_max]`: `after` alone ⇒ `max >= after`; `before`
+    ///   alone ⇒ `min <= before`; both ⇒ the intervals overlap.
+    ///   Boundary equality is included (>=/<=). A row whose max is NULL
+    ///   is a point event at its min (`COALESCE(max, min)`).
+    ///
+    /// The result is consumed as an allow-SET passed into
+    /// `passes_recall_filters` (membership, never a textual
+    /// `RID IN (...)` list) plus the direct-scoring universe lane in
+    /// `recall_inner` — never as a post-filter over a bounded
+    /// similarity pool.
+    fn event_time_eligible_rids(
+        &self,
+        namespace: Option<&str>,
+        event_after: Option<f64>,
+        event_before: Option<f64>,
+    ) -> Result<std::collections::HashSet<String>> {
+        let mut sql = String::from("SELECT rid FROM memories WHERE event_time_min IS NOT NULL");
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(ns) = namespace {
+            sql.push_str(&format!(" AND namespace = ?{}", params.len() + 1));
+            params.push(Box::new(ns.to_string()));
+        }
+        if let Some(after) = event_after {
+            sql.push_str(&format!(
+                " AND COALESCE(event_time_max, event_time_min) >= ?{}",
+                params.len() + 1
+            ));
+            params.push(Box::new(after));
+        }
+        if let Some(before) = event_before {
+            sql.push_str(&format!(" AND event_time_min <= ?{}", params.len() + 1));
+            params.push(Box::new(before));
+        }
+        let conn = self.read_conn();
+        let mut stmt = conn.prepare(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let rids = stmt
+            .query_map(param_refs.as_slice(), |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<std::collections::HashSet<String>, _>>()?;
+        Ok(rids)
     }
 
     /// Reinforce a memory on access — increase half_life, update last_access,

--- a/crates/yantrikdb-core/src/engine/reembed.rs
+++ b/crates/yantrikdb-core/src/engine/reembed.rs
@@ -2593,7 +2593,9 @@ mod tests {
         let query = vec![0.99_f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let results = db
             .recall(
-                &query, 5, None, None, false, true, None, true, None, None, None, None, None, false,
+                &query, 5, None, None, false, true, None, true, None, None, None, None, None,
+                false, None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
         assert_eq!(

--- a/crates/yantrikdb-core/src/engine/tests/backpressure_lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/tests/backpressure_lifecycle.rs
@@ -349,6 +349,8 @@ fn record_commits_row_and_both_oplog_ops_atomically() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(

--- a/crates/yantrikdb-core/src/engine/tests/basics.rs
+++ b/crates/yantrikdb-core/src/engine/tests/basics.rs
@@ -326,6 +326,8 @@ fn test_recall_basic() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(results.len(), 2);
@@ -403,6 +405,8 @@ fn recall_survives_nan_embedding_in_candidate_pool() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .expect("recall must not panic with a NaN embedding in the candidate pool");
     assert!(
@@ -806,7 +810,8 @@ fn contract_gate_rejects_invalid_writes() {
         assert!(matches!(
             db.recall(
                 &bad_query, 5, None, None, false, false, None, true, None, None, None, None, None,
-                false,
+                false, None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap_err(),
             YantrikDbError::InvalidEmbedding { path: "recall", .. }
@@ -833,6 +838,8 @@ fn contract_gate_rejects_invalid_writes() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap()
         .len(),
@@ -860,6 +867,8 @@ fn test_recall_empty() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(results.is_empty());

--- a/crates/yantrikdb-core/src/engine/tests/bundled_embedder.rs
+++ b/crates/yantrikdb-core/src/engine/tests/bundled_embedder.rs
@@ -1476,6 +1476,8 @@ fn recall_logs_demand_and_surfaces_gaps() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(

--- a/crates/yantrikdb-core/src/engine/tests/consolidate_cluster.rs
+++ b/crates/yantrikdb-core/src/engine/tests/consolidate_cluster.rs
@@ -555,6 +555,8 @@ fn record_synthesis_new_evidence_supersedes_the_previous_logical_generation() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(!hits.iter().any(|memory| memory.rid == first_rid));
@@ -902,6 +904,8 @@ fn recall_prefers_matching_synthesis_representation_and_survives_reopen() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap()
     }

--- a/crates/yantrikdb-core/src/engine/tests/corrections.rs
+++ b/crates/yantrikdb-core/src/engine/tests/corrections.rs
@@ -149,6 +149,8 @@ fn correct_reembed_updates_retrieval_vector_delta_and_cold() {
         let emb = db.embed(q).unwrap();
         db.recall(
             &emb, 10, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap()
         .into_iter()
@@ -554,6 +556,8 @@ fn correct_then_forget_leaves_no_resurrected_vector() {
     let hits = db
         .recall(
             &q, 10, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(
@@ -875,6 +879,8 @@ fn follower_replay_applies_corrected_embedding() {
     let hits = follower
         .recall(
             &q, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(

--- a/crates/yantrikdb-core/src/engine/tests/created_at.rs
+++ b/crates/yantrikdb-core/src/engine/tests/created_at.rs
@@ -266,6 +266,8 @@ fn imported_event_time_reaches_recall_not_just_the_row() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     let hit = hits
@@ -464,6 +466,8 @@ fn future_created_at_scores_as_new_not_amplified() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(

--- a/crates/yantrikdb-core/src/engine/tests/dimensions.rs
+++ b/crates/yantrikdb-core/src/engine/tests/dimensions.rs
@@ -105,6 +105,8 @@ fn test_domain_filter() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(
@@ -186,6 +188,8 @@ fn test_source_filter() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(
@@ -282,6 +286,8 @@ fn test_domain_and_source_combined_filter() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(
@@ -310,6 +316,8 @@ fn test_domain_and_source_combined_filter() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(
@@ -491,6 +499,8 @@ fn recall_top_k_above_legacy_candidate_cap_is_not_underfilled() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(results.len(), 600);
@@ -554,6 +564,8 @@ fn explicit_filter_exhausts_small_index_past_nearer_decoys() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(results.len(), 20);

--- a/crates/yantrikdb-core/src/engine/tests/encryption.rs
+++ b/crates/yantrikdb-core/src/engine/tests/encryption.rs
@@ -158,6 +158,8 @@ fn test_encrypted_recall_roundtrip() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(results.len(), 2);
@@ -237,6 +239,8 @@ fn test_encrypted_archive_hydrate() {
     let results = db
         .recall(
             &emb, 10, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(results.iter().any(|r| r.rid == rid));

--- a/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
+++ b/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
@@ -1,0 +1,498 @@
+use super::*;
+
+// ── #149 phase 2: valid-time filter on recall ────────────────────────
+//
+// `event_after` / `event_before` (epoch seconds) define the ELIGIBLE
+// UNIVERSE before relevance ranking and top_k — filter-first, per the
+// reviewer-confirmed contract:
+//
+//   - NULL `event_time_min` rows are EXCLUDED whenever either bound is
+//     set (unknown-when is not in-window; a future opt-in may re-admit
+//     them, never a default);
+//   - inclusive interval overlap: `after` alone ⇒ max >= after,
+//     `before` alone ⇒ min <= before, both ⇒ the intervals overlap,
+//     boundary equality included;
+//   - `event_after > event_before` is a typed InvalidInput error, not
+//     an empty result;
+//   - transaction-time filtering (`time_window`, `recall_as_of`) is a
+//     SEPARATE axis and is untouched.
+//
+// The tests below are the six adversarial cases from the contract. The
+// pin test is the load-bearing one: it is the case that post-filtering
+// a bounded similarity pool cannot pass.
+// =====================================================================
+
+/// Caller-supplied event-time metadata. The caller owns all three keys
+/// as one unit (merge_event_dates ownership rule), so all three are
+/// supplied together.
+fn event_meta(iso: &str, min: f64, max: f64) -> serde_json::Value {
+    serde_json::json!({
+        "event_dates": [iso],
+        "event_time_min": min,
+        "event_time_max": max,
+    })
+}
+
+/// A unit vector nearly parallel to axis 0 — decoy similarity ~1.0
+/// against an axis-0 query, each decoy distinct.
+fn decoy_vec(i: usize, dim: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; dim];
+    v[0] = 1.0;
+    v[1 + (i % (dim - 1))] = 0.001 * (1.0 + (i / (dim - 1)) as f32);
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    v.iter().map(|x| x / norm).collect()
+}
+
+/// A unit vector with LOW (0.3) similarity to the axis-0 query — far
+/// below every decoy, so it can never enter a bounded similarity pool
+/// on merit.
+fn low_sim_vec(dim: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; dim];
+    v[0] = 0.3;
+    v[1] = (1.0f32 - 0.09).sqrt();
+    v
+}
+
+fn axis0(dim: usize) -> Vec<f32> {
+    let mut v = vec![0.0f32; dim];
+    v[0] = 1.0;
+    v
+}
+
+/// The full recall call with only the valid-time bounds varying.
+/// `skip_reinforce` so repeated recalls in one test observe, not mutate.
+fn recall_window(
+    db: &YantrikDB,
+    query: &[f32],
+    top_k: usize,
+    namespace: Option<&str>,
+    event_after: Option<f64>,
+    event_before: Option<f64>,
+) -> crate::error::Result<Vec<RecallResult>> {
+    db.recall(
+        query,
+        top_k,
+        None,  // time_window (transaction time — separate axis)
+        None,  // memory_type
+        false, // include_consolidated
+        false, // expand_entities
+        None,  // query_text
+        true,  // skip_reinforce
+        namespace,
+        None,  // domain
+        None,  // source
+        None,  // certainty_min
+        None,  // order
+        false, // include_superseded
+        event_after,
+        event_before,
+    )
+}
+
+/// Record with a fixed low importance (0.4 — below every importance-
+/// fallback threshold, so ONLY the vector pool or the #149 universe
+/// lane can admit these rows; nothing else can mask a false negative).
+fn put(db: &YantrikDB, text: &str, meta: &serde_json::Value, emb: &[f32]) -> String {
+    db.record(
+        text, "episodic", 0.4, 0.0, 604800.0, meta, emb, "default", 0.8, "general", "user", None,
+    )
+    .unwrap()
+}
+
+fn rid_set(results: &[RecallResult]) -> std::collections::HashSet<String> {
+    results.iter().map(|r| r.rid.clone()).collect()
+}
+
+/// (a) THE PIN TEST — the case this issue exists to fix.
+///
+/// 80 in-cache decoys sit at similarity ~1.0 to the query and carry NO
+/// event time; ONE relevant record carries an in-window event time but
+/// similarity 0.3. With top_k=3 the unfiltered candidate pool is
+/// `recall_fetch_plan`'s top_k*20 = 60 nearest — all decoys — so the
+/// relevant record's similarity rank (81st) is BELOW the pool size.
+/// An implementation that post-filters that bounded pool returns
+/// nothing (the bounded-by-today's-top-k false negative); filter-first
+/// must return the record because it is the only member of the
+/// eligible universe.
+#[test]
+fn pin_in_window_record_below_the_similarity_pool_is_still_returned() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+
+    for i in 0..80 {
+        put(
+            &db,
+            &format!("decoy note {i}"),
+            &empty_meta(),
+            &decoy_vec(i, 8),
+        );
+    }
+    let relevant = put(
+        &db,
+        "the outage happened back then",
+        &event_meta("2001-09-09", 1_000_000.0, 1_000_000.0),
+        &low_sim_vec(8),
+    );
+
+    // Precondition making the pin adversarial: unbounded recall at the
+    // same top_k never surfaces the relevant record on similarity.
+    let unbounded = recall_window(&db, &query, 3, Some("default"), None, None).unwrap();
+    assert!(
+        !rid_set(&unbounded).contains(&relevant),
+        "precondition: the in-window record must NOT be reachable through \
+         the unfiltered top-k similarity pool"
+    );
+
+    let bounded = recall_window(
+        &db,
+        &query,
+        3,
+        Some("default"),
+        Some(999_000.0),
+        Some(1_001_000.0),
+    )
+    .unwrap();
+    assert_eq!(
+        rid_set(&bounded),
+        std::collections::HashSet::from([relevant.clone()]),
+        "filter-first: the ONLY member of the eligible universe must be \
+         returned even though its similarity rank is below the candidate \
+         pool size — post-filtering a bounded pool fails exactly here"
+    );
+    // The universe lane stamps its admission.
+    assert!(
+        bounded[0]
+            .why_retrieved
+            .iter()
+            .any(|w| w == "event_time_window"),
+        "the direct-scored admission should carry the event_time_window why marker"
+    );
+}
+
+/// (b) Better similarity does not buy eligibility: an out-of-window row
+/// scoring far above every in-window row is excluded.
+#[test]
+fn higher_scoring_out_of_window_rows_are_excluded() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+
+    // Near-perfect similarity, but the event sits OUTSIDE the window.
+    let outside = put(
+        &db,
+        "perfect match, wrong era",
+        &event_meta("1970-01-24", 2_000_000.0, 2_000_000.0),
+        &decoy_vec(0, 8),
+    );
+    // Weak similarity, event inside the window.
+    let inside = put(
+        &db,
+        "weak match, right era",
+        &event_meta("1970-01-12", 1_000_000.0, 1_000_000.0),
+        &low_sim_vec(8),
+    );
+
+    let results = recall_window(&db, &query, 10, None, Some(900_000.0), Some(1_100_000.0)).unwrap();
+    let rids = rid_set(&results);
+    assert!(rids.contains(&inside), "in-window row must be returned");
+    assert!(
+        !rids.contains(&outside),
+        "out-of-window row must be excluded despite better similarity"
+    );
+}
+
+/// (c) Boundary equality is INCLUDED on both edges: `max == after` and
+/// `min == before` both qualify (inclusive interval overlap).
+#[test]
+fn boundary_equality_is_included() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+
+    // Interval [1_000.0, 2_000.0].
+    let interval = put(
+        &db,
+        "spanning event",
+        &event_meta("1970-01-01", 1_000.0, 2_000.0),
+        &decoy_vec(0, 8),
+    );
+
+    // after == event_time_max: overlap at exactly one point — included.
+    let at_max = recall_window(&db, &query, 10, None, Some(2_000.0), None).unwrap();
+    assert!(
+        rid_set(&at_max).contains(&interval),
+        "event_time_max == event_after must be included (inclusive)"
+    );
+
+    // before == event_time_min: overlap at exactly one point — included.
+    let at_min = recall_window(&db, &query, 10, None, None, Some(1_000.0)).unwrap();
+    assert!(
+        rid_set(&at_min).contains(&interval),
+        "event_time_min == event_before must be included (inclusive)"
+    );
+
+    // And one epsilon past each edge is OUT.
+    let past_max = recall_window(&db, &query, 10, None, Some(2_000.5), None).unwrap();
+    assert!(
+        !rid_set(&past_max).contains(&interval),
+        "event_after just past event_time_max must exclude"
+    );
+    let past_min = recall_window(&db, &query, 10, None, None, Some(999.5)).unwrap();
+    assert!(
+        !rid_set(&past_min).contains(&interval),
+        "event_before just before event_time_min must exclude"
+    );
+}
+
+/// (d) NULL event-time rows: excluded whenever EITHER bound is set,
+/// still returned when no bound is set.
+#[test]
+fn null_event_time_rows_are_excluded_only_when_a_bound_is_set() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+
+    let dated = put(
+        &db,
+        "dated row",
+        &event_meta("1970-01-12", 1_000_000.0, 1_000_000.0),
+        &decoy_vec(0, 8),
+    );
+    let undated = put(&db, "undated row", &empty_meta(), &decoy_vec(1, 8));
+
+    // No bounds: both reachable.
+    let open = recall_window(&db, &query, 10, None, None, None).unwrap();
+    assert!(rid_set(&open).contains(&undated));
+    assert!(rid_set(&open).contains(&dated));
+
+    // after alone — a window the undated row would trivially "satisfy"
+    // if NULL were treated as always-in: excluded instead.
+    let after_only = recall_window(&db, &query, 10, None, Some(0.0), None).unwrap();
+    assert!(
+        !rid_set(&after_only).contains(&undated),
+        "NULL event_time_min must be excluded when event_after is set"
+    );
+    assert!(rid_set(&after_only).contains(&dated));
+
+    // before alone: same exclusion.
+    let before_only = recall_window(&db, &query, 10, None, None, Some(2_000_000.0)).unwrap();
+    assert!(
+        !rid_set(&before_only).contains(&undated),
+        "NULL event_time_min must be excluded when event_before is set"
+    );
+    assert!(rid_set(&before_only).contains(&dated));
+}
+
+/// (e) Half-open windows follow the overlap semantics: `after` alone
+/// keeps everything ending at/after it, `before` alone keeps
+/// everything starting at/before it.
+#[test]
+fn only_after_and_only_before_each_follow_overlap_semantics() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+
+    let early = put(
+        &db,
+        "early event",
+        &event_meta("1970-01-01", 1_000.0, 1_000.0),
+        &decoy_vec(0, 8),
+    );
+    let middle = put(
+        &db,
+        "middle event",
+        &event_meta("1970-01-01", 2_000.0, 2_000.0),
+        &decoy_vec(1, 8),
+    );
+    let late = put(
+        &db,
+        "late event",
+        &event_meta("1970-01-01", 3_000.0, 3_000.0),
+        &decoy_vec(2, 8),
+    );
+
+    let after = recall_window(&db, &query, 10, None, Some(2_000.0), None).unwrap();
+    assert_eq!(
+        rid_set(&after),
+        std::collections::HashSet::from([middle.clone(), late.clone()]),
+        "after alone: event_time_max >= after (boundary in, earlier out)"
+    );
+
+    let before = recall_window(&db, &query, 10, None, None, Some(2_000.0)).unwrap();
+    assert_eq!(
+        rid_set(&before),
+        std::collections::HashSet::from([early, middle]),
+        "before alone: event_time_min <= before (boundary in, later out)"
+    );
+}
+
+/// An inverted window is a caller error (typed InvalidInput), never an
+/// empty result — empty would falsely claim "nothing happened then".
+#[test]
+fn inverted_window_is_invalid_input_not_empty() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+    put(
+        &db,
+        "some event",
+        &event_meta("1970-01-12", 1_000_000.0, 1_000_000.0),
+        &decoy_vec(0, 8),
+    );
+
+    let err = recall_window(&db, &query, 10, None, Some(2_000.0), Some(1_000.0)).unwrap_err();
+    assert!(
+        matches!(err, crate::error::YantrikDbError::InvalidInput(_)),
+        "event_after > event_before must be InvalidInput, got {err:?}"
+    );
+}
+
+/// (f) Leader/follower ELIGIBLE-UNIVERSE parity: after replication
+/// apply, the same bounded recall draws from the same eligible rid set
+/// on both engines. One row is stamped by the datetext extractor from
+/// prose (the natural path), one by caller-supplied keys, one is
+/// undated, one is out-of-window.
+///
+/// DELIBERATELY NARROWED CONTRACT (review decision, #173): this proves
+/// universe MEMBERSHIP parity, not returned-set parity under a tight
+/// top_k. A follower's record ops carry only the embedding hash, so its
+/// vectorless rows score 0.0 and RANKING can diverge from the leader
+/// until embeddings materialize — see
+/// `bounded_recall_follower_topk_ranking_divergence_is_deterministic`,
+/// which pins that degradation explicitly. Full replica query parity
+/// (embedding replication/materialization) is tracked separately.
+#[test]
+fn bounded_recall_is_replication_parity_safe() {
+    use crate::replication::{apply_ops, extract_ops_since};
+
+    let leader = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+
+    // Natural path: the datetext extractor stamps 2024-03-15 from prose.
+    let rid_prose = put(
+        &leader,
+        "met Alice on 2024-03-15",
+        &empty_meta(),
+        &decoy_vec(0, 8),
+    );
+    // Caller-supplied keys, same window.
+    let rid_caller = put(
+        &leader,
+        "spring planning session",
+        &event_meta("2024-03-20", 1_710_892_800.0, 1_710_892_800.0),
+        &decoy_vec(1, 8),
+    );
+    // Out-of-window (2023) and undated rows must be absent on BOTH.
+    let rid_2023 = put(
+        &leader,
+        "an older event",
+        &event_meta("2023-03-15", 1_678_838_400.0, 1_678_838_400.0),
+        &decoy_vec(2, 8),
+    );
+    let rid_undated = put(&leader, "no date at all", &empty_meta(), &decoy_vec(3, 8));
+
+    let follower = YantrikDB::new(":memory:", 8).unwrap();
+    let ops = extract_ops_since(&leader.conn(), None, None, None, 100).unwrap();
+    apply_ops(&follower, &ops).unwrap();
+
+    // March 2024 window.
+    let (after, before) = (1_709_251_200.0, 1_711_929_600.0);
+    let on_leader = recall_window(&leader, &query, 10, None, Some(after), Some(before)).unwrap();
+    let on_follower =
+        recall_window(&follower, &query, 10, None, Some(after), Some(before)).unwrap();
+
+    let expected: std::collections::HashSet<String> =
+        [rid_prose.clone(), rid_caller.clone()].into();
+    assert_eq!(
+        rid_set(&on_leader),
+        expected,
+        "leader: exactly the two in-window rows (prose-stamped + caller-stamped)"
+    );
+    assert_eq!(
+        rid_set(&on_follower),
+        rid_set(&on_leader),
+        "follower after apply_ops must return the same rid set for the same bounds"
+    );
+    // Guard the negative half explicitly on both engines.
+    for (name, results) in [("leader", &on_leader), ("follower", &on_follower)] {
+        let rids = rid_set(results);
+        assert!(!rids.contains(&rid_2023), "{name}: 2023 row must be out");
+        assert!(
+            !rids.contains(&rid_undated),
+            "{name}: undated row must be out"
+        );
+    }
+}
+
+/// The documented follower degradation the narrowed contract accepts
+/// (review finding, #173): a follower's vectorless eligible rows all
+/// score 0.0, so under a tight top_k its RANKING diverges from the
+/// leader deterministically (rid tie-break) even though the eligible
+/// universe is identical. Reproduces the reviewer's exact scenario:
+/// orthogonal distractor recorded first (earlier rid), exact-vector
+/// relevant row second, top_k=1 — leader returns the relevant row,
+/// follower returns the distractor. If embedding materialization ever
+/// lands and this test FAILS on the follower half, that is the signal
+/// to restore full returned-set parity in the contract.
+#[test]
+fn bounded_recall_follower_topk_ranking_divergence_is_deterministic() {
+    use crate::replication::{apply_ops, extract_ops_since};
+
+    let leader = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+
+    // Distractor FIRST: earlier rid wins a 0.0-score tie-break. Low
+    // similarity (0.3) so the leader unambiguously ranks it below the
+    // exact-vector row. (NOT decoy_vec — that helper is deliberately
+    // ~parallel to the query.)
+    let rid_distractor = put(
+        &leader,
+        "in-window distractor",
+        &event_meta("2024-03-10", 1_710_028_800.0, 1_710_028_800.0),
+        &low_sim_vec(8),
+    );
+    let rid_relevant = put(
+        &leader,
+        "in-window relevant",
+        &event_meta("2024-03-20", 1_710_892_800.0, 1_710_892_800.0),
+        &query, // exact query vector
+    );
+
+    let follower = YantrikDB::new(":memory:", 8).unwrap();
+    let ops = extract_ops_since(&leader.conn(), None, None, None, 100).unwrap();
+    apply_ops(&follower, &ops).unwrap();
+
+    let (after, before) = (1_709_251_200.0, 1_711_929_600.0);
+    let on_leader = recall_window(&leader, &query, 1, None, Some(after), Some(before)).unwrap();
+    let on_follower = recall_window(&follower, &query, 1, None, Some(after), Some(before)).unwrap();
+
+    assert_eq!(
+        on_leader[0].rid, rid_relevant,
+        "leader ranks by real similarity"
+    );
+    assert_eq!(
+        on_follower[0].rid, rid_distractor,
+        "follower (vectorless, all 0.0) tie-breaks by rid — the documented \
+         deterministic degradation; if this ever returns the relevant row, \
+         embedding materialization landed and the contract can widen"
+    );
+}
+
+/// Non-finite bounds are rejected up front (repo-wide caller-scalar
+/// rule): NaN makes every comparison false, so it would silently pass
+/// the inversion check and match nothing — a lie shaped like an empty
+/// result.
+#[test]
+fn non_finite_bounds_are_invalid_scalars() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+    for (after, before) in [
+        (Some(f64::NAN), None),
+        (None, Some(f64::NAN)),
+        (Some(f64::INFINITY), None),
+        (None, Some(f64::NEG_INFINITY)),
+        (Some(f64::NAN), Some(f64::NAN)),
+    ] {
+        let err = recall_window(&db, &query, 5, None, after, before).unwrap_err();
+        assert!(
+            matches!(err, crate::error::YantrikDbError::InvalidScalar { .. }),
+            "non-finite bound (after={after:?}, before={before:?}) must be \
+             InvalidScalar, got {err:?}"
+        );
+    }
+}

--- a/crates/yantrikdb-core/src/engine/tests/interactive_recall.rs
+++ b/crates/yantrikdb-core/src/engine/tests/interactive_recall.rs
@@ -270,6 +270,8 @@ fn test_recall_refine_excludes_originals() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert_eq!(first_results.len(), 2);

--- a/crates/yantrikdb-core/src/engine/tests/metamorphic.rs
+++ b/crates/yantrikdb-core/src/engine/tests/metamorphic.rs
@@ -140,6 +140,8 @@ fn top_rids(db: &YantrikDB, query: &str, k: usize) -> Vec<String> {
         None,
         None,
         false,
+        None, // event_after (#149)
+        None, // event_before (#149)
     )
     .expect("recall")
     .into_iter()
@@ -715,6 +717,8 @@ fn certainty_floor_holds_across_every_lane() {
             Some(0.8),
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(

--- a/crates/yantrikdb-core/src/engine/tests/mod.rs
+++ b/crates/yantrikdb-core/src/engine/tests/mod.rs
@@ -24,6 +24,7 @@ mod encryption;
 #[cfg(feature = "bundled-embedder")]
 mod encryption_canary;
 mod event_time_columns;
+mod event_time_recall;
 // The explain suite drives the full text path (record_text/
 // recall_text_explained), which needs the bundled embedder — slim
 // builds (--no-default-features) have no `with_default`.

--- a/crates/yantrikdb-core/src/engine/tests/recall_confidence.rs
+++ b/crates/yantrikdb-core/src/engine/tests/recall_confidence.rs
@@ -83,6 +83,8 @@ fn recall_certainty_min_filters_low_certainty() {
             Some(0.5), // certainty_min
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
 
@@ -125,6 +127,8 @@ fn recall_order_certainty_returns_results_in_certainty_desc() {
             None,
             Some("certainty"),
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
 
@@ -167,6 +171,8 @@ fn recall_order_recency_returns_results_in_created_at_desc() {
             None,
             Some("recency"),
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
 
@@ -233,6 +239,8 @@ fn recall_order_first_mention_uses_metadata_then_created_at() {
                 None,
                 Some(order),
                 false,
+                None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
         assert_eq!(
@@ -269,6 +277,8 @@ fn recall_order_invalid_string_returns_invalid_input_error() {
             None,
             Some("most_relevant"), // typo / not a valid order
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .expect_err("invalid order string must return error");
 
@@ -307,6 +317,8 @@ fn recall_default_order_is_relevance_unchanged() {
             None,
             None, // default order = relevance
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
 

--- a/crates/yantrikdb-core/src/engine/tests/recall_graph.rs
+++ b/crates/yantrikdb-core/src/engine/tests/recall_graph.rs
@@ -231,16 +231,22 @@ fn test_recall_deterministic_with_skip_reinforce() {
     let r1 = db
         .recall(
             &query, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     let r2 = db
         .recall(
             &query, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     let r3 = db
         .recall(
             &query, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
 
@@ -299,6 +305,8 @@ fn test_reinforce_mutates_but_skip_does_not() {
         None,
         None,
         false,
+        None, // event_after (#149)
+        None, // event_before (#149)
     )
     .unwrap();
     let after_skip = db.get(&rid).unwrap().unwrap().half_life;
@@ -320,6 +328,8 @@ fn test_reinforce_mutates_but_skip_does_not() {
         None,
         None,
         false,
+        None, // event_after (#149)
+        None, // event_before (#149)
     )
     .unwrap();
     let after_reinforce = db.get(&rid).unwrap().unwrap().half_life;
@@ -382,6 +392,8 @@ fn test_graph_expansion_off_no_graph_results() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     for r in &results {
@@ -448,6 +460,8 @@ fn test_graph_expansion_on_boosts_connected_memory() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
 
@@ -559,6 +573,8 @@ fn test_recall_scores_bounded() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     for r in &results {
@@ -676,6 +692,8 @@ fn test_recall_top_k_respected_with_graph_expansion() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
 

--- a/crates/yantrikdb-core/src/engine/tests/replication_api.rs
+++ b/crates/yantrikdb-core/src/engine/tests/replication_api.rs
@@ -64,6 +64,8 @@ fn test_insert_vector_makes_recall_find_it() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
 
@@ -398,6 +400,8 @@ fn record_with_rid_makes_recall_find_it() {
     let results = db
         .recall(
             &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(
@@ -759,6 +763,8 @@ fn tombstone_with_rid_hides_from_recall() {
     let r = db
         .recall(
             &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(r.iter().any(|x| x.rid == rid), "visible before tombstone");
@@ -770,6 +776,8 @@ fn tombstone_with_rid_hides_from_recall() {
     let r2 = db
         .recall(
             &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(!r2.iter().any(|x| x.rid == rid), "hidden after tombstone");

--- a/crates/yantrikdb-core/src/engine/tests/ryw_visibility.rs
+++ b/crates/yantrikdb-core/src/engine/tests/ryw_visibility.rs
@@ -185,6 +185,8 @@ fn issue_8_tombstoned_memories_excluded_from_recall() {
     let before = db
         .recall(
             &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(
@@ -198,6 +200,8 @@ fn issue_8_tombstoned_memories_excluded_from_recall() {
     let after = db
         .recall(
             &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(
@@ -242,6 +246,8 @@ fn issue_8_tombstoned_persists_across_engine_reopen() {
         let after = db2
             .recall(
                 &emb, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+                None, // event_after (#149)
+                None, // event_before (#149)
             )
             .unwrap();
         assert!(

--- a/crates/yantrikdb-core/src/engine/tests/storage_fts.rs
+++ b/crates/yantrikdb-core/src/engine/tests/storage_fts.rs
@@ -216,6 +216,8 @@ fn test_archive_memory() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(
@@ -258,6 +260,8 @@ fn test_hydrate_memory() {
     let results = db
         .recall(
             &emb, 10, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(
@@ -379,6 +383,8 @@ fn test_evict() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     for r in &results {

--- a/crates/yantrikdb-core/src/engine/tests/trace_entities.rs
+++ b/crates/yantrikdb-core/src/engine/tests/trace_entities.rs
@@ -84,6 +84,8 @@ fn t06_anti_laundering_chokepoint() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     let hit = results

--- a/crates/yantrikdb-core/tests/kill_correct_boundary.rs
+++ b/crates/yantrikdb-core/tests/kill_correct_boundary.rs
@@ -163,7 +163,8 @@ fn kill_after_correct_commit_keeps_sql_consistent_and_index_rebuilds() {
     let q = db.embed("financial revenue report").unwrap();
     let hits = db
         .recall(
-            &q, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            &q, 5, None, None, false, false, None, true, None, None, None, None, None, false, None,
+            None,
         )
         .unwrap();
     assert!(

--- a/crates/yantrikdb-core/tests/pack_mount.rs
+++ b/crates/yantrikdb-core/tests/pack_mount.rs
@@ -98,6 +98,8 @@ fn record(db: &YantrikDB, text: &str, emb: &[f32], ns: &str) -> String {
 fn recall_texts(db: &YantrikDB, query: &[f32], k: usize) -> Vec<String> {
     db.recall(
         query, k, None, None, false, false, None, true, None, None, None, None, None, false,
+        None, // event_after (#149)
+        None, // event_before (#149)
     )
     .unwrap()
     .into_iter()
@@ -202,6 +204,88 @@ fn embedder_identity_survives_reopen() {
             YantrikDbError::ChangeEmbedderDigestRequiresReembed { .. }
         ),
         "expected digest guard, got {err:?}"
+    );
+}
+
+/// #149 phase 2: bounded recall must EXCLUDE all mounted-pack rows.
+///
+/// Pack rows live outside the host's indexed event-time universe, so
+/// their event time is effectively unknown — the NULL-excluded rule
+/// extends to them. This is the review-blocker regression: before the
+/// gate, `collect_pack_candidates` merged unconditionally and a pack
+/// hit could appear despite `event_after`/`event_before`, bypassing
+/// both NULL-exclusion and filter-first. Full pack event-time support
+/// is a follow-up (the #164 v1.1 pack-lane pattern).
+#[test]
+fn bounded_recall_excludes_mounted_pack_rows() {
+    let dir = tmpdir("bounded");
+    let pack = dir.join("physics.ydbpack");
+    build_pack(
+        &dir,
+        pack.to_str().unwrap(),
+        "E0",
+        &[("gluons bind quarks", 3)],
+    );
+
+    let db = host(&dir, "E0");
+    // A dated host record inside the window, so the bounded recall has a
+    // legitimate result and the pack row's absence is attributable to the
+    // pack gate rather than an empty universe.
+    db.record_text(
+        "met the physicist on 2024-03-15",
+        "semantic",
+        0.6,
+        0.0,
+        604800.0,
+        &serde_json::json!({}),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap();
+    db.mount_pack(pack.to_str().unwrap()).unwrap();
+
+    let query = vec_on(3, 0.05);
+    let unbounded = recall_texts(&db, &query, 5);
+    assert!(
+        unbounded.iter().any(|t| t.contains("gluons")),
+        "pack content must be retrievable in UNBOUNDED recall: {unbounded:?}"
+    );
+
+    // 2024-01-01..2024-12-31 — the dated host record overlaps; the pack
+    // row (unknown event time) must not appear.
+    let bounded: Vec<String> = db
+        .recall(
+            &query,
+            5,
+            None,
+            None,
+            false,
+            false,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            Some(1704067200.0),
+            Some(1735603200.0),
+        )
+        .unwrap()
+        .into_iter()
+        .map(|r| r.text)
+        .collect();
+    assert!(
+        !bounded.iter().any(|t| t.contains("gluons")),
+        "bounded recall must exclude mounted-pack rows: {bounded:?}"
+    );
+    assert!(
+        bounded.iter().any(|t| t.contains("physicist")),
+        "the in-window host record must still be returned: {bounded:?}"
     );
 }
 
@@ -508,6 +592,8 @@ fn host_correction_supersedes_pack_row() {
     let pack_rid = db
         .recall(
             &query, 5, None, None, false, false, None, true, None, None, None, None, None, false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap()
         .into_iter()
@@ -1220,6 +1306,8 @@ fn mounted_pack_reports_its_namespace() {
             None,
             None,
             false,
+            None, // event_after (#149)
+            None, // event_before (#149)
         )
         .unwrap();
     assert!(

--- a/crates/yantrikdb-python/src/py_engine/memory.rs
+++ b/crates/yantrikdb-python/src/py_engine/memory.rs
@@ -137,7 +137,7 @@ impl PyYantrikDB {
     // entity-linked noise sharing an entity name outranks genuinely
     // similar records. Neutral even on the synthetic connected corpus.
     // Opt in per-call for curated, dense entity graphs.
-    #[pyo3(signature = (query=None, query_embedding=None, top_k=10, time_window=None, memory_type=None, include_consolidated=false, expand_entities=false, skip_reinforce=false, namespace=None, domain=None, source=None, certainty_min=None, order=None, include_superseded=false, snippets=false, min_score_ratio=None))]
+    #[pyo3(signature = (query=None, query_embedding=None, top_k=10, time_window=None, memory_type=None, include_consolidated=false, expand_entities=false, skip_reinforce=false, namespace=None, domain=None, source=None, certainty_min=None, order=None, include_superseded=false, snippets=false, min_score_ratio=None, event_after=None, event_before=None))]
     #[allow(clippy::too_many_arguments)]
     fn recall(
         &self,
@@ -173,6 +173,12 @@ impl PyYantrikDB {
         // behavior for existing callers).
         snippets: bool,
         min_score_ratio: Option<f64>,
+        // #149 phase 2: valid-time bounds (epoch seconds). FILTER-FIRST —
+        // the window defines the eligible universe before ranking/top_k;
+        // NULL event-time rows are excluded when either bound is set;
+        // interval overlap is inclusive; after > before raises ValueError.
+        event_after: Option<f64>,
+        event_before: Option<f64>,
     ) -> PyResult<Vec<PyObject>> {
         let db = self
             .inner
@@ -207,6 +213,8 @@ impl PyYantrikDB {
                 certainty_min,
                 order,
                 include_superseded,
+                event_after,
+                event_before,
             )
             .map_err(map_err)?;
 
@@ -495,6 +503,8 @@ impl PyYantrikDB {
                     None,  // certainty_min (#46)
                     None,  // order (#46) — relevance default
                     false, // include_superseded (v0.10 Item 1)
+                    None,  // event_after (#149)
+                    None,  // event_before (#149)
                 )
                 .map_err(map_err)?;
             let out = pyo3::types::PyDict::new(py);
@@ -531,6 +541,8 @@ impl PyYantrikDB {
                 None,  // certainty_min (#46)
                 None,  // order (#46) — relevance default
                 false, // include_superseded (v0.10 Item 1) — policy default
+                None,  // event_after (#149)
+                None,  // event_before (#149)
             )
             .map_err(map_err)?;
 

--- a/crates/yantrikdb-wasm/src/lib.rs
+++ b/crates/yantrikdb-wasm/src/lib.rs
@@ -218,7 +218,7 @@ impl WasmYantrikDB {
         let results = self.inner
             .recall(
                 &embedding, top_k, None, None, false, false, None, false, None, None, None,
-                None, None, false,
+                None, None, false, None, None,
             )
             .map_err(|e| JsError::new(&e.to_string()))?;
 


### PR DESCRIPTION
Phase 2 of #149, implemented verbatim on the reviewer-confirmed contract (swarm design decision, 2026-08-23): when `event_after`/`event_before` is set, the temporal bounds define the **eligible universe before relevance and top_k** — never a post-filter on a bounded similarity pool, which is exactly the false-negative shape #149 names.

## Semantics (contract)
- Inclusive interval-overlap: `after` ⇒ `event_time_max >= after`; `before` ⇒ `event_time_min <= before`; both ⇒ window overlap
- NULL event-time rows excluded whenever a bound is set (`include_unknown_event_time` reserved as future explicit opt-in, never the default)
- `event_after > event_before` is `InvalidInput`, not an empty result
- Transaction-time (`time_window`, `recall_as_of`) untouched

## Mechanism
One indexed SQL query over `idx_memories_event_time` builds the universe as a rid set (no textual IN-list); `passes_recall_filters` — the single every-lane predicate — gates all lanes on membership; a universe lane direct-scores any eligible row no lane admitted (similarity ranks; eligibility is temporal; no floor). Two latent premises fixed so filter-first holds on followers: the empty-vector-pool short-circuit no longer fires under bounds, and batched embedding reads skip NULL rows (follower record ops carry only the embedding hash) — such rows admit at similarity 0.0, keeping leader/follower rid-set parity.

## Tests
All six contract adversarial cases + validation, in `event_time_recall.rs`: the pin test (in-window record ranked 81st against 80 decoys with pool size 60 — still returned; fails under pool-post-filtering), out-of-window excluded despite higher score, boundary equality inclusive, NULL-excluded-only-under-bounds, only-after/only-before overlap semantics, replication parity via `apply_ops`, inverted-window error.

Python binding: `recall(..., event_after=None, event_before=None)`.

**Scope note:** per the frozen expected-gain audit (#172), this ships as product/API capability — the explicit-date cohort ceiling on BEAM full-400 is +0.0125, so no model run is funded on it. Phase 3 (as-of pool) is deprioritized behind the composition arm.

Full lib suite on the rebase over #171: **2059 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)