### PR TITLE
bench: preregister facet applicability filter

### DIFF
--- a/benchmarks/amb/COMPLETE_FACET_COMPOSITION_COLLISION_AUDIT.md
+++ b/benchmarks/amb/COMPLETE_FACET_COMPOSITION_COLLISION_AUDIT.md
@@ -1,0 +1,61 @@
+# AMB Complete Facet Composition Collision Audit
+
+## Decision
+
+**Do not run the byte-identical v3 replication.**
+
+Four of the ten v2 event-ordering loss rows have a plausible facet collision.
+The frozen funding gate prohibited another identical run when three or more
+rows qualified. Complete-lane composition therefore remains opt-in, and the
+v2 overall lift of `+0.028727` is not banked for default promotion.
+
+This result names a plausible mechanism for the v2 event-ordering decline:
+conditionally applicable standing instructions can alter an unrelated answer
+when every verified facet is composed without query-scope compatibility.
+
+## Frozen Inputs
+
+- Evaluation SHA-256:
+  `27ab6cacb1370b631f086ab70c371e4d6b49ac9c2f859e15cadce0c22c63bea5`
+- Event-ordering losses inspected: 10
+- External calls made for this audit: 0
+- Protocol: `COMPLETE_FACET_COMPOSITION_REPLICATION_PREREGISTRATION.md`
+
+The loss rows were not inspected until the funding protocol was committed,
+independently countersigned, and merged in PR #177.
+
+## Frozen Criterion
+
+A row has a plausible collision when a composed directive governs dates,
+timelines, scheduling, deadlines, event chronology, or ordered output and the
+control-to-treatment answer change could reasonably be affected by that rule.
+
+## Row Audit
+
+| Query ID | Collision | Basis |
+|---|---|---|
+| `3_event_ordering_1` | No | The panel governs markup, debugging, and performance metrics. It has no qualifying temporal or ordered-output rule. |
+| `6_event_ordering_0` | **Yes** | Same-subject resume rules require structured, quantified bullets. Treatment promoted that formatting rule into an answer item. |
+| `9_event_ordering_1` | **Yes** | The panel is entirely date, time, deadline, and time-zone rules. A dated control answer became an abstention. |
+| `10_event_ordering_1` | **Yes** | Timeline and date rules directly changed treatment into a fully date-stamped list. |
+| `11_event_ordering_0` | No | A detailed-timeline rule applies to project schedules, not to an ordered list of hiring concepts; the other rules are unrelated. |
+| `12_event_ordering_1` | No | The date rule applies to scheduled events, not to undated philosophical reflection. Query-side chronology alone does not satisfy the directive-side criterion. |
+| `16_event_ordering_0` | No | The panel contains budgeting and investment-content rules, with no qualifying temporal or ordered-output rule. |
+| `16_event_ordering_1` | No | The same financial-content panel contains no qualifying temporal or ordered-output rule. |
+| `18_event_ordering_1` | No | Scheduling-date rules do not govern a chronology of personal and work challenges. The topical mental-health rule is outside the frozen criterion. |
+| `20_event_ordering_1` | **Yes** | A detailed-timeline rule for patent application processes directly matches the patent-process ordering request. |
+
+Total: **4 plausible collisions, 6 non-collisions**.
+
+## Consequence
+
+The preregistered `4/10 >= 3/10` stop condition is met. No identical v3 run is
+authorized, and there will be no third attempt at complete-lane replication.
+A future scored arm must change the mechanism and receive a fresh
+preregistration.
+
+The next mechanism must use a general, auditable rule-type versus answer-type
+compatibility predicate. The ten loss rows may motivate the design, but no
+threshold or query list may be tuned to them. Near-domain controls must also
+prove that date and timeline rules remain available when the request actually
+calls for dates, deadlines, schedules, meetings, or process timelines.

--- a/benchmarks/amb/COMPLETE_FACET_COMPOSITION_RESULT.md
+++ b/benchmarks/amb/COMPLETE_FACET_COMPOSITION_RESULT.md
@@ -13,6 +13,11 @@ composition remains opt-in.
 The miss is `0.005486` beyond the floor. It is not rounded away or waived:
 the preregistered gate is binary by design.
 
+The preregistered zero-call follow-up found plausible facet collisions in four
+of the ten event-ordering loss rows. That exceeded the frozen stop threshold,
+so the byte-identical v3 replication was not run. See
+`COMPLETE_FACET_COMPOSITION_COLLISION_AUDIT.md` for the row-level evidence.
+
 ## Frozen Run
 
 - Model: `deepseek-v4-flash:0731-cloud`
@@ -84,3 +89,8 @@ No category-based router, larger repeat, or threshold adjustment is authorized
 from this result. A future mechanism may use product-valid intent or budget
 semantics, but it requires a new preregistration and must not select on these
 observed category outcomes.
+
+The collision audit narrows that future work: conditionally applicable facets
+need a principled rule-type versus answer-type compatibility check before
+composition. Complete-lane composition without that check remains permanently
+opt-in under the replication protocol.

--- a/benchmarks/amb/FACET_APPLICABILITY_V4_PREREGISTRATION.md
+++ b/benchmarks/amb/FACET_APPLICABILITY_V4_PREREGISTRATION.md
@@ -116,6 +116,15 @@ No score, category, gold answer, rubric, answer text, or judge output was read
 by the census. General product behavior still defaults unparsed directives to
 inclusion; the frozen corpus's expected parse coverage is 100%.
 
+A second query-only check covered the four already-frozen collision rows. All
+`4/4` fall inside the 28-row suppression cohort. The exact named collision
+directive is suppressed on rows 6, 9, and 10. On row 20, the patent-process
+timeline rule remains included because the query explicitly requests stages of
+the patent process; two unrelated deadline/meeting rules are suppressed. This
+is the intended near-domain control, not an ID-specific exception: the same
+predicate retains any process-timeline rule when the query asks for a process
+timeline.
+
 ## Pre-Call Abort Gate
 
 `build_applicable_facet_contexts.py` must rebuild the treatment through the
@@ -143,7 +152,7 @@ new preregistration commit.
 - One answer and one judge per arm per query
 - Seed: `20260826`
 - Projected calls: 800 answers and 800 judges
-- Paired bootstrap: 20,000 resamples, seed `20260826`
+- Paired bootstrap: 20,000 resamples, seed `20260827`
 - Synthetic benchmark data only; no real companion memories
 - New output path and initially absent checkpoint; resume only after an
   interruption within this run

--- a/benchmarks/amb/FACET_APPLICABILITY_V4_PREREGISTRATION.md
+++ b/benchmarks/amb/FACET_APPLICABILITY_V4_PREREGISTRATION.md
@@ -1,0 +1,170 @@
+# AMB Standing-Facet Applicability V4 Preregistration
+
+Status: mechanism and gates frozen before product preflight or external calls.
+
+## Question
+
+Can a narrow, auditable rule-type versus answer-shape predicate preserve the
+standing-instruction lift while removing the form-transform collisions caused
+by complete query-independent composition?
+
+V2 improved the full cohort by `+0.028727` and instruction following by
+`+0.093750`, but event ordering crossed the frozen harm floor. The subsequent
+zero-call audit found plausible collisions in `4/10` event-ordering losses and
+prohibited an identical replication. V4 changes the mechanism; it does not
+reuse or pool v2 answers or scores.
+
+## Design Law
+
+V4 is **default-include and suppresses only on a positive form conflict**.
+Topic similarity is not used. Absence of a match never suppresses a facet.
+Unparsed or ambiguous directives remain included.
+
+The predicate version is `facet-form-conflict-v1`. It is recorded in every
+row audit and decision trace.
+
+### Directive Parsing
+
+The parser recognizes only the exact conditional form:
+
+```text
+<action> when I ask about <condition>
+```
+
+It preserves the exact action and condition text. The action is typed as:
+
+| Type | Positive lexical evidence in the action |
+|---|---|
+| `date_time` | date, time, time zone, deadline, timeline, schedule, meeting, or appointment |
+| `formatting_structure` | format, bullets, headings, citation style, syntax highlighting, tree diagram, visual aid, markup, HTML, layout, or minimalist style |
+| `non_transforming` | every other parsed action |
+
+Date/time typing runs before formatting typing, so `format dates` is a
+`date_time` transform.
+
+The condition is independently typed as `process_timeline`, `date_time`,
+`formatting_structure`, or `other`. Process terms are checked first, then
+date/time terms, then formatting terms.
+
+### Query Answer Shape
+
+The query-only classifier emits non-exclusive Boolean features:
+
+- `chronology_of_mentions`: requires both an ordering cue (`in order`,
+  `order in which`, `chronological`, or `sequence`) and a conversation-history
+  cue (`brought up`, `mentioned`, `discussed`, `throughout`, or `across`).
+- `date_time_request`: explicit `when`, date/time, due, deadline, scheduled,
+  scheduling, meeting-time, or appointment-time language.
+- `process_timeline_request`: a steps/stages/process/procedure term plus a
+  request term such as what, which, how, walk me through, or order.
+- `formatting_request`: explicit format, organize, design, layout, structure,
+  style, citation, references, markup, HTML, bullets, or headings language.
+
+The classifier reads query text only. It never reads benchmark category, gold
+answer, rubric, prior answer, judge output, or score.
+
+### Compatibility Table
+
+Outside `chronology_of_mentions`, every facet is included. Within a chronology
+of mentions:
+
+| Directive type | Include when | Otherwise |
+|---|---|---|
+| `non_transforming` | always | n/a |
+| `date_time` | query requests date/time and condition is date/time; or query requests a process timeline and condition is a process timeline | suppress |
+| `formatting_structure` | query explicitly requests formatting and condition is formatting/structure | suppress |
+| unparsed | always | n/a |
+
+This distinguishes `When was X?`, where date rules remain active, from `In
+what order did I mention X?`, where an unrelated date-format rule can transform
+the requested answer. It also retains a patent-process timeline rule for an
+ordered patent-stage request and retains date formatting for an ordered list of
+deadlines. Bare `list` language is not treated as a formatting request.
+
+## Frozen Cohort And Composition
+
+- Cohort: the same 400 BEAM 100k queries as the frozen `ydb-0151` control.
+- Control: exact original context bytes, with SHA-256
+  `918f572927b75ab1bb2ae3edf5656eada132cf9a644953f31bf693c695d46863`.
+- Treatment: product-extracted, active, verified, user-backed standing facets
+  filtered by `facet-form-conflict-v1` and prepended in first-mention order.
+- No ordinary block is removed, truncated, reordered, or rewritten.
+- The facet panel remains additive and capped at 256 tokens.
+- Extraction, persistence, close/reopen, provenance validation, and dependency
+  resolution are identical to v2.
+
+The v4 treatment hash and paired manifest hash must be committed before any
+external call.
+
+## Query-Only Design Census
+
+Before this protocol was frozen, a score-blind census over query text and the
+v2 facet panels produced the following expected product-preflight values:
+
+- rows: `400`
+- unique persisted directive texts: `90`
+- conditional parses: `90/90`
+- canonical instruction targets retained: `40/40`
+- rows with suppression: `28`
+- facets suppressed: `53`
+- suppression reasons: `41` date/time conflicts and `12` formatting conflicts
+- explicit date-request rows: `41`
+- date/time facet exposures on those rows retained: `68/68`
+- compatible process-timeline inclusions inside chronology rows: `1`
+
+No score, category, gold answer, rubric, answer text, or judge output was read
+by the census. General product behavior still defaults unparsed directives to
+inclusion; the frozen corpus's expected parse coverage is 100%.
+
+## Pre-Call Abort Gate
+
+`build_applicable_facet_contexts.py` must rebuild the treatment through the
+product path and abort before model calls unless:
+
+1. All query-only census counts above reproduce exactly.
+2. All 40 canonical instruction targets remain selected.
+3. Every suppressed decision is a parsed `date_time` or
+   `formatting_structure` directive on a `chronology_of_mentions` query.
+4. All original contexts remain exact byte suffixes with identical parsed
+   ordinary memory blocks.
+5. No facet panel exceeds 256 tokens.
+6. A second fresh product open reproduces identical selected RIDs, predicate
+   traces, and treatment bytes.
+7. Unit controls prove both directions: unrelated date/format transforms are
+   suppressed on mention chronologies, while direct date requests, ordered
+   deadlines, and matching process timelines retain their rules.
+
+Any mismatch abandons or amends the arm before external calls and requires a
+new preregistration commit.
+
+## External Run
+
+- Model: `deepseek-v4-flash:0731-cloud`
+- One answer and one judge per arm per query
+- Seed: `20260826`
+- Projected calls: 800 answers and 800 judges
+- Paired bootstrap: 20,000 resamples, seed `20260826`
+- Synthetic benchmark data only; no real companion memories
+- New output path and initially absent checkpoint; resume only after an
+  interruption within this run
+
+## Promotion Gates
+
+All gates must pass:
+
+1. Instruction-following delta is at least `+0.05`, with more wins than
+   losses.
+2. Overall delta is non-negative and its paired 95% interval lower bound is at
+   least `-0.01`.
+3. Pooled other-nine-category delta is at least `-0.005`.
+4. Summarization delta is at least `-0.01`.
+5. No category other than instruction following is below `-0.025`.
+6. Event-ordering delta is non-negative.
+
+Gate 6 is intentionally stricter than v2's harm floor. V4 exists specifically
+to remove a named event-ordering interaction; a negative point estimate does
+not demonstrate that fix well enough for a default-on database feature.
+
+Every category mean, paired interval, and win/tie/loss count is reported. Any
+failure leaves standing-facet composition opt-in. There is no post-hoc
+threshold change, category router, query allowlist, or score-tuned exception.

--- a/benchmarks/amb/build_applicable_facet_contexts.py
+++ b/benchmarks/amb/build_applicable_facet_contexts.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Build standing-facet contexts with auditable form-conflict suppression."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from collections.abc import Callable
+from pathlib import Path
+
+try:
+    from .build_complete_facet_contexts import (
+        MAX_FACET_TOKENS,
+        _control_payload,
+        _facet_snapshots,
+        _ingest_and_extract,
+        _json_bytes,
+        _remove_store,
+        _sha256_bytes,
+        _sha256_file,
+        _source_map,
+        load_rows,
+        normalize_directive,
+        overlay_control_contexts,
+        render_facet_panel,
+        select_facets,
+    )
+    from .audit_knowledge_update_gold import load_conversations
+    from .reorder_speaker_first_contexts import split_memory_blocks
+except ImportError:  # pragma: no cover - direct script execution
+    from build_complete_facet_contexts import (
+        MAX_FACET_TOKENS,
+        _control_payload,
+        _facet_snapshots,
+        _ingest_and_extract,
+        _json_bytes,
+        _remove_store,
+        _sha256_bytes,
+        _sha256_file,
+        _source_map,
+        load_rows,
+        normalize_directive,
+        overlay_control_contexts,
+        render_facet_panel,
+        select_facets,
+    )
+    from audit_knowledge_update_gold import load_conversations
+    from reorder_speaker_first_contexts import split_memory_blocks
+
+
+PROTOCOL = "applicable-standing-facet-composition-v4"
+PREDICATE_VERSION = "facet-form-conflict-v1"
+EXPECTED_ROWS = 400
+EXPECTED_INSTRUCTION_TARGETS = 40
+EXPECTED_FACETS = 90
+
+CONDITION_RE = re.compile(
+    r"\bwhen\s+I\s+ask\s+about\s+(.+?)(?:[.!?]\s*)?$", re.IGNORECASE
+)
+CHRONOLOGY_RE = re.compile(
+    r"\b(?:in\s+order|order\s+in\s+which|chronological(?:ly)?|sequence)\b",
+    re.IGNORECASE,
+)
+HISTORY_RE = re.compile(
+    r"\b(?:brought\s+up|mentioned|discussed|throughout|across)\b",
+    re.IGNORECASE,
+)
+DATE_REQUEST_RE = re.compile(
+    r"^\s*when\b|\b(?:what|which)\s+(?:date|time)\b|\bdate\s+of\b|"
+    r"\b(?:due|deadline|deadlines|scheduled|scheduling|meeting\s+time|"
+    r"appointment\s+time)\b",
+    re.IGNORECASE,
+)
+PROCESS_RE = re.compile(r"\b(?:steps?|stages?|process(?:es)?|procedure)\b", re.I)
+PROCESS_REQUEST_RE = re.compile(
+    r"\b(?:what|which|how|walk\s+me\s+through|order)\b", re.IGNORECASE
+)
+FORMAT_RE = re.compile(
+    r"\b(?:format|formatting|organize|organise|organization|design|layout|"
+    r"structure|style|citation|references?|markup|html|bullets?|headings?)\b",
+    re.IGNORECASE,
+)
+DATE_RULE_RE = re.compile(
+    r"\b(?:date|dates|time|times|time\s*zone|timezone|deadline|deadlines|"
+    r"timeline|timelines|schedule|scheduling|meeting|appointment)\b",
+    re.IGNORECASE,
+)
+FORMAT_RULE_RE = re.compile(
+    r"\b(?:format|formatting|bullet|bullets|heading|headings|citation\s+style|"
+    r"syntax\s+highlighting|tree\s+diagram|visual\s+aid|markup|html|layout|"
+    r"minimalist)\b",
+    re.IGNORECASE,
+)
+
+
+def parse_condition(directive: str) -> tuple[str, str] | None:
+    """Return exact action and condition for the narrow v1 conditional form."""
+    match = CONDITION_RE.search(directive.strip())
+    if match is None:
+        return None
+    action = directive[: match.start()].strip(" ,;:")
+    condition = match.group(1).strip(" ,;:.!?")
+    if not action or not condition:
+        return None
+    return action, condition
+
+
+def directive_type(action: str) -> str:
+    """Classify only answer-form transforms; everything else is non-transforming."""
+    if DATE_RULE_RE.search(action):
+        return "date_time"
+    if FORMAT_RULE_RE.search(action):
+        return "formatting_structure"
+    return "non_transforming"
+
+
+def scope_type(condition: str) -> str:
+    """Classify the request shape named by the directive's own condition."""
+    if PROCESS_RE.search(condition):
+        return "process_timeline"
+    if DATE_RULE_RE.search(condition):
+        return "date_time"
+    if FORMAT_RE.search(condition):
+        return "formatting_structure"
+    return "other"
+
+
+def query_shape(query: str) -> dict[str, bool]:
+    """Return deterministic, non-exclusive answer-shape features."""
+    return {
+        "chronology_of_mentions": bool(
+            CHRONOLOGY_RE.search(query) and HISTORY_RE.search(query)
+        ),
+        "date_time_request": bool(DATE_REQUEST_RE.search(query)),
+        "process_timeline_request": bool(
+            PROCESS_RE.search(query) and PROCESS_REQUEST_RE.search(query)
+        ),
+        "formatting_request": bool(FORMAT_RE.search(query)),
+    }
+
+
+def facet_decision(query: str, facet: dict) -> dict:
+    """Default-include, suppressing only a positive form conflict."""
+    text = str(facet.get("text") or "")
+    parsed = parse_condition(text)
+    shapes = query_shape(query)
+    base = {
+        "rid": str(facet.get("rid") or ""),
+        "predicate_version": PREDICATE_VERSION,
+        "query_shape": shapes,
+        "condition_parsed": parsed is not None,
+    }
+    if parsed is None:
+        return {
+            **base,
+            "action": None,
+            "condition": None,
+            "directive_type": "unparsed",
+            "scope_type": "unparsed",
+            "include": True,
+            "reason": "default_include_unparsed",
+        }
+
+    action, condition = parsed
+    rule_type = directive_type(action)
+    rule_scope = scope_type(condition)
+    typed = {
+        **base,
+        "action": action,
+        "condition": condition,
+        "directive_type": rule_type,
+        "scope_type": rule_scope,
+    }
+    if not shapes["chronology_of_mentions"] or rule_type == "non_transforming":
+        return {**typed, "include": True, "reason": "default_include_no_conflict"}
+
+    if rule_type == "date_time":
+        compatible = (shapes["date_time_request"] and rule_scope == "date_time") or (
+            shapes["process_timeline_request"] and rule_scope == "process_timeline"
+        )
+        return {
+            **typed,
+            "include": compatible,
+            "reason": (
+                "include_compatible_date_time"
+                if compatible
+                else "suppress_chronology_date_time_conflict"
+            ),
+        }
+
+    compatible = shapes["formatting_request"] and rule_scope == "formatting_structure"
+    return {
+        **typed,
+        "include": compatible,
+        "reason": (
+            "include_compatible_formatting"
+            if compatible
+            else "suppress_chronology_formatting_conflict"
+        ),
+    }
+
+
+def select_applicable_facets(
+    query: str, facets: list[dict]
+) -> tuple[list[dict], list[dict]]:
+    ordered = select_facets(facets)
+    decisions = [facet_decision(query, facet) for facet in ordered]
+    selected = [
+        facet
+        for facet, decision in zip(ordered, decisions, strict=True)
+        if decision["include"]
+    ]
+    return selected, decisions
+
+
+def build_context_rows(
+    rows: list[dict],
+    facets_by_namespace: dict[str, dict],
+    token_counter: Callable[[str], int],
+) -> tuple[dict, dict]:
+    """Compose v4 treatment rows and a complete predicate trace."""
+    treatment_rows = []
+    row_audits = []
+    target_rows = 0
+    targets_retained = 0
+    max_extra_tokens = 0
+    reasons: Counter[str] = Counter()
+    date_query_rows = 0
+    date_facets_available = 0
+    date_facets_retained = 0
+    compatible_process_timeline_inclusions = 0
+
+    inventory = [
+        (namespace, facet)
+        for namespace, lane in facets_by_namespace.items()
+        for facet in lane.get("facets") or []
+    ]
+    parsed_inventory = sum(
+        parse_condition(str(facet.get("text") or "")) is not None
+        for _, facet in inventory
+    )
+
+    for row in rows:
+        query_id = str(row.get("query_id") or "")
+        query = str(row.get("query") or "")
+        metadata = row.get("meta") or {}
+        namespace = str(metadata.get("conversation_id") or "")
+        if not query_id or not query or not namespace:
+            raise ValueError(f"row lacks query identity fields: {query_id!r}")
+        lane = facets_by_namespace.get(namespace)
+        if lane is None or int(lane.get("omitted") or 0) != 0:
+            raise ValueError(f"row {query_id!r} lacks a complete facet inventory")
+        facets = list(lane.get("facets") or [])
+        selected, decisions = select_applicable_facets(query, facets)
+        reasons.update(decision["reason"] for decision in decisions)
+        shapes = query_shape(query)
+        if shapes["date_time_request"]:
+            date_query_rows += 1
+            date_facets_available += sum(
+                decision["directive_type"] == "date_time" for decision in decisions
+            )
+            date_facets_retained += sum(
+                decision["directive_type"] == "date_time" and decision["include"]
+                for decision in decisions
+            )
+        if shapes["chronology_of_mentions"] and shapes["process_timeline_request"]:
+            compatible_process_timeline_inclusions += sum(
+                decision["reason"] == "include_compatible_date_time"
+                and decision["scope_type"] == "process_timeline"
+                for decision in decisions
+            )
+
+        panel = render_facet_panel(selected) if selected else ""
+        panel_tokens = token_counter(panel)
+        if panel_tokens > MAX_FACET_TOKENS:
+            raise ValueError(
+                f"row {query_id!r} facet panel uses {panel_tokens} tokens; "
+                f"limit is {MAX_FACET_TOKENS}"
+            )
+        reference_context = str(row.get("context") or "")
+        treatment_context = panel + reference_context
+        ordinary_suffix = treatment_context[len(panel) :]
+        if ordinary_suffix != reference_context:
+            raise AssertionError(f"row {query_id!r} changed ordinary context bytes")
+        if split_memory_blocks(ordinary_suffix) != split_memory_blocks(
+            reference_context
+        ):
+            raise AssertionError(f"row {query_id!r} changed ordinary memory blocks")
+
+        target = str(metadata.get("instruction_being_tested") or "").strip()
+        target_retained = None
+        if target:
+            target_rows += 1
+            target_retained = normalize_directive(target) in {
+                normalize_directive(str(facet.get("text") or "")) for facet in selected
+            }
+            targets_retained += int(target_retained)
+
+        max_extra_tokens = max(max_extra_tokens, panel_tokens)
+        treatment_rows.append({"query_id": query_id, "context": treatment_context})
+        row_audits.append(
+            {
+                "query_id": query_id,
+                "namespace": namespace,
+                "predicate_version": PREDICATE_VERSION,
+                "query_shape": shapes,
+                "available_facets": len(facets),
+                "selected_facets": len(selected),
+                "suppressed_facets": len(facets) - len(selected),
+                "selected_rids": [str(facet.get("rid") or "") for facet in selected],
+                "facet_tokens": panel_tokens,
+                "ordinary_context_exact": ordinary_suffix == reference_context,
+                "target_retained": target_retained,
+                "decisions": decisions,
+            }
+        )
+
+    audit = {
+        "protocol": PROTOCOL,
+        "predicate_version": PREDICATE_VERSION,
+        "rows": len(rows),
+        "facet_inventory": len(inventory),
+        "parsed_facets": parsed_inventory,
+        "parse_rate": parsed_inventory / len(inventory) if inventory else 0.0,
+        "max_facet_tokens_allowed": MAX_FACET_TOKENS,
+        "max_facet_tokens_observed": max_extra_tokens,
+        "ordinary_contexts_exact": sum(
+            row["ordinary_context_exact"] for row in row_audits
+        ),
+        "instruction_target_rows": target_rows,
+        "instruction_targets_retained": targets_retained,
+        "rows_with_suppression": sum(
+            row["suppressed_facets"] > 0 for row in row_audits
+        ),
+        "suppressed_facets": sum(row["suppressed_facets"] for row in row_audits),
+        "decision_reasons": dict(sorted(reasons.items())),
+        "date_query_rows": date_query_rows,
+        "date_facets_available_on_date_queries": date_facets_available,
+        "date_facets_retained_on_date_queries": date_facets_retained,
+        "compatible_process_timeline_inclusions": (
+            compatible_process_timeline_inclusions
+        ),
+        "selection_uses_query_text": True,
+        "selection_uses_category": False,
+        "selection_uses_gold_rubric_answer_or_score": False,
+        "unparsed_policy": "default_include",
+        "row_audits": row_audits,
+    }
+    return {"results": treatment_rows}, audit
+
+
+def validate_full400_preflight(audit: dict) -> None:
+    errors = []
+    expected = {
+        "rows": EXPECTED_ROWS,
+        "facet_inventory": EXPECTED_FACETS,
+        "parsed_facets": EXPECTED_FACETS,
+        "ordinary_contexts_exact": EXPECTED_ROWS,
+        "instruction_target_rows": EXPECTED_INSTRUCTION_TARGETS,
+        "instruction_targets_retained": EXPECTED_INSTRUCTION_TARGETS,
+        "rows_with_suppression": 28,
+        "suppressed_facets": 53,
+        "date_query_rows": 41,
+        "date_facets_available_on_date_queries": 68,
+        "date_facets_retained_on_date_queries": 68,
+        "compatible_process_timeline_inclusions": 1,
+    }
+    for key, value in expected.items():
+        if audit.get(key) != value:
+            errors.append(f"expected {key}={value}, got {audit.get(key)}")
+    if audit["max_facet_tokens_observed"] > MAX_FACET_TOKENS:
+        errors.append("facet token ceiling exceeded")
+    expected_reasons = {
+        "default_include_no_conflict": 1746,
+        "include_compatible_date_time": 1,
+        "suppress_chronology_date_time_conflict": 41,
+        "suppress_chronology_formatting_conflict": 12,
+    }
+    if audit["decision_reasons"] != expected_reasons:
+        errors.append(
+            f"expected decision_reasons={expected_reasons}, "
+            f"got {audit['decision_reasons']}"
+        )
+    for row in audit["row_audits"]:
+        for decision in row["decisions"]:
+            if decision["include"]:
+                continue
+            if not row["query_shape"]["chronology_of_mentions"]:
+                errors.append(f"non-chronology suppression in {row['query_id']}")
+            if decision["directive_type"] not in {"date_time", "formatting_structure"}:
+                errors.append(f"unsupported suppression type in {row['query_id']}")
+            if not decision["condition_parsed"]:
+                errors.append(f"unparsed directive suppressed in {row['query_id']}")
+    if errors:
+        raise RuntimeError(
+            "pre-call applicability gate failed:\n- " + "\n- ".join(errors)
+        )
+
+
+def main() -> int:
+    from memory_bench.utils import count_tokens
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--control-contexts", type=Path, required=True)
+    parser.add_argument("--documents", type=Path, required=True)
+    parser.add_argument("--yantrikdb-python", type=Path, required=True)
+    parser.add_argument("--db", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--model", default="deepseek-v4-flash:0731-cloud")
+    args = parser.parse_args()
+
+    rows = overlay_control_contexts(
+        load_rows(args.results), load_rows(args.control_contexts)
+    )
+    namespaces = list(
+        dict.fromkeys(
+            str((row.get("meta") or {}).get("conversation_id") or "") for row in rows
+        )
+    )
+    if any(not namespace for namespace in namespaces):
+        raise ValueError("one or more rows lack conversation_id")
+    if args.db.exists() and not args.overwrite:
+        raise FileExistsError(f"store already exists: {args.db}")
+    if args.overwrite:
+        _remove_store(args.db)
+    args.db.parent.mkdir(parents=True, exist_ok=True)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    sys.path.insert(0, str(args.yantrikdb_python.resolve()))
+    from yantrikdb import YantrikDB
+
+    conversations = load_conversations(args.documents)
+    db = YantrikDB.with_default(str(args.db))
+    try:
+        extraction_audits = _ingest_and_extract(db, conversations, namespaces)
+    finally:
+        db.close()
+
+    source_map = _source_map(args.db)
+    db = YantrikDB.with_default(str(args.db))
+    try:
+        snapshots = _facet_snapshots(db, namespaces, source_map)
+        treatment, audit = build_context_rows(rows, snapshots, count_tokens)
+    finally:
+        db.close()
+    validate_full400_preflight(audit)
+
+    db = YantrikDB.with_default(str(args.db))
+    try:
+        replay_snapshots = _facet_snapshots(db, namespaces, source_map)
+        replay_treatment, replay_audit = build_context_rows(
+            rows, replay_snapshots, count_tokens
+        )
+    finally:
+        db.close()
+    replay_exact = _json_bytes(replay_treatment) == _json_bytes(treatment)
+    replay_selection_exact = [
+        row["selected_rids"] for row in replay_audit["row_audits"]
+    ] == [row["selected_rids"] for row in audit["row_audits"]]
+    replay_trace_exact = [row["decisions"] for row in replay_audit["row_audits"]] == [
+        row["decisions"] for row in audit["row_audits"]
+    ]
+    if not replay_exact or not replay_selection_exact or not replay_trace_exact:
+        raise RuntimeError("fresh-open applicability replay was not exact")
+
+    control = _control_payload(rows)
+    control_path = args.out_dir / "control.json"
+    treatment_path = args.out_dir / "applicable-facets.json"
+    preflight_path = args.out_dir / "preflight.json"
+    control_path.write_bytes(_json_bytes(control))
+    treatment_path.write_bytes(_json_bytes(treatment))
+
+    query_ids = [str(row["query_id"]) for row in rows]
+    preflight = {
+        **audit,
+        "status": "passed",
+        "product_path": {
+            "raw_turn_ingestion": True,
+            "persisted_facet_extraction": True,
+            "store_reopened_before_selection": True,
+            "query_shape_filtering": True,
+            "second_fresh_open_replay_exact": replay_exact,
+            "second_fresh_open_selection_exact": replay_selection_exact,
+            "second_fresh_open_predicate_trace_exact": replay_trace_exact,
+            "category_or_gold_used_during_selection": False,
+        },
+        "extraction_audits": extraction_audits,
+        "source_sha256": {
+            "results": _sha256_file(args.results),
+            "control_contexts": _sha256_file(args.control_contexts),
+            "documents": _sha256_file(args.documents),
+        },
+        "ordered_query_ids_sha256": _sha256_bytes(
+            json.dumps(query_ids, separators=(",", ":")).encode("utf-8")
+        ),
+        "arms": {
+            "control": {
+                "file": control_path.name,
+                "sha256": _sha256_file(control_path),
+            },
+            "treatment": {
+                "file": treatment_path.name,
+                "sha256": _sha256_file(treatment_path),
+            },
+        },
+        "external_evaluation": {
+            "model": args.model,
+            "answer_repeats": 1,
+            "judge_repeats": 1,
+            "answer_calls": len(rows) * 2,
+            "judge_calls": len(rows) * 2,
+            "synthetic_benchmark_data_only": True,
+            "real_companion_memories_included": False,
+        },
+    }
+    preflight_path.write_bytes(_json_bytes(preflight))
+    print(
+        json.dumps(
+            {
+                key: value
+                for key, value in preflight.items()
+                if key not in {"row_audits", "extraction_audits"}
+            },
+            indent=2,
+        )
+    )
+    print(f"preflight_sha256={_sha256_file(preflight_path)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_amb_build_applicable_facet_contexts.py
+++ b/tests/test_amb_build_applicable_facet_contexts.py
@@ -1,0 +1,123 @@
+from benchmarks.amb.build_applicable_facet_contexts import (
+    PREDICATE_VERSION,
+    facet_decision,
+    parse_condition,
+    query_shape,
+    select_applicable_facets,
+)
+
+
+def _facet(rid, text, first=1.0):
+    return {
+        "rid": rid,
+        "text": text,
+        "turn": int(first),
+        "first_mention_at": first,
+    }
+
+
+DATE_RULE = _facet(
+    "date",
+    'Always format dates as "Month Day, Year" when I ask about timeline details.',
+)
+PATENT_RULE = _facet(
+    "patent",
+    "Always provide detailed timelines when I ask about patent application processes.",
+    2.0,
+)
+RESUME_RULE = _facet(
+    "resume",
+    "Always use structured bullet points with quantified achievements when I ask "
+    "about resume formatting preferences.",
+    3.0,
+)
+CONTENT_RULE = _facet(
+    "content",
+    "Always include cultural context when I ask about social norms.",
+    4.0,
+)
+
+
+def test_parse_condition_preserves_action_and_scope():
+    assert parse_condition(DATE_RULE["text"]) == (
+        'Always format dates as "Month Day, Year"',
+        "timeline details",
+    )
+    assert parse_condition("Always reply in French.") is None
+
+
+def test_query_shape_disambiguates_date_request_from_mention_chronology():
+    date = query_shape("When was the Montserrat Writers' Festival?")
+    assert date["date_time_request"]
+    assert not date["chronology_of_mentions"]
+
+    chronology = query_shape(
+        "List the order in which I brought up project topics throughout our "
+        "conversations, in order."
+    )
+    assert chronology["chronology_of_mentions"]
+    assert not chronology["date_time_request"]
+
+
+def test_default_include_applies_outside_positive_form_conflict():
+    decision = facet_decision("When was the festival?", DATE_RULE)
+    assert decision["include"]
+    assert decision["predicate_version"] == PREDICATE_VERSION
+
+    unparsed = facet_decision(
+        "List events in chronological sequence throughout our chats.",
+        _facet("u", "Always reply in French."),
+    )
+    assert unparsed["include"]
+    assert unparsed["reason"] == "default_include_unparsed"
+
+
+def test_chronology_suppresses_unrequested_date_and_format_transforms():
+    query = (
+        "Can you list the order in which I brought up different aspects of my "
+        "resume throughout our conversations in order?"
+    )
+    selected, decisions = select_applicable_facets(
+        query, [DATE_RULE, PATENT_RULE, RESUME_RULE, CONTENT_RULE]
+    )
+    assert [facet["rid"] for facet in selected] == ["content"]
+    assert {
+        decision["reason"] for decision in decisions if not decision["include"]
+    } == {
+        "suppress_chronology_date_time_conflict",
+        "suppress_chronology_formatting_conflict",
+    }
+
+
+def test_ordered_deadline_inverse_control_retains_date_rule():
+    query = (
+        "List the order in which I mentioned each deadline throughout our "
+        "conversations, in order."
+    )
+    decision = facet_decision(query, DATE_RULE)
+    assert decision["query_shape"]["chronology_of_mentions"]
+    assert decision["query_shape"]["date_time_request"]
+    assert decision["include"]
+    assert decision["reason"] == "include_compatible_date_time"
+
+
+def test_process_timeline_inverse_control_retains_matching_rule():
+    query = (
+        "Walk me through the order in which I brought up the different stages "
+        "of my patent process throughout our conversations."
+    )
+    decision = facet_decision(query, PATENT_RULE)
+    assert decision["query_shape"]["process_timeline_request"]
+    assert decision["include"]
+    assert decision["reason"] == "include_compatible_date_time"
+
+
+def test_same_topic_does_not_override_answer_shape_conflict():
+    query = (
+        "List the order in which I brought up improvements to my resume "
+        "throughout our conversations."
+    )
+    decision = facet_decision(query, RESUME_RULE)
+    assert decision["scope_type"] == "formatting_structure"
+    assert not decision["query_shape"]["formatting_request"]
+    assert not decision["include"]


### PR DESCRIPTION
Records the countersigned 4/10 collision audit and freezes v4's default-include, positive-conflict-only facet applicability predicate before product preflight or external calls. Adds a product-backed builder with versioned decision traces, exact query-only census gates, near-domain controls, and a nonnegative event-ordering promotion gate. Verification: 12 focused tests pass; Ruff check and format pass. No external calls were made.