### PR TITLE
bench: freeze final facet power protocol

### DIFF
--- a/benchmarks/amb/FACET_APPLICABILITY_V5_POWER_PREREGISTRATION.md
+++ b/benchmarks/amb/FACET_APPLICABILITY_V5_POWER_PREREGISTRATION.md
@@ -1,0 +1,163 @@
+# AMB Standing-Facet Applicability V5 Final Power Preregistration
+
+Status: estimator, seeds, tooling, gates, and finality frozen before any v5
+external call.
+
+## Decision Question
+
+The unchanged `facet-form-conflict-v1` treatment produced a positive v4
+overall point estimate (`+0.014255`) and instruction-following lift (`+0.075`),
+but failed the summarization and event-ordering gates on one answer draw. Does
+the same mechanism pass all six gates when answer variance is reduced by three
+independent draws per query and arm?
+
+This is a power check, not a new treatment. No predicate, context, category,
+prompt, judge, threshold, or cohort is changed after v4. No v4 answer, score,
+or judge output is pooled into v5.
+
+## Frozen Inputs
+
+- Cohort: the same 400 BEAM 100k queries.
+- Model: `deepseek-v4-flash:0731-cloud` for answers and judges.
+- Control SHA-256:
+  `918f572927b75ab1bb2ae3edf5656eada132cf9a644953f31bf693c695d46863`.
+- Treatment SHA-256:
+  `688c17fa3d2b50d4484b16b6906a2a2ae3285a7c9d1b6901cd330f364ac8e4f2`.
+- Paired manifest SHA-256:
+  `cbf3471d3fbaf656097899fe4426ed70f74c931c1f5a50ed56bc86a30c9f9fc4`.
+- Ordered query-ID SHA-256:
+  `08b325da5c5a9830bdc94cb25fc09a74c5e4dc06b70e433911b27c5352901b52`.
+- Score-blind category source: BEAM `data/beam/100k/queries.json.gz`,
+  SHA-256
+  `f58e001b3aeb0f13c894aa0ca6896a8181addbec4c140cc982cd0de9c0f0c465`.
+
+The v4 product preflight remains the lineage proof: 400/400 ordinary contexts
+were exact, all 40 instruction targets were retained, all close/reopen replays
+were exact, and the treatment was built by the product path. V5 consumes the
+already-frozen scorer artifacts byte for byte and does not rebuild them.
+
+Before this document was committed, all three exact `--preflight-only`
+commands reproduced the frozen manifest, arm, and ordered query-ID hashes. Each
+reported two 400-row arms, 800 projected answers, 800 projected judges,
+`workers=2`, bootstrap seed `20260831`, and its matching run/model seed from the
+table below. All three output paths and all three `.partial` checkpoint paths
+were absent. The focused evaluator, combiner, v4-gate, and v5-gate test set
+passed `21/21`; Ruff check and format passed.
+
+## Estimator
+
+Three independent paired runs each produce one answer and one judge per arm
+per query. They use these run and provider-model seed pairs:
+
+| Replicate | Run/arm-order seed | Provider model seed |
+|---|---:|---:|
+| 1 | `20260828` | `20260828` |
+| 2 | `20260829` | `20260829` |
+| 3 | `20260830` | `20260830` |
+
+For each query, the final control score is the arithmetic mean of its three
+control scores and the final treatment score is the arithmetic mean of its
+three treatment scores. The paired delta is treatment mean minus control mean.
+Every overall/category mean, win/tie/loss count, interval, and gate is computed
+over those 400 paired mean-of-three deltas.
+
+The existing evaluator's `--answer-repeats 3` path is prohibited because it
+selects median-scored answers for pair-level comparison. V5 instead runs three
+separate `--answer-repeats 1 --judge-repeats 1` evaluations and combines them
+with `combine_paired_replicates.py`.
+
+`--model-seed` is bound before the benchmark package imports its Ollama
+provider, recorded in each run fingerprint, and verified against the imported
+provider value before calls. A cloud provider may honor this seed loosely;
+independence rests on three separate runs, while seed binding makes their
+configuration auditable rather than promising provider determinism.
+
+The final paired bootstrap uses 20,000 query-level resamples and the separate
+seed `20260831`. Individual replicate intervals are not decision evidence.
+
+## Call Budget
+
+- Answers: `400 queries * 2 arms * 3 replicates = 2,400`.
+- Judges: `2,400 answers * 1 judge = 2,400`.
+- Total external calls: `4,800`.
+
+No output or checkpoint path may exist at first launch. A `.partial` file may
+be resumed only for the same interrupted replicate and only when its complete
+run fingerprint matches. Replicates run serially. Their logs are not inspected
+for scores until all three runs complete, so a partial result cannot influence
+whether later replicates run.
+
+## Frozen Commands
+
+Each replicate first runs `--preflight-only` with the exact shared paths,
+model, manifest, worker count, repeat counts, run seed, model seed, and
+bootstrap seed. Preflight must report two 400-row arms with the frozen ordered
+query-ID hash, 800 answer calls, 800 judge calls, and the expected execution
+seeds without constructing a client or making an external call.
+
+The scoring command template is:
+
+```powershell
+python benchmarks/amb/paired_frozen_context_eval.py `
+  --contexts-a .tmp-facet-applicability-v4-product/paired/ydb0151-all400.json `
+  --contexts-b .tmp-facet-applicability-v4-product/paired/applicable-facets-all400-v4.json `
+  --label-a ydb0151-all400 `
+  --label-b applicable-facets-all400-v4 `
+  --model deepseek-v4-flash:0731-cloud `
+  --split 100k `
+  --workers 2 `
+  --answer-repeats 1 `
+  --judge-repeats 1 `
+  --seed <20260828|20260829|20260830> `
+  --model-seed <same-seed> `
+  --bootstrap-seed 20260831 `
+  --manifest .tmp-facet-applicability-v4-product/paired/manifest.json `
+  --out .tmp-facet-applicability-v5-power/replicate-<same-seed>.json
+```
+
+After all three complete, the frozen combiner validates every input hash,
+fingerprint, configuration, 400-row cohort, and ordered query ID before writing
+`combined-v5.json`. `analyze_facet_applicability_v5.py` then reads only IDs and
+frozen category labels from the score-blind BEAM query source and applies the
+six gates below with bootstrap seed `20260831`.
+
+```powershell
+python benchmarks/amb/combine_paired_replicates.py `
+  --replicate .tmp-facet-applicability-v5-power/replicate-20260828.json `
+  --replicate .tmp-facet-applicability-v5-power/replicate-20260829.json `
+  --replicate .tmp-facet-applicability-v5-power/replicate-20260830.json `
+  --expected-seed 20260828 --expected-seed 20260829 --expected-seed 20260830 `
+  --expected-model-seed 20260828 `
+  --expected-model-seed 20260829 `
+  --expected-model-seed 20260830 `
+  --bootstrap-seed 20260831 `
+  --output .tmp-facet-applicability-v5-power/combined-v5.json
+
+python benchmarks/amb/analyze_facet_applicability_v5.py `
+  --result .tmp-facet-applicability-v5-power/combined-v5.json `
+  --source $env:AMB_ROOT/data/beam/100k/queries.json.gz `
+  --output .tmp-facet-applicability-v5-power/analysis-v5.json
+```
+
+## Promotion Gates
+
+All six v4 gates are unchanged and all must pass:
+
+1. Instruction-following delta is at least `+0.05`, with more wins than
+   losses.
+2. Overall delta is non-negative and its paired 95% interval lower bound is at
+   least `-0.01`.
+3. Pooled other-nine-category delta is at least `-0.005`.
+4. Summarization delta is at least `-0.01`.
+5. No category other than instruction following is below `-0.025`.
+6. Event-ordering delta is non-negative.
+
+There is no post-hoc threshold change, category router, query allowlist,
+replicate exclusion, score-tuned exception, or v4 pooling.
+
+## Finality
+
+this is the LAST composition arm on this line regardless of outcome. Pass all
+six → default-on promotion. Any fail → opt-in is TERMINAL, arc closes, no
+further power escalation, no mechanism variants without a fundamentally new
+evidence base.

--- a/benchmarks/amb/analyze_facet_applicability_v5.py
+++ b/benchmarks/amb/analyze_facet_applicability_v5.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Apply the final v5 gates to a validated mean-of-three paired result."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+try:
+    from .analyze_facet_applicability_v4 import analyze
+    from .paired_frozen_context_eval import _run_fingerprint, load_rows
+except ImportError:  # pragma: no cover - direct script execution
+    from analyze_facet_applicability_v4 import analyze
+    from paired_frozen_context_eval import _run_fingerprint, load_rows
+
+
+EXPECTED_PROTOCOL = "paired-independent-mean-of-three-v1"
+EXPECTED_REPLICATE_SEEDS = [20260828, 20260829, 20260830]
+EXPECTED_BOOTSTRAP_SEED = 20260831
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def analyze_v5(result: dict, source_rows: list[dict]) -> dict:
+    config = result.get("run_config") or {}
+    if result.get("run_fingerprint") != _run_fingerprint(config):
+        raise ValueError("combined result fingerprint does not match its run config")
+    if config.get("protocol") != EXPECTED_PROTOCOL:
+        raise ValueError("result is not the frozen independent mean-of-three protocol")
+    if result.get("replicate_seeds") != EXPECTED_REPLICATE_SEEDS:
+        raise ValueError("result run seeds do not match the frozen v5 seeds")
+    if result.get("model_seeds") != EXPECTED_REPLICATE_SEEDS:
+        raise ValueError("result model seeds do not match the frozen v5 seeds")
+    if config.get("replicate_seeds") != EXPECTED_REPLICATE_SEEDS:
+        raise ValueError("run config seeds do not match the frozen v5 seeds")
+    if config.get("model_seeds") != EXPECTED_REPLICATE_SEEDS:
+        raise ValueError("run config model seeds do not match the frozen v5 seeds")
+    if config.get("replicate_count") != 3:
+        raise ValueError("result does not contain exactly three replicates")
+    category_rows = [
+        {**row, "query_id": row.get("query_id") or row.get("id")} for row in source_rows
+    ]
+    report = analyze(result, category_rows, EXPECTED_BOOTSTRAP_SEED)
+    report["protocol"] = "facet-applicability-v5-final-power-analysis-v1"
+    report["finality"] = (
+        "default-on-promotion" if report["promotion_passed"] else "terminal-opt-in"
+    )
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    result = json.loads(args.result.read_text(encoding="utf-8"))
+    report = analyze_v5(result, load_rows(args.source))
+    report["result_sha256"] = _sha256_file(args.result)
+    report["source_sha256"] = _sha256_file(args.source)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/combine_paired_replicates.py
+++ b/benchmarks/amb/combine_paired_replicates.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Combine independent paired runs by per-query arithmetic means."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import statistics
+from pathlib import Path
+
+try:
+    from .paired_frozen_context_eval import (
+        _paired_bootstrap_interval,
+        _run_fingerprint,
+    )
+except ImportError:  # pragma: no cover - direct script execution
+    from paired_frozen_context_eval import _paired_bootstrap_interval, _run_fingerprint
+
+
+EXPECTED_PAIRS = 400
+EXPECTED_REPLICATES = 3
+COMMON_RUN_KEYS = (
+    "manifest_sha256",
+    "contexts_a_sha256",
+    "contexts_b_sha256",
+    "query_ids_sha256",
+    "label_a",
+    "label_b",
+    "model",
+    "split",
+    "answer_repeats",
+    "judge_repeats",
+    "workers",
+)
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _require_equal(actual, expected, message: str) -> None:
+    if actual != expected:
+        raise ValueError(f"{message}: expected={expected!r} actual={actual!r}")
+
+
+def _validate_result(
+    result: dict,
+    path: Path,
+    expected_seed: int,
+    expected_model_seed: int,
+    expected_bootstrap_seed: int,
+) -> tuple[dict, list[dict]]:
+    config = result.get("run_config") or {}
+    pairs = result.get("pairs") or []
+    prefix = path.name
+
+    _require_equal(result.get("run_fingerprint"), _run_fingerprint(config), prefix)
+    _require_equal(result.get("seed"), expected_seed, f"{prefix}: output seed")
+    _require_equal(config.get("seed"), expected_seed, f"{prefix}: run seed")
+    _require_equal(
+        result.get("model_seed"),
+        expected_model_seed,
+        f"{prefix}: output model seed",
+    )
+    _require_equal(
+        config.get("model_seed"),
+        expected_model_seed,
+        f"{prefix}: run model seed",
+    )
+    _require_equal(
+        result.get("bootstrap_seed"),
+        expected_bootstrap_seed,
+        f"{prefix}: output bootstrap seed",
+    )
+    _require_equal(
+        config.get("bootstrap_seed"),
+        expected_bootstrap_seed,
+        f"{prefix}: run bootstrap seed",
+    )
+    _require_equal(
+        (result.get("summary") or {}).get("paired_bootstrap_seed"),
+        expected_bootstrap_seed,
+        f"{prefix}: summary bootstrap seed",
+    )
+    _require_equal(result.get("label_a"), config.get("label_a"), f"{prefix}: label_a")
+    _require_equal(result.get("label_b"), config.get("label_b"), f"{prefix}: label_b")
+    _require_equal(result.get("model"), config.get("model"), f"{prefix}: model")
+    _require_equal(result.get("answer_repeats"), 1, f"{prefix}: answer repeats")
+    _require_equal(config.get("answer_repeats"), 1, f"{prefix}: run answer repeats")
+    _require_equal(result.get("judge_repeats"), 1, f"{prefix}: judge repeats")
+    _require_equal(config.get("judge_repeats"), 1, f"{prefix}: run judge repeats")
+    _require_equal(len(pairs), EXPECTED_PAIRS, f"{prefix}: completed pairs")
+    _require_equal(
+        (result.get("summary") or {}).get("n"),
+        EXPECTED_PAIRS,
+        f"{prefix}: summary pairs",
+    )
+
+    query_ids = [str(pair.get("query_id") or "") for pair in pairs]
+    if any(not query_id for query_id in query_ids):
+        raise ValueError(f"{prefix}: every pair must have a query_id")
+    if len(set(query_ids)) != len(query_ids):
+        raise ValueError(f"{prefix}: duplicate query_ids")
+    for pair in pairs:
+        score_a = float(pair["score_a"])
+        score_b = float(pair["score_b"])
+        delta = float(pair["delta_b_minus_a"])
+        if not all(math.isfinite(value) for value in (score_a, score_b, delta)):
+            raise ValueError(f"{prefix}: non-finite score for {pair['query_id']}")
+        if not math.isclose(delta, score_b - score_a, abs_tol=1e-12):
+            raise ValueError(f"{prefix}: inconsistent delta for {pair['query_id']}")
+    return config, pairs
+
+
+def combine(
+    paths: list[Path],
+    expected_seeds: list[int],
+    expected_model_seeds: list[int],
+    bootstrap_seed: int,
+) -> dict:
+    if len(paths) != EXPECTED_REPLICATES:
+        raise ValueError(f"expected exactly {EXPECTED_REPLICATES} replicate files")
+    if len(expected_seeds) != EXPECTED_REPLICATES:
+        raise ValueError(f"expected exactly {EXPECTED_REPLICATES} run seeds")
+    if len(expected_model_seeds) != EXPECTED_REPLICATES:
+        raise ValueError(f"expected exactly {EXPECTED_REPLICATES} model seeds")
+    if len(set(expected_seeds)) != EXPECTED_REPLICATES:
+        raise ValueError("run seeds must be distinct")
+    if len(set(expected_model_seeds)) != EXPECTED_REPLICATES:
+        raise ValueError("model seeds must be distinct")
+
+    loaded = [json.loads(path.read_text(encoding="utf-8")) for path in paths]
+    validated = [
+        _validate_result(result, path, seed, model_seed, bootstrap_seed)
+        for result, path, seed, model_seed in zip(
+            loaded, paths, expected_seeds, expected_model_seeds
+        )
+    ]
+    configs = [item[0] for item in validated]
+    replicate_pairs = [item[1] for item in validated]
+    baseline = {key: configs[0].get(key) for key in COMMON_RUN_KEYS}
+    for index, config in enumerate(configs[1:], 2):
+        actual = {key: config.get(key) for key in COMMON_RUN_KEYS}
+        _require_equal(actual, baseline, f"replicate {index}: common run config")
+
+    query_ids = [str(pair["query_id"]) for pair in replicate_pairs[0]]
+    for index, pairs in enumerate(replicate_pairs[1:], 2):
+        _require_equal(
+            [str(pair["query_id"]) for pair in pairs],
+            query_ids,
+            f"replicate {index}: ordered query IDs",
+        )
+
+    combined_pairs = []
+    for pair_index, query_id in enumerate(query_ids):
+        scores_a = [float(pairs[pair_index]["score_a"]) for pairs in replicate_pairs]
+        scores_b = [float(pairs[pair_index]["score_b"]) for pairs in replicate_pairs]
+        score_a = statistics.fmean(scores_a)
+        score_b = statistics.fmean(scores_b)
+        combined_pairs.append(
+            {
+                "query_id": query_id,
+                "score_a": score_a,
+                "score_b": score_b,
+                "delta_b_minus_a": score_b - score_a,
+                "replicate_scores_a": scores_a,
+                "replicate_scores_b": scores_b,
+                "replicate_deltas_b_minus_a": [
+                    value_b - value_a for value_a, value_b in zip(scores_a, scores_b)
+                ],
+            }
+        )
+
+    deltas = [pair["delta_b_minus_a"] for pair in combined_pairs]
+    scores_a = [pair["score_a"] for pair in combined_pairs]
+    scores_b = [pair["score_b"] for pair in combined_pairs]
+    lower, upper = _paired_bootstrap_interval(deltas, bootstrap_seed)
+    source_replicates = [
+        {
+            "path": str(path),
+            "sha256": _sha256_file(path),
+            "run_fingerprint": result["run_fingerprint"],
+            "seed": seed,
+            "model_seed": model_seed,
+        }
+        for path, result, seed, model_seed in zip(
+            paths, loaded, expected_seeds, expected_model_seeds
+        )
+    ]
+    run_config = {
+        **baseline,
+        "protocol": "paired-independent-mean-of-three-v1",
+        "replicate_count": EXPECTED_REPLICATES,
+        "replicate_seeds": expected_seeds,
+        "model_seeds": expected_model_seeds,
+        "bootstrap_seed": bootstrap_seed,
+        "source_sha256": [source["sha256"] for source in source_replicates],
+        "score_aggregation": "per-query-arm-arithmetic-mean-v1",
+    }
+    summary = {
+        "n": len(combined_pairs),
+        "replicate_count": EXPECTED_REPLICATES,
+        "mean_a": statistics.fmean(scores_a),
+        "mean_b": statistics.fmean(scores_b),
+        "mean_delta_b_minus_a": statistics.fmean(deltas),
+        "paired_bootstrap_95_ci": [lower, upper],
+        "paired_bootstrap_seed": bootstrap_seed,
+        "wins_b": sum(delta > 0 for delta in deltas),
+        "ties": sum(delta == 0 for delta in deltas),
+        "wins_a": sum(delta < 0 for delta in deltas),
+    }
+    return {
+        "run_config": run_config,
+        "run_fingerprint": _run_fingerprint(run_config),
+        "label_a": baseline["label_a"],
+        "label_b": baseline["label_b"],
+        "model": baseline["model"],
+        "answer_repeats_per_replicate": 1,
+        "judge_repeats_per_answer": 1,
+        "replicate_seeds": expected_seeds,
+        "model_seeds": expected_model_seeds,
+        "bootstrap_seed": bootstrap_seed,
+        "source_replicates": source_replicates,
+        "summary": summary,
+        "pairs": combined_pairs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--replicate", type=Path, action="append", required=True)
+    parser.add_argument("--expected-seed", type=int, action="append", required=True)
+    parser.add_argument(
+        "--expected-model-seed", type=int, action="append", required=True
+    )
+    parser.add_argument("--bootstrap-seed", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    result = combine(
+        args.replicate,
+        args.expected_seed,
+        args.expected_model_seed,
+        args.bootstrap_seed,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result["summary"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/paired_frozen_context_eval.py
+++ b/benchmarks/amb/paired_frozen_context_eval.py
@@ -19,6 +19,7 @@ import argparse
 import gzip
 import hashlib
 import json
+import os
 import random
 import statistics
 import sys
@@ -160,12 +161,20 @@ def _resolve_bootstrap_seed(run_seed: int, bootstrap_seed: int | None) -> int:
     return run_seed if bootstrap_seed is None else bootstrap_seed
 
 
+def _resolve_model_seed(model_seed: int | None) -> int:
+    """Preserve the provider's historical environment/default seed behavior."""
+    if model_seed is not None:
+        return model_seed
+    return int(os.environ.get("OMB_OLLAMA_SEED", "0"))
+
+
 def _load_resume_checkpoint(path: Path, run_fingerprint: str) -> dict[str, dict]:
     prior = json.loads(path.read_text(encoding="utf-8"))
     if prior.get("run_fingerprint") != run_fingerprint:
         raise ValueError(
             "resume checkpoint does not match the current manifest, contexts, "
-            "model, labels, split, run/bootstrap seeds, workers, and judge settings"
+            "model, labels, split, run/model/bootstrap seeds, workers, and judge "
+            "settings"
         )
     pairs = prior.get("pairs", [])
     query_ids = [pair.get("query_id") for pair in pairs]
@@ -259,6 +268,7 @@ def main() -> int:
     parser.add_argument("--answer-repeats", type=int, default=1)
     parser.add_argument("--judge-repeats", type=int, default=1)
     parser.add_argument("--seed", type=int, default=20260820)
+    parser.add_argument("--model-seed", type=int)
     parser.add_argument("--bootstrap-seed", type=int)
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--out", type=Path)
@@ -270,13 +280,21 @@ def main() -> int:
     if args.answer_repeats < 1 or args.answer_repeats % 2 == 0:
         parser.error("--answer-repeats must be a positive odd number")
     bootstrap_seed = _resolve_bootstrap_seed(args.seed, args.bootstrap_seed)
+    try:
+        model_seed = _resolve_model_seed(args.model_seed)
+    except ValueError as error:
+        parser.error(f"invalid OMB_OLLAMA_SEED: {error}")
     if args.limit is not None:
         parser.error("--limit is incompatible with a frozen manifest run")
     if not args.preflight_only and args.out is None:
         parser.error("--out is required unless --preflight-only is set")
 
-    # These imports are deliberately after argument validation. In particular,
-    # preflight never imports or constructs an LLM client.
+    # memory_bench.dataset imports the llm package, whose Ollama seed is captured
+    # at module import time. Pin the environment before any memory_bench import.
+    os.environ["OMB_OLLAMA_SEED"] = str(model_seed)
+
+    # These imports are deliberately after argument validation. Preflight never
+    # constructs an LLM client or makes an external call.
     from memory_bench.dataset import get_dataset
     from memory_bench.utils import count_tokens
 
@@ -321,16 +339,34 @@ def main() -> int:
         )
     print(
         json.dumps(
-            {key: value for key, value in preflight.items() if key != "query_ids"},
+            {
+                **{
+                    key: value for key, value in preflight.items() if key != "query_ids"
+                },
+                "execution": {
+                    "seed": args.seed,
+                    "model_seed": model_seed,
+                    "bootstrap_seed": bootstrap_seed,
+                    "workers": args.workers,
+                },
+            },
             indent=2,
         )
     )
     if args.preflight_only:
         return 0
 
-    from memory_bench.llm.ollama import OllamaLLM
+    from memory_bench.llm import ollama as ollama_module
     from memory_bench.models import QueryResult
     from memory_bench.modes.rag import RAGMode
+
+    imported_model_seed = getattr(ollama_module, "_SEED", None)
+    if imported_model_seed != model_seed:
+        parser.error(
+            "Ollama provider was imported before --model-seed was bound; refusing "
+            f"requested={model_seed} imported={imported_model_seed}"
+        )
+    OllamaLLM = ollama_module.OllamaLLM
 
     run_config = {
         "manifest_sha256": preflight["manifest_sha256"],
@@ -344,6 +380,7 @@ def main() -> int:
         "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "seed": args.seed,
+        "model_seed": model_seed,
         "bootstrap_seed": bootstrap_seed,
         "workers": args.workers,
     }
@@ -370,7 +407,7 @@ def main() -> int:
     remaining = [query_id for query_id in ids if query_id not in completed]
     print(
         f"[{args.label_a} vs {args.label_b}] pairs={len(ids)} "
-        f"resume={len(completed)} model={args.model}",
+        f"resume={len(completed)} model={args.model} model_seed={model_seed}",
         file=sys.stderr,
         flush=True,
     )
@@ -548,6 +585,7 @@ def main() -> int:
         "answer_repeats": args.answer_repeats,
         "judge_repeats": args.judge_repeats,
         "seed": args.seed,
+        "model_seed": model_seed,
         "bootstrap_seed": bootstrap_seed,
         "summary": summary,
         "pairs": pairs,

--- a/tests/test_amb_analyze_facet_applicability_v5.py
+++ b/tests/test_amb_analyze_facet_applicability_v5.py
@@ -1,0 +1,75 @@
+import pytest
+
+from benchmarks.amb.analyze_facet_applicability_v5 import analyze_v5
+from benchmarks.amb.paired_frozen_context_eval import _run_fingerprint
+
+
+CATEGORIES = [
+    "abstention",
+    "contradiction_resolution",
+    "event_ordering",
+    "information_extraction",
+    "instruction_following",
+    "knowledge_update",
+    "multi_session_reasoning",
+    "preference_following",
+    "summarization",
+    "temporal_reasoning",
+]
+SEEDS = [20260828, 20260829, 20260830]
+
+
+def _fixture(category_deltas=None):
+    category_deltas = category_deltas or {"instruction_following": 0.1}
+    pairs = []
+    rows = []
+    for category in CATEGORIES:
+        for index in range(40):
+            query_id = f"{category}-{index}"
+            delta = category_deltas.get(category, 0.0)
+            pairs.append({"query_id": query_id, "score_a": 0.5, "score_b": 0.5 + delta})
+            rows.append({"query_id": query_id, "meta": {"question_category": category}})
+    run_config = {
+        "protocol": "paired-independent-mean-of-three-v1",
+        "replicate_count": 3,
+        "replicate_seeds": SEEDS,
+        "model_seeds": SEEDS,
+        "bootstrap_seed": 20260831,
+    }
+    result = {
+        "bootstrap_seed": 20260831,
+        "replicate_seeds": SEEDS,
+        "model_seeds": SEEDS,
+        "run_config": run_config,
+        "run_fingerprint": _run_fingerprint(run_config),
+        "summary": {"paired_bootstrap_seed": 20260831},
+        "pairs": pairs,
+    }
+    return result, rows
+
+
+def test_v5_analyzer_passes_and_records_default_on_finality():
+    result, rows = _fixture()
+
+    report = analyze_v5(result, rows)
+
+    assert report["promotion_passed"] is True
+    assert report["finality"] == "default-on-promotion"
+    assert report["protocol"] == "facet-applicability-v5-final-power-analysis-v1"
+
+
+def test_v5_analyzer_failure_is_terminal_opt_in():
+    result, rows = _fixture({"instruction_following": 0.04})
+
+    report = analyze_v5(result, rows)
+
+    assert report["promotion_passed"] is False
+    assert report["finality"] == "terminal-opt-in"
+
+
+def test_v5_analyzer_rejects_mutated_combined_config():
+    result, rows = _fixture()
+    result["run_config"]["bootstrap_seed"] = 7
+
+    with pytest.raises(ValueError, match="fingerprint"):
+        analyze_v5(result, rows)

--- a/tests/test_amb_combine_paired_replicates.py
+++ b/tests/test_amb_combine_paired_replicates.py
@@ -1,0 +1,136 @@
+import json
+
+import pytest
+
+from benchmarks.amb.combine_paired_replicates import combine
+from benchmarks.amb.paired_frozen_context_eval import _run_fingerprint
+
+
+SEEDS = [20260828, 20260829, 20260830]
+
+
+def _result(seed, score_a, score_b, context_b="treatment-hash"):
+    config = {
+        "manifest_sha256": "manifest-hash",
+        "contexts_a_sha256": "control-hash",
+        "contexts_b_sha256": context_b,
+        "query_ids_sha256": "query-hash",
+        "label_a": "control",
+        "label_b": "treatment",
+        "model": "test-model",
+        "split": "100k",
+        "answer_repeats": 1,
+        "judge_repeats": 1,
+        "seed": seed,
+        "model_seed": seed,
+        "bootstrap_seed": 20260831,
+        "workers": 2,
+    }
+    pairs = [
+        {
+            "query_id": f"q{index:03d}",
+            "score_a": score_a,
+            "score_b": score_b,
+            "delta_b_minus_a": score_b - score_a,
+        }
+        for index in range(400)
+    ]
+    return {
+        "run_config": config,
+        "run_fingerprint": _run_fingerprint(config),
+        "label_a": "control",
+        "label_b": "treatment",
+        "model": "test-model",
+        "answer_repeats": 1,
+        "judge_repeats": 1,
+        "seed": seed,
+        "model_seed": seed,
+        "bootstrap_seed": 20260831,
+        "summary": {"n": 400, "paired_bootstrap_seed": 20260831},
+        "pairs": pairs,
+    }
+
+
+def _write_replicates(tmp_path, results):
+    paths = []
+    for seed, result in zip(SEEDS, results):
+        path = tmp_path / f"replicate-{seed}.json"
+        path.write_text(json.dumps(result), encoding="utf-8")
+        paths.append(path)
+    return paths
+
+
+def test_combiner_uses_per_query_arm_means_and_binds_sources(tmp_path):
+    paths = _write_replicates(
+        tmp_path,
+        [
+            _result(SEEDS[0], 0.2, 0.6),
+            _result(SEEDS[1], 0.4, 0.5),
+            _result(SEEDS[2], 0.6, 0.4),
+        ],
+    )
+
+    combined = combine(paths, SEEDS, SEEDS, bootstrap_seed=20260831)
+
+    pair = combined["pairs"][0]
+    assert pair["replicate_scores_a"] == [0.2, 0.4, 0.6]
+    assert pair["replicate_scores_b"] == [0.6, 0.5, 0.4]
+    assert pair["score_a"] == pytest.approx(0.4)
+    assert pair["score_b"] == pytest.approx(0.5)
+    assert pair["delta_b_minus_a"] == pytest.approx(0.1)
+    assert combined["summary"]["n"] == 400
+    assert combined["summary"]["paired_bootstrap_seed"] == 20260831
+    assert len(combined["source_replicates"]) == 3
+    assert all(source["sha256"] for source in combined["source_replicates"])
+    assert combined["run_fingerprint"] == _run_fingerprint(combined["run_config"])
+
+
+def test_combiner_rejects_common_config_drift(tmp_path):
+    results = [
+        _result(SEEDS[0], 0.2, 0.6),
+        _result(SEEDS[1], 0.4, 0.5, context_b="changed"),
+        _result(SEEDS[2], 0.6, 0.4),
+    ]
+    paths = _write_replicates(tmp_path, results)
+
+    with pytest.raises(ValueError, match="common run config"):
+        combine(paths, SEEDS, SEEDS, bootstrap_seed=20260831)
+
+
+def test_combiner_rejects_reordered_or_incomplete_cohort(tmp_path):
+    results = [
+        _result(SEEDS[0], 0.2, 0.6),
+        _result(SEEDS[1], 0.4, 0.5),
+        _result(SEEDS[2], 0.6, 0.4),
+    ]
+    results[1]["pairs"].reverse()
+    paths = _write_replicates(tmp_path, results)
+
+    with pytest.raises(ValueError, match="ordered query IDs"):
+        combine(paths, SEEDS, SEEDS, bootstrap_seed=20260831)
+
+
+def test_combiner_rejects_seed_or_fingerprint_mismatch(tmp_path):
+    results = [
+        _result(SEEDS[0], 0.2, 0.6),
+        _result(SEEDS[1], 0.4, 0.5),
+        _result(SEEDS[2], 0.6, 0.4),
+    ]
+    results[2]["model_seed"] = 7
+    paths = _write_replicates(tmp_path, results)
+
+    with pytest.raises(ValueError, match="output model seed"):
+        combine(paths, SEEDS, SEEDS, bootstrap_seed=20260831)
+
+
+def test_combiner_rejects_replicate_bootstrap_seed_mismatch(tmp_path):
+    results = [
+        _result(SEEDS[0], 0.2, 0.6),
+        _result(SEEDS[1], 0.4, 0.5),
+        _result(SEEDS[2], 0.6, 0.4),
+    ]
+    results[1]["summary"]["paired_bootstrap_seed"] = 7
+    paths = _write_replicates(tmp_path, results)
+
+    with pytest.raises(ValueError, match="summary bootstrap seed"):
+        combine(paths, SEEDS, SEEDS, bootstrap_seed=20260831)

--- a/tests/test_paired_frozen_context_eval.py
+++ b/tests/test_paired_frozen_context_eval.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 
@@ -10,6 +11,7 @@ from benchmarks.amb.paired_frozen_context_eval import (
     _ordered_query_ids_sha256,
     _paired_bootstrap_interval,
     _resolve_bootstrap_seed,
+    _resolve_model_seed,
     _run_fingerprint,
     _sha256_file,
     validate_manifest,
@@ -190,6 +192,22 @@ def test_bootstrap_seed_is_independent_and_resume_bound():
     )
     assert _resolve_bootstrap_seed(5, None) == 5
     assert _resolve_bootstrap_seed(5, 8) == 8
+
+
+def test_model_seed_is_explicit_or_preserves_provider_default(monkeypatch):
+    monkeypatch.delenv("OMB_OLLAMA_SEED", raising=False)
+    assert _resolve_model_seed(None) == 0
+
+    monkeypatch.setenv("OMB_OLLAMA_SEED", "13")
+    assert _resolve_model_seed(None) == 13
+    assert _resolve_model_seed(17) == 17
+    assert os.environ["OMB_OLLAMA_SEED"] == "13"
+
+
+def test_model_seed_changes_run_fingerprint():
+    assert _run_fingerprint({"seed": 5, "model_seed": 7}) != _run_fingerprint(
+        {"seed": 5, "model_seed": 8}
+    )
 
 
 def test_resume_checkpoint_rejects_duplicate_pairs(tmp_path):


### PR DESCRIPTION
Freezes the countersigned final k=3 power check before any v5 external call. Adds explicit provider model-seed binding, three-run mean combiner, final six-gate analyzer, no-call preflight record, and terminal finality clause. Validation: 21 focused tests passed; Ruff check/format passed; all three exact 400-row preflights reproduced frozen hashes and call budgets; all output/checkpoint paths remain absent. Local uv.lock and .tmp artifacts are intentionally excluded.