### PR TITLE
bench(amb): decompose direct-engine loss bucket

### DIFF
--- a/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
+++ b/benchmarks/amb/CATEGORY_LOSS_FUNNEL.md
@@ -120,6 +120,53 @@ its gate. The Q7 A/A calibration also observed about `0.02` answer-generation
 standard error within a 40-query category. Threshold claims therefore require
 replication even when a single full run crosses 90.
 
+### Direct-engine bucket decomposition
+
+The `16.422` direct-engine label is substantially more optimistic than its
+name suggests. The machine-readable audit now decomposes it:
+
+| Component | Points | Share of bucket | Basis |
+|---|---:|---:|---|
+| event ordering | 7.093 | 43.2% | whole category, optimistic |
+| temporal reasoning | 5.875 | 35.8% | whole category, optimistic |
+| abstention provenance | 1.750 | 10.7% | audited zero-row proxy |
+| instruction salience | 0.875 | 5.3% | audited score-deficit share |
+| summarization retrieval | 0.459 | 2.8% | audited item-retention proxy |
+| preference salience | 0.250 | 1.5% | audited score-deficit share |
+| information-extraction retrieval | 0.099 | 0.6% | audited item-retention proxy |
+| contradiction retrieval | 0.021 | 0.1% | audited item-retention proxy |
+
+Thus `12.968` points, or `79.0%` of the bucket, are not row-level engine
+attributions at all. They are the complete loss of two weak categories placed
+in the engine bucket as an optimistic ceiling assumption. This distinction is
+important when choosing work: a category being temporal does not prove an
+event-time index can recover its loss.
+
+The existing experiments narrow those two wholesale assignments further:
+
+- Event ordering's best complete concern-selected synthesis result is
+  `0.33969` versus the frozen `0.29071`, a measured recovery of `0.490` full
+  benchmark points, or only `6.9%` of the category's assigned loss. It remains
+  opt-in because 13/40 rows regressed and required query-dependent item
+  granularity; fixed write-time coarse synthesis is not valid.
+- Temporal reasoning exposes an explicit calendar date in only 1/40 queries,
+  for at most `0.250` full benchmark points under a perfect direct filter.
+  Three mechanically invalid gold calculations account for `0.750` points,
+  while endpoint-only retrieval regressed and endpoint-prepending was
+  inconclusive. The remainder is primarily operand selection, arithmetic,
+  and revision ambiguity, not yet an engine attribution.
+- The standing-instruction facet recovered `0.750` of its `0.875` attributed
+  points on the target slice. Its global-default failure came from composition
+  cost, now measured separately as whole-block displacement.
+- Equal-budget role-aware abstention recovered `0.500` points in its discovery
+  run but missed the preregistered lift gate and showed answer variance.
+
+Knowledge update and multi-session reasoning contribute exactly zero to the
+current direct-engine bucket. Their large losses are assigned to benchmark
+integrity, reader assembly, and residual shares. They may motivate product
+features, but they must not be cited as explaining the `16.422` direct-engine
+number without a new row-level attribution.
+
 ## Decision
 
 Do not spend the next product cycle increasing generic top-k for summarization,

--- a/benchmarks/amb/audit_category_loss_funnel.py
+++ b/benchmarks/amb/audit_category_loss_funnel.py
@@ -396,6 +396,43 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
             for category, summary in tail_summaries.items()
         )
     )
+    direct_engine_components = {
+        "event_ordering_whole_category": {
+            "points": loss("event_ordering"),
+            "basis": "whole_category_optimistic",
+        },
+        "temporal_reasoning_whole_category": {
+            "points": loss("temporal_reasoning"),
+            "basis": "whole_category_optimistic",
+        },
+        "summarization_retrieval_proxy": {
+            "points": loss("summarization")
+            * _attribution_share(summarization, "ours"),
+            "basis": "audited_retrieval_proxy",
+        },
+        "abstention_provenance_proxy": {
+            "points": loss("abstention") * _attribution_share(abstention, "ours"),
+            "basis": "audited_provenance_proxy",
+        },
+        **{
+            f"{category}_retrieval_proxy": {
+                "points": loss(category) * _attribution_share(summary, "ours"),
+                "basis": "audited_retrieval_proxy",
+            }
+            for category, summary in tail_summaries.items()
+        },
+    }
+    direct_engine_component_total = sum(
+        component["points"] for component in direct_engine_components.values()
+    )
+    if abs(direct_engine_component_total - ours_direct) > 1e-9:
+        raise ValueError("direct-engine component decomposition does not conserve")
+    wholesale_direct = sum(
+        component["points"]
+        for component in direct_engine_components.values()
+        if component["basis"] == "whole_category_optimistic"
+    )
+    audited_direct = ours_direct - wholesale_direct
     undiagnosed_tail = sum(
         loss(category)
         for category, summary in tail_summaries.items()
@@ -436,6 +473,28 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
             for category, value in sorted(category_losses.items())
         },
         "buckets": {name: round(value, 6) for name, value in buckets.items()},
+        "direct_engine_decomposition": {
+            "components": {
+                name: {
+                    **component,
+                    "points": round(component["points"], 6),
+                    "share_of_direct_engine": (
+                        round(component["points"] / ours_direct, 6)
+                        if ours_direct
+                        else None
+                    ),
+                }
+                for name, component in direct_engine_components.items()
+            },
+            "whole_category_optimistic_points": round(wholesale_direct, 6),
+            "whole_category_optimistic_share": (
+                round(wholesale_direct / ours_direct, 6) if ours_direct else None
+            ),
+            "audited_proxy_points": round(audited_direct, 6),
+            "audited_proxy_share": (
+                round(audited_direct / ours_direct, 6) if ours_direct else None
+            ),
+        },
         "bucket_conservation_delta": round(total_loss - bucket_total, 12),
         "optimistic_ceiling_percent": round(100.0 - dead, 6),
         "points_required_to_reach_90": round(recovery_to_90, 6),
@@ -458,6 +517,10 @@ def ceiling_estimate(result_payload: dict, summaries: dict[str, dict]) -> dict:
             "ours_direct_engine": (
                 "all event-ordering and temporal loss plus retrieval-attributed "
                 "shares in audited categories"
+            ),
+            "direct_engine_decomposition": (
+                "whole-category event/temporal assignments are optimistic buckets, "
+                "not row-level causal diagnoses"
             ),
             "optimistic_ceiling": "full recovery of every point not classified dead",
             "reader_shaping_sensitivity": (

--- a/tests/test_amb_audit_category_loss_funnel.py
+++ b/tests/test_amb_audit_category_loss_funnel.py
@@ -280,3 +280,14 @@ def test_ceiling_estimate_conserves_full_line_loss():
         "audited_residual": 4.612351,
     }
     assert full_estimate["reader_shaping_recovery_sensitivity"]["0.5"] == 91.545497
+    direct = full_estimate["direct_engine_decomposition"]
+    assert direct["whole_category_optimistic_points"] == 12.967857
+    assert direct["whole_category_optimistic_share"] == 0.789662
+    assert direct["audited_proxy_points"] == 3.454179
+    assert abs(
+        sum(component["points"] for component in direct["components"].values())
+        - full_estimate["buckets"]["ours_direct_engine"]
+    ) <= 2e-6
+    assert direct["components"]["event_ordering_whole_category"]["basis"] == (
+        "whole_category_optimistic"
+    )


### PR DESCRIPTION
Makes the 16.422-point direct-engine ceiling auditable by component. The key correction is interpretive: 12.967857 points (78.9662%) are whole-category optimistic assignments for event_ordering and temporal_reasoning, not row-level causal engine diagnoses; only 3.454179 points come from audited retrieval/provenance proxies. The JSON now reports every component, basis, and share and asserts exact conservation. Documentation overlays measured mechanism results: concern-selected event synthesis recovered 0.490 full points but remains opt-in; explicit-date temporal reach is capped at 0.250 points; instruction facets recovered 0.750/0.875 target points but need safe composition; role-aware abstention missed its gate. Knowledge update and multi-session currently contribute zero to the direct bucket. Verification: Ruff clean; 4 focused tests; real frozen 400-row audit rerun with exact conservation.