### PR TITLE
bench: preregister complete facet composition arm

### DIFF
--- a/benchmarks/amb/COMPLETE_FACET_COMPOSITION_PREFLIGHT.md
+++ b/benchmarks/amb/COMPLETE_FACET_COMPOSITION_PREFLIGHT.md
@@ -1,0 +1,48 @@
+# Complete Facet Composition V2: Product Preflight
+
+The frozen v2 mechanism passed its full 400-row product preflight before any
+external answer or judge call was made.
+
+## Result
+
+| Gate | Result |
+|---|---:|
+| Rows aligned | 400/400 |
+| Canonical instruction targets retained | 40/40 |
+| Complete verified lanes composed | 400/400 |
+| Ordinary contexts byte-exact | 400/400 |
+| Maximum additive facet tokens | 131/256 |
+| Facets per namespace | 3–5 |
+| Fresh-open artifact replay | exact |
+| Fresh-open RID selection replay | exact |
+
+Composition used no query text, category, gold answer, rubric, prior answer,
+or score. Extraction used raw turns only, persisted product facets, verified
+user evidence, and a fresh store open before composition.
+
+## Frozen Inputs
+
+| Input | SHA-256 |
+|---|---|
+| Metadata-rich 400-row result | `5ae03eade3a39c1fbaa3cf84eb9e0a2b64d50f179d6270eb8d9b5a645f051236` |
+| Frozen control contexts | `918f572927b75ab1bb2ae3edf5656eada132cf9a644953f31bf693c695d46863` |
+| BEAM 100k documents | `fc0e64bac38fcde26eece776e818f70374338d4591ecc75346cb27b613d4c128` |
+| Ordered query IDs | `08b325da5c5a9830bdc94cb25fc09a74c5e4dc06b70e433911b27c5352901b52` |
+
+## Paired Evaluation Freeze
+
+| Artifact | SHA-256 |
+|---|---|
+| Control arm | `918f572927b75ab1bb2ae3edf5656eada132cf9a644953f31bf693c695d46863` |
+| Complete-facet arm | `43a222af04195cc2d18d3a2ad15124a73208afeb0df352c956e69e86c5c5d9fb` |
+| Paired manifest | `b1b3b009b4f5d531d58edb80f157d46f02d80169535f190e1d603806cb673989` |
+
+The paired evaluator independently validated 400 rows per arm, identical query
+order, 5,913,445 control context tokens, 5,956,705 treatment context tokens,
+and a fixed budget of 800 answer plus 800 judge calls using
+`deepseek-v4-flash:0731-cloud`.
+
+The full local preflight report SHA-256 was
+`9129ae7ef2939eea031e675d8f8fad6eb390356cfc9b59cec0e784a860b101c5`.
+Large context and database artifacts remain untracked; the builder reconstructs
+them from the frozen inputs above.

--- a/benchmarks/amb/COMPLETE_FACET_COMPOSITION_PREREGISTRATION.md
+++ b/benchmarks/amb/COMPLETE_FACET_COMPOSITION_PREREGISTRATION.md
@@ -1,0 +1,82 @@
+# AMB Complete Facet Composition Preregistration
+
+Status: v2 protocol frozen after the v1 pre-call abort; product preflight
+passed and external scoring was authorized without changing the mechanism.
+
+## Question
+
+Can additive composition of the complete verified standing-instruction lane
+preserve the instruction-following lift without the unrelated-category
+context displacement observed in the rejected full-400 default-on arm?
+
+## Why V2
+
+The preregistered v1 scope-similarity selector aborted before external scoring:
+it retained 36 of 40 canonical instruction targets. All four misses were
+answer-form rules, such as date formatting, that apply to a topical question
+without being what the question is about. Changing `k` after this audit is
+forbidden.
+
+V2 removes query selection. Each BEAM namespace's complete verified lane fits
+below the additive 256-token ceiling. At this scale, selecting a subset would
+add semantic failure modes without solving a budget problem. Selection under
+genuine budget pressure is a separate follow-up for larger facet stores.
+
+## Frozen Mechanism
+
+- Cohort: all 400 rows from the same frozen `ydb-0151` control.
+- Control: every original context byte remains unchanged.
+- Treatment: a dedicated standing-instruction panel is prepended. No ordinary
+  retrieved block is removed, truncated, reordered, or rewritten.
+- Extraction uses persisted, verified `standing_instruction` facets and their
+  user evidence. The store is closed and reopened before composition.
+- Every query receives its namespace's complete verified facet lane in
+  first-mention order, with RID as the deterministic tie-break.
+- Any lane truncation aborts. There is no query route, similarity threshold,
+  category route, or score-tuned parameter.
+- The facet panel has a separate ceiling of 256 tokens. It is additive rather
+  than charged against the ordinary retrieval budget.
+- Composition may read facet text, first-mention time, and RID. It may not
+  read query text, category, gold answers, rubrics, prior answers, or scores.
+
+## Pre-Call Abort Gate
+
+`build_complete_facet_contexts.py` must construct the arm through the public
+product path and abort before any model call unless all conditions hold:
+
+1. Exactly 400 rows are aligned and all 40 canonical instruction targets are
+   present in their treatment panels. Target metadata is used only for this
+   abort audit, never for composition.
+2. Every row receives every verified standing facet in its namespace.
+3. Every original context is an exact byte suffix of treatment and its parsed
+   ordinary memory-block sequence is unchanged.
+4. No facet panel exceeds 256 tokens.
+5. A second fresh product open reconstructs identical selected RIDs and an
+   identical treatment artifact.
+
+Failure abandons or redesigns the arm before scoring. The mechanism and budget
+must not be tuned against external full-400 scores.
+
+## External Run
+
+- Model: `deepseek-v4-flash:0731-cloud`.
+- One answer and one judge per arm per row.
+- Projected calls: 800 answers and 800 judges.
+- Synthetic benchmark data only; no real companion memories.
+- The paired bootstrap uses 20,000 resamples and seed `20260820`.
+
+## Promotion Gates
+
+All gates must pass:
+
+1. `instruction_following` delta is at least `+0.05`, with more wins than
+   losses.
+2. Overall delta is non-negative and its paired 95% interval lower bound is at
+   least `-0.01`.
+3. The pooled other-nine-category delta is at least `-0.005`.
+4. `summarization` delta is at least `-0.01`.
+5. No other category delta is below `-0.025`.
+
+Every category mean, paired win/tie/loss count, and bootstrap interval is
+reported regardless of outcome. Failure keeps complete-lane composition
+opt-in and does not authorize post-hoc routing against benchmark categories.

--- a/benchmarks/amb/SELECTIVE_FACET_COMPOSITION_V1_ABORT.md
+++ b/benchmarks/amb/SELECTIVE_FACET_COMPOSITION_V1_ABORT.md
@@ -1,0 +1,29 @@
+# Selective Facet Composition V1: Pre-Call Abort
+
+The frozen v1 scope-similarity selector was run only through its product
+preflight on the 400-row BEAM 100k cohort. No answer or judge calls were made.
+
+## Result
+
+- Canonical instruction targets retained: **36/40**
+- Ordinary control contexts changed: **0/400**
+- Extracted target facets missing from storage: **0/40**
+- Decision: **abort v1 before external scoring**
+
+The four misses were:
+
+| Query ID | Query | Omitted rule |
+|---|---|---|
+| `10_instruction_following_0` | When was the Montserrat Writers' Festival? | Format dates as Month Day, Year for timeline details |
+| `17_instruction_following_0` | When is my meetings at Montserrat Studios? | Format dates as MM/DD/YYYY for scheduling details |
+| `17_instruction_following_1` | When was my meetings at East Janethaven Library? | Format dates as MM/DD/YYYY for scheduling details |
+| `20_instruction_following_1` | When is the non-provisional patent filing scheduled? | Confirm exact dates for deadlines or meetings |
+
+All omitted rules governed answer form. Query-to-scope similarity instead
+favored facets whose topics appeared literally in the questions. Fixed-budget
+checks of full-directive, action-only, combined action/scope, and dual-lane
+ranking retained at most 36/40. Per the preregistration, `k` was not increased.
+
+V2 therefore tests complete-lane additive composition while all verified
+facets fit the preregistered 256-token budget. Budget-pressure selection for
+larger stores remains a separate product problem.

--- a/benchmarks/amb/build_complete_facet_contexts.py
+++ b/benchmarks/amb/build_complete_facet_contexts.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Freeze additive, complete standing-instruction contexts from product facets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+try:
+    from .audit_knowledge_update_gold import iter_turns, load_conversations
+    from .reorder_speaker_first_contexts import split_memory_blocks
+except ImportError:  # pragma: no cover - direct script execution
+    from audit_knowledge_update_gold import iter_turns, load_conversations
+    from reorder_speaker_first_contexts import split_memory_blocks
+
+
+PROTOCOL = "complete-standing-facet-composition-v2"
+MAX_FACET_TOKENS = 256
+EXPECTED_ROWS = 400
+EXPECTED_INSTRUCTION_TARGETS = 40
+TRAILING_LINK_RE = re.compile(r"\s*->->.*$")
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _json_bytes(value: object) -> bytes:
+    return json.dumps(value, indent=2).encode("utf-8")
+
+
+def load_rows(path: Path) -> list[dict]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    return payload if isinstance(payload, list) else payload.get("results") or []
+
+
+def overlay_control_contexts(
+    rows: list[dict], control_rows: list[dict]
+) -> list[dict]:
+    """Join frozen control contexts onto metadata-rich rows in exact order."""
+    row_ids = [str(row.get("query_id") or "") for row in rows]
+    control_ids = [str(row.get("query_id") or "") for row in control_rows]
+    if not row_ids or any(not query_id for query_id in row_ids):
+        raise ValueError("metadata results contain a missing query_id")
+    if len(set(row_ids)) != len(row_ids):
+        raise ValueError("metadata results contain duplicate query_ids")
+    if row_ids != control_ids:
+        raise ValueError("metadata results and control contexts differ in query order")
+    return [
+        {**row, "context": str(control.get("context") or "")}
+        for row, control in zip(rows, control_rows, strict=True)
+    ]
+
+
+def normalize_directive(text: str) -> str:
+    return " ".join(text.split()).casefold()
+
+
+def select_facets(facets: list[dict]) -> list[dict]:
+    """Return the complete verified lane in deterministic first-mention order."""
+    return sorted(
+        facets,
+        key=lambda row: (
+            float(row.get("first_mention_at") or 0.0),
+            str(row.get("rid") or ""),
+        ),
+    )
+
+
+def render_facet_panel(facets: list[dict]) -> str:
+    lines = [
+        f"- [Turn {facet['turn']}] User: {facet['text']}" for facet in facets
+    ]
+    return (
+        "## Memory 0\n"
+        "Standing user instructions (authoritative user statements):\n"
+        + "\n".join(lines)
+        + "\n\n"
+    )
+
+
+def build_context_rows(
+    rows: list[dict],
+    facets_by_namespace: dict[str, dict],
+    token_counter: Callable[[str], int],
+) -> tuple[dict, dict]:
+    """Compose the treatment and return its pre-call invariant audit."""
+    treatment_rows = []
+    row_audits = []
+    target_rows = 0
+    targets_retained = 0
+    max_extra_tokens = 0
+    facet_counts = []
+
+    for row in rows:
+        query_id = str(row.get("query_id") or "")
+        if not query_id:
+            raise ValueError("row lacks query_id")
+        metadata = row.get("meta") or {}
+        namespace = str(metadata.get("conversation_id") or "")
+        if not namespace:
+            raise ValueError(f"row {query_id!r} lacks conversation_id")
+        lane = facets_by_namespace.get(namespace)
+        if lane is None:
+            raise ValueError(f"row {query_id!r} has no facet lane snapshot")
+        if int(lane.get("omitted") or 0) != 0:
+            raise ValueError(
+                f"row {query_id!r} facet inventory is incomplete: {lane!r}"
+            )
+        facets = list(lane.get("facets") or [])
+        selected = select_facets(facets)
+        if not selected:
+            raise ValueError(f"row {query_id!r} has an empty verified facet lane")
+        facet_counts.append(len(selected))
+
+        panel = render_facet_panel(selected)
+        panel_tokens = token_counter(panel)
+        if panel_tokens > MAX_FACET_TOKENS:
+            raise ValueError(
+                f"row {query_id!r} facet panel uses {panel_tokens} tokens; "
+                f"limit is {MAX_FACET_TOKENS}"
+            )
+        reference_context = str(row.get("context") or "")
+        treatment_context = panel + reference_context
+        ordinary_suffix = treatment_context[len(panel) :]
+        if ordinary_suffix != reference_context:
+            raise AssertionError(f"row {query_id!r} changed ordinary context bytes")
+        if split_memory_blocks(ordinary_suffix) != split_memory_blocks(reference_context):
+            raise AssertionError(f"row {query_id!r} changed ordinary memory blocks")
+
+        target = str(metadata.get("instruction_being_tested") or "").strip()
+        target_retained = None
+        if target:
+            target_rows += 1
+            target_retained = normalize_directive(target) in {
+                normalize_directive(str(facet.get("text") or ""))
+                for facet in selected
+            }
+            targets_retained += int(target_retained)
+
+        max_extra_tokens = max(max_extra_tokens, panel_tokens)
+        treatment_rows.append({"query_id": query_id, "context": treatment_context})
+        row_audits.append(
+            {
+                "query_id": query_id,
+                "namespace": namespace,
+                "available_facets": len(facets),
+                "selected_facets": len(selected),
+                "selected_rids": [str(facet.get("rid") or "") for facet in selected],
+                "selected_turns": [facet.get("turn") for facet in selected],
+                "facet_tokens": panel_tokens,
+                "ordinary_context_sha256": _sha256_bytes(
+                    reference_context.encode("utf-8")
+                ),
+                "ordinary_context_exact": ordinary_suffix == reference_context,
+                "target_retained": target_retained,
+            }
+        )
+
+    treatment = {"results": treatment_rows}
+    audit = {
+        "protocol": PROTOCOL,
+        "rows": len(rows),
+        "max_facet_tokens_allowed": MAX_FACET_TOKENS,
+        "max_facet_tokens_observed": max_extra_tokens,
+        "complete_lane_rows": sum(
+            row["selected_facets"] == row["available_facets"]
+            for row in row_audits
+        ),
+        "min_facets_per_row": min(facet_counts, default=0),
+        "max_facets_per_row": max(facet_counts, default=0),
+        "ordinary_contexts_exact": sum(
+            row["ordinary_context_exact"] for row in row_audits
+        ),
+        "instruction_target_rows": target_rows,
+        "instruction_targets_retained": targets_retained,
+        "selection_fields": ["facet.first_mention_at", "facet.rid"],
+        "selection_uses_query": False,
+        "selection_uses_category": False,
+        "selection_uses_gold_rubric_answer_or_score": False,
+        "target_metadata_used_for_abort_audit_only": True,
+        "row_audits": row_audits,
+    }
+    return treatment, audit
+
+
+def validate_full400_preflight(audit: dict) -> None:
+    errors = []
+    if audit["rows"] != EXPECTED_ROWS:
+        errors.append(f"expected {EXPECTED_ROWS} rows, got {audit['rows']}")
+    if audit["instruction_target_rows"] != EXPECTED_INSTRUCTION_TARGETS:
+        errors.append(
+            "expected "
+            f"{EXPECTED_INSTRUCTION_TARGETS} instruction targets, got "
+            f"{audit['instruction_target_rows']}"
+        )
+    if audit["instruction_targets_retained"] != EXPECTED_INSTRUCTION_TARGETS:
+        errors.append(
+            "canonical target retention is "
+            f"{audit['instruction_targets_retained']}/{EXPECTED_INSTRUCTION_TARGETS}"
+        )
+    if audit["complete_lane_rows"] != audit["rows"]:
+        errors.append("one or more rows omitted a verified standing facet")
+    if audit["ordinary_contexts_exact"] != audit["rows"]:
+        errors.append("one or more ordinary contexts changed")
+    if audit["max_facet_tokens_observed"] > MAX_FACET_TOKENS:
+        errors.append("facet token ceiling exceeded")
+    if errors:
+        raise RuntimeError("pre-call facet gate failed:\n- " + "\n- ".join(errors))
+
+
+def _remove_store(path: Path) -> None:
+    for suffix in ("", "-shm", "-wal"):
+        candidate = Path(f"{path}{suffix}")
+        if candidate.exists():
+            candidate.unlink()
+
+
+def _ingest_and_extract(db: object, conversations: dict, namespaces: list[str]) -> dict:
+    audits = {}
+    placeholder_dim = len(db.embed("__facet_source_placeholder__"))
+    placeholder_embedding = [1.0] + [0.0] * (placeholder_dim - 1)
+    for namespace in namespaces:
+        conversation = conversations.get(namespace)
+        if conversation is None:
+            raise ValueError(f"missing conversation {namespace!r}")
+        for position, turn in enumerate(
+            iter_turns(conversation.get("chat") or []), start=1
+        ):
+            text = TRAILING_LINK_RE.sub("", str(turn.get("content") or "")).strip()
+            if not text:
+                continue
+            db.record(
+                text,
+                embedding=placeholder_embedding,
+                metadata={
+                    "conversation_id": namespace,
+                    "source_turn": turn.get("id"),
+                },
+                namespace=namespace,
+                source=str(turn.get("role") or "unknown").casefold(),
+                created_at=1_700_000_000.0 + position,
+            )
+        audits[namespace] = db.extract_standing_instructions(
+            namespace=namespace, dry_run=False
+        )
+    return audits
+
+
+def _source_map(path: Path) -> dict[str, dict]:
+    connection = sqlite3.connect(path)
+    try:
+        rows = connection.execute(
+            "SELECT rid, namespace, source, metadata FROM memories "
+            "WHERE synthesis_axis IS NULL"
+        ).fetchall()
+    finally:
+        connection.close()
+    out = {}
+    for rid, namespace, source, raw_metadata in rows:
+        metadata = json.loads(raw_metadata or "{}")
+        out[rid] = {
+            "namespace": namespace,
+            "role": source,
+            "turn": metadata.get("source_turn"),
+        }
+    return out
+
+
+def _facet_snapshots(db: object, namespaces: list[str], source_map: dict) -> dict:
+    snapshots = {}
+    for namespace in namespaces:
+        lane = db.recall_facets(namespace=namespace, limit=10_000)
+        facets = []
+        for facet in lane.get("facets") or []:
+            sources = [source_map[rid] for rid in facet.get("source_rids") or []]
+            if not sources or any(source["role"] != "user" for source in sources):
+                raise AssertionError(f"facet lacks verified user evidence: {facet!r}")
+            facets.append(
+                {
+                    **facet,
+                    "turn": min(source["turn"] for source in sources),
+                }
+            )
+        snapshots[namespace] = {
+            "facets": facets,
+            "omitted": int(lane.get("omitted") or 0),
+        }
+    return snapshots
+
+
+def _control_payload(rows: list[dict]) -> dict:
+    return {
+        "results": [
+            {"query_id": str(row["query_id"]), "context": str(row.get("context") or "")}
+            for row in rows
+        ]
+    }
+
+
+def main() -> int:
+    from memory_bench.utils import count_tokens
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--control-contexts", type=Path, required=True)
+    parser.add_argument("--documents", type=Path, required=True)
+    parser.add_argument("--yantrikdb-python", type=Path, required=True)
+    parser.add_argument("--db", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--model", default="deepseek-v4-flash:0731-cloud")
+    args = parser.parse_args()
+
+    rows = overlay_control_contexts(
+        load_rows(args.results), load_rows(args.control_contexts)
+    )
+    namespaces = list(
+        dict.fromkeys(
+            str((row.get("meta") or {}).get("conversation_id") or "")
+            for row in rows
+        )
+    )
+    if any(not namespace for namespace in namespaces):
+        raise ValueError("one or more rows lack conversation_id")
+    if args.db.exists() and not args.overwrite:
+        raise FileExistsError(f"store already exists: {args.db}")
+    if args.overwrite:
+        _remove_store(args.db)
+    args.db.parent.mkdir(parents=True, exist_ok=True)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    sys.path.insert(0, str(args.yantrikdb_python.resolve()))
+    from yantrikdb import YantrikDB
+
+    conversations = load_conversations(args.documents)
+    db = YantrikDB.with_default(str(args.db))
+    try:
+        extraction_audits = _ingest_and_extract(db, conversations, namespaces)
+    finally:
+        db.close()
+
+    source_map = _source_map(args.db)
+    db = YantrikDB.with_default(str(args.db))
+    try:
+        snapshots = _facet_snapshots(db, namespaces, source_map)
+        treatment, audit = build_context_rows(
+            rows, snapshots, count_tokens
+        )
+    finally:
+        db.close()
+    validate_full400_preflight(audit)
+
+    # A second fresh open must reconstruct the same artifact exactly.
+    db = YantrikDB.with_default(str(args.db))
+    try:
+        replay_snapshots = _facet_snapshots(db, namespaces, source_map)
+        replay_treatment, replay_audit = build_context_rows(
+            rows, replay_snapshots, count_tokens
+        )
+    finally:
+        db.close()
+    replay_exact = _json_bytes(replay_treatment) == _json_bytes(treatment)
+    replay_selection_exact = [
+        row["selected_rids"] for row in replay_audit["row_audits"]
+    ] == [row["selected_rids"] for row in audit["row_audits"]]
+    if not replay_exact or not replay_selection_exact:
+        raise RuntimeError("fresh-open product replay did not reconstruct the artifact")
+
+    control = _control_payload(rows)
+    control_path = args.out_dir / "control.json"
+    treatment_path = args.out_dir / "selective-facets.json"
+    preflight_path = args.out_dir / "preflight.json"
+    control_path.write_bytes(_json_bytes(control))
+    treatment_path.write_bytes(_json_bytes(treatment))
+
+    query_ids = [str(row["query_id"]) for row in rows]
+    preflight = {
+        **audit,
+        "status": "passed",
+        "product_path": {
+            "raw_turn_ingestion": True,
+            "persisted_facet_extraction": True,
+            "store_reopened_before_selection": True,
+            "query_independent_complete_lane": True,
+            "second_fresh_open_replay_exact": replay_exact,
+            "second_fresh_open_selection_exact": replay_selection_exact,
+            "query_or_gold_used_during_extraction": False,
+        },
+        "extraction_audits": extraction_audits,
+        "source_sha256": {
+            "results": _sha256_file(args.results),
+            "control_contexts": _sha256_file(args.control_contexts),
+            "documents": _sha256_file(args.documents),
+        },
+        "ordered_query_ids_sha256": _sha256_bytes(
+            json.dumps(query_ids, separators=(",", ":")).encode("utf-8")
+        ),
+        "arms": {
+            "control": {
+                "file": control_path.name,
+                "sha256": _sha256_file(control_path),
+            },
+            "treatment": {
+                "file": treatment_path.name,
+                "sha256": _sha256_file(treatment_path),
+            },
+        },
+        "external_evaluation": {
+            "model": args.model,
+            "answer_repeats": 1,
+            "judge_repeats": 1,
+            "answer_calls": len(rows) * 2,
+            "judge_calls": len(rows) * 2,
+            "synthetic_benchmark_data_only": True,
+            "real_companion_memories_included": False,
+        },
+    }
+    preflight_path.write_bytes(_json_bytes(preflight))
+    print(
+        json.dumps(
+            {
+                key: value
+                for key, value in preflight.items()
+                if key not in {"row_audits", "extraction_audits"}
+            },
+            indent=2,
+        )
+    )
+    print(f"preflight_sha256={_sha256_file(preflight_path)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_amb_build_complete_facet_contexts.py
+++ b/tests/test_amb_build_complete_facet_contexts.py
@@ -1,0 +1,118 @@
+from benchmarks.amb.build_complete_facet_contexts import (
+    MAX_FACET_TOKENS,
+    build_context_rows,
+    overlay_control_contexts,
+    select_facets,
+    validate_full400_preflight,
+)
+
+
+def _facet(rid, text, turn, first):
+    return {
+        "rid": rid,
+        "text": text,
+        "turn": turn,
+        "first_mention_at": first,
+        "source_rids": [f"source-{rid}"],
+    }
+
+
+FACETS = [
+    _facet("a", "Always include versions when I ask about libraries.", 2, 2.0),
+    _facet("b", "Always cite sources when I ask about research papers.", 4, 4.0),
+    _facet("c", "Always use Celsius when I ask about weather.", 6, 6.0),
+]
+
+
+def _tokens(text):
+    return len(text.split())
+
+
+def test_control_context_join_is_exact_and_keeps_metadata():
+    rows = [
+        {"query_id": "q1", "query": "first", "context": "stale"},
+        {"query_id": "q2", "query": "second", "context": "stale"},
+    ]
+    joined = overlay_control_contexts(
+        rows,
+        [
+            {"query_id": "q1", "context": "control one"},
+            {"query_id": "q2", "context": "control two"},
+        ],
+    )
+    assert [row["context"] for row in joined] == ["control one", "control two"]
+    assert [row["query"] for row in joined] == ["first", "second"]
+    assert rows[0]["context"] == "stale"
+
+
+def test_control_context_join_rejects_order_drift():
+    rows = [{"query_id": "q1"}, {"query_id": "q2"}]
+    try:
+        overlay_control_contexts(
+            rows, [{"query_id": "q2"}, {"query_id": "q1"}]
+        )
+    except ValueError as error:
+        assert "query order" in str(error)
+    else:
+        raise AssertionError("query order drift did not abort")
+
+
+def test_every_query_gets_complete_first_mention_order():
+    selected = select_facets(list(reversed(FACETS)))
+    assert [row["rid"] for row in selected] == ["a", "b", "c"]
+
+
+def test_additive_composition_keeps_ordinary_context_and_target():
+    row = {
+        "query_id": "q1",
+        "query": "Which libraries are used?",
+        "context": "## Memory 1\noriginal first\n\n## Memory 2\noriginal second\n",
+        "meta": {
+            "conversation_id": "unit",
+            "instruction_being_tested": FACETS[0]["text"],
+        },
+    }
+    treatment, audit = build_context_rows(
+        [row], {"unit": {"facets": FACETS, "omitted": 0}}, _tokens
+    )
+    context = treatment["results"][0]["context"]
+    assert context.endswith(row["context"])
+    assert audit["complete_lane_rows"] == 1
+    assert audit["max_facets_per_row"] == 3
+    assert audit["ordinary_contexts_exact"] == 1
+    assert audit["instruction_targets_retained"] == 1
+    assert audit["max_facet_tokens_observed"] <= MAX_FACET_TOKENS
+
+
+def test_incomplete_lane_and_failed_full400_gate_abort():
+    row = {
+        "query_id": "q1",
+        "query": "Which libraries are used?",
+        "context": "## Memory 1\noriginal\n",
+        "meta": {"conversation_id": "unit"},
+    }
+    try:
+        build_context_rows(
+            [row], {"unit": {"facets": FACETS, "omitted": 1}}, _tokens
+        )
+    except ValueError as error:
+        assert "incomplete" in str(error)
+    else:
+        raise AssertionError("incomplete facet inventory did not abort")
+    try:
+        validate_full400_preflight(
+            {
+                "rows": 1,
+                "instruction_target_rows": 0,
+                "instruction_targets_retained": 0,
+                "complete_lane_rows": 1,
+                "min_facets_per_row": 5,
+                "max_facets_per_row": 5,
+                "ordinary_contexts_exact": 1,
+                "max_facet_tokens_observed": 10,
+            }
+        )
+    except RuntimeError as error:
+        assert "pre-call facet gate failed" in str(error)
+    else:
+        raise AssertionError("invalid full-400 audit did not abort")


### PR DESCRIPTION
## Summary
- preregister query-independent, additive composition of each namespace's complete verified standing-facet lane
- preserve the v1 scope-ranking abort (36/40 target retention) and its four answer-form misses
- add a product-backed 400-row builder with frozen-control overlay, provenance checks, token/byte invariants, and fresh-open exact replay
- record the passed v2 preflight and paired-evaluation hashes

## Preflight
- targets retained: 40/40
- complete lanes: 400/400
- ordinary contexts byte-exact: 400/400
- max additive panel: 131/256 tokens
- fresh-open artifact and RID replay: exact
- paired manifest: 400 rows/arm, 800 answer + 800 judge calls, no real companion memories

## Validation
- 5 focused harness tests passed
- Ruff passed
- git diff --check passed

The externally scored run was started only after the frozen product and paired-manifest gates passed.