### PR TITLE
fix: separate paired bootstrap seed

### DIFF
--- a/benchmarks/amb/COMPLETE_FACET_COMPOSITION_RESULT.md
+++ b/benchmarks/amb/COMPLETE_FACET_COMPOSITION_RESULT.md
@@ -36,6 +36,11 @@ so the byte-identical v3 replication was not run. See
 The preregistration and product preflight were committed and merged before
 scored results were inspected.
 
+Tooling note recorded after v2: evaluator seed `20260820` controlled both arm
+order and paired-bootstrap resampling. The bootstrap method and reported
+interval remain valid, but the two random streams were seed-coupled; v4 binds
+them independently.
+
 ## Overall Result
 
 | Arm | Mean rubric score |

--- a/benchmarks/amb/paired_frozen_context_eval.py
+++ b/benchmarks/amb/paired_frozen_context_eval.py
@@ -156,12 +156,16 @@ def _run_fingerprint(config: dict) -> str:
     return _sha256_bytes(encoded)
 
 
+def _resolve_bootstrap_seed(run_seed: int, bootstrap_seed: int | None) -> int:
+    return run_seed if bootstrap_seed is None else bootstrap_seed
+
+
 def _load_resume_checkpoint(path: Path, run_fingerprint: str) -> dict[str, dict]:
     prior = json.loads(path.read_text(encoding="utf-8"))
     if prior.get("run_fingerprint") != run_fingerprint:
         raise ValueError(
             "resume checkpoint does not match the current manifest, contexts, "
-            "model, labels, split, seed, workers, and judge settings"
+            "model, labels, split, run/bootstrap seeds, workers, and judge settings"
         )
     pairs = prior.get("pairs", [])
     query_ids = [pair.get("query_id") for pair in pairs]
@@ -255,6 +259,7 @@ def main() -> int:
     parser.add_argument("--answer-repeats", type=int, default=1)
     parser.add_argument("--judge-repeats", type=int, default=1)
     parser.add_argument("--seed", type=int, default=20260820)
+    parser.add_argument("--bootstrap-seed", type=int)
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--out", type=Path)
     parser.add_argument("--resume", action="store_true")
@@ -264,6 +269,7 @@ def main() -> int:
         parser.error("--judge-repeats must be a positive odd number")
     if args.answer_repeats < 1 or args.answer_repeats % 2 == 0:
         parser.error("--answer-repeats must be a positive odd number")
+    bootstrap_seed = _resolve_bootstrap_seed(args.seed, args.bootstrap_seed)
     if args.limit is not None:
         parser.error("--limit is incompatible with a frozen manifest run")
     if not args.preflight_only and args.out is None:
@@ -338,6 +344,7 @@ def main() -> int:
         "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "seed": args.seed,
+        "bootstrap_seed": bootstrap_seed,
         "workers": args.workers,
     }
     run_fingerprint = _run_fingerprint(run_config)
@@ -496,13 +503,14 @@ def main() -> int:
         for pair in pairs
         for delta in pair["answer_repeat_comparison"]["deltas_b_minus_a"]
     ]
-    lower, upper = _paired_bootstrap_interval(deltas, args.seed)
+    lower, upper = _paired_bootstrap_interval(deltas, bootstrap_seed)
     summary = {
         "n": len(pairs),
         "mean_a": statistics.fmean(scores_a) if scores_a else 0.0,
         "mean_b": statistics.fmean(scores_b) if scores_b else 0.0,
         "mean_delta_b_minus_a": statistics.fmean(deltas) if deltas else 0.0,
         "paired_bootstrap_95_ci": [lower, upper],
+        "paired_bootstrap_seed": bootstrap_seed,
         "wins_b": sum(delta > 0 for delta in deltas),
         "ties": sum(delta == 0 for delta in deltas),
         "wins_a": sum(delta < 0 for delta in deltas),
@@ -540,6 +548,7 @@ def main() -> int:
         "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "seed": args.seed,
+        "bootstrap_seed": bootstrap_seed,
         "summary": summary,
         "pairs": pairs,
     }

--- a/tests/test_paired_frozen_context_eval.py
+++ b/tests/test_paired_frozen_context_eval.py
@@ -8,6 +8,8 @@ from benchmarks.amb.paired_frozen_context_eval import (
     _load_resume_checkpoint,
     _median_scored_result,
     _ordered_query_ids_sha256,
+    _paired_bootstrap_interval,
+    _resolve_bootstrap_seed,
     _run_fingerprint,
     _sha256_file,
     validate_manifest,
@@ -159,7 +161,7 @@ def test_repeated_answers_interleave_arms_and_select_median_score():
 
 def test_resume_checkpoint_is_bound_to_run_fingerprint(tmp_path):
     checkpoint = tmp_path / "run.partial"
-    fingerprint = _run_fingerprint({"model": "a", "seed": 7})
+    fingerprint = _run_fingerprint({"model": "a", "seed": 7, "bootstrap_seed": 11})
     _write_json(
         checkpoint,
         {
@@ -173,8 +175,21 @@ def test_resume_checkpoint_is_bound_to_run_fingerprint(tmp_path):
     with pytest.raises(ValueError, match="does not match"):
         _load_resume_checkpoint(
             checkpoint,
-            _run_fingerprint({"model": "b", "seed": 7}),
+            _run_fingerprint({"model": "b", "seed": 7, "bootstrap_seed": 11}),
         )
+
+
+def test_bootstrap_seed_is_independent_and_resume_bound():
+    deltas = [-1.0, 0.0, 0.0, 0.5, 1.0]
+    interval_a = _paired_bootstrap_interval(deltas, seed=7, samples=101)
+    interval_b = _paired_bootstrap_interval(deltas, seed=8, samples=101)
+
+    assert interval_a != interval_b
+    assert _run_fingerprint({"seed": 5, "bootstrap_seed": 7}) != _run_fingerprint(
+        {"seed": 5, "bootstrap_seed": 8}
+    )
+    assert _resolve_bootstrap_seed(5, None) == 5
+    assert _resolve_bootstrap_seed(5, 8) == 8
 
 
 def test_resume_checkpoint_rejects_duplicate_pairs(tmp_path):


### PR DESCRIPTION
Adds an explicit bootstrap seed to the paired frozen-context evaluator while preserving the prior run-seed default. The resolved bootstrap seed is bound into the run fingerprint and resume checkpoint, used only for the paired confidence interval, and recorded in the summary and output. Validation: 6 focused tests passed; Ruff check and format passed; frozen v4 preflight-only passed with run seed 20260826 and bootstrap seed 20260827. No external calls made.