### PR TITLE
perf(engine): persisted Unicode-normalized entity key (schema v49)

### DIFF
--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -15,7 +15,9 @@
 // freezes the query/child features needed for offline membership calibration.
 // v47 adds claims.hlc so relate LWW compares causal order, not wall clocks (#148).
 // v48 makes valid time reachable at recall: event_time_min/max columns + index (#149).
-pub const SCHEMA_VERSION: i32 = 48;
+// v49 persists the Unicode-lowercased entity key (memory_entities.entity_name_norm + index)
+// so recall_thread resolves names by indexed lookup instead of an O(V) vocabulary scan.
+pub const SCHEMA_VERSION: i32 = 49;
 
 pub const SCHEMA_SQL: &str = "
 -- Memory records: the source of truth
@@ -1080,10 +1082,16 @@ CREATE TABLE IF NOT EXISTS memory_chunks (
 CREATE TABLE IF NOT EXISTS memory_entities (
     memory_rid TEXT NOT NULL,
     entity_name TEXT NOT NULL,
+    -- v49: Rust str::to_lowercase() of entity_name (full Unicode fold; SQL
+    -- LOWER() is ASCII-only and must never produce this value). Stamped by
+    -- every writer via engine::thread::normalize_entity_name and backfilled
+    -- in Rust at open (the entity_norm_backfill stage) for migrated stores.
+    entity_name_norm TEXT,
     PRIMARY KEY (memory_rid, entity_name)
 );
 CREATE INDEX IF NOT EXISTS idx_memory_entities_entity ON memory_entities(entity_name);
 CREATE INDEX IF NOT EXISTS idx_memory_entities_rid ON memory_entities(memory_rid);
+CREATE INDEX IF NOT EXISTS idx_memory_entities_norm ON memory_entities(entity_name_norm, memory_rid);
 
 -- FTS5 for full-text search on memories
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(text, content=memories, content_rowid=rowid);
@@ -3056,4 +3064,25 @@ WHERE metadata IS NOT NULL AND json_valid(metadata);
 CREATE INDEX IF NOT EXISTS idx_memories_event_time
     ON memories(namespace, event_time_min, event_time_max)
     WHERE event_time_min IS NOT NULL;
+";
+
+/// v48 -> v49 (#188 follow-up, reviewer finding): `recall_thread` resolved
+/// requested entity names by scanning `SELECT DISTINCT entity_name FROM
+/// memory_entities` and Unicode-lowercasing EVERY name in Rust per request
+/// — O(V) over the global entity vocabulary, across namespaces, on every
+/// call. The Rust-side lowercase existed because SQL LOWER() is ASCII-only
+/// and must match `crate::graph::tokenize`'s Unicode lowercasing. v49
+/// persists that normalized key (`entity_name_norm`, stamped by every
+/// writer via `engine::thread::normalize_entity_name`) so resolution
+/// becomes one indexed lookup. Statements stay idempotent-friendly: the
+/// runner is `run_migration_idempotent` (the v0.7.3 contract).
+pub const MIGRATE_V48_TO_V49: &str = "
+ALTER TABLE memory_entities ADD COLUMN entity_name_norm TEXT;
+-- NO SQL backfill here, deliberately: SQLite LOWER() is ASCII-only, so
+-- 'MÜNSTER' would become 'mÜnster' — corrupting every non-ASCII entity
+-- name and diverging from crate::graph::tokenize's Unicode lowercasing.
+-- The ENGINE backfills post-migration in Rust (open()'s
+-- entity_norm_backfill stage) with str::to_lowercase().
+CREATE INDEX IF NOT EXISTS idx_memory_entities_norm
+    ON memory_entities(entity_name_norm, memory_rid);
 ";

--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -1082,15 +1082,21 @@ CREATE TABLE IF NOT EXISTS memory_chunks (
 CREATE TABLE IF NOT EXISTS memory_entities (
     memory_rid TEXT NOT NULL,
     entity_name TEXT NOT NULL,
-    -- v49: Rust str::to_lowercase() of entity_name (full Unicode fold; SQL
-    -- LOWER() is ASCII-only and must never produce this value). Stamped by
-    -- every writer via engine::thread::normalize_entity_name and backfilled
-    -- in Rust at open (the entity_norm_backfill stage) for migrated stores.
+    -- v49: Unicode lowercase of entity_name (Rust str::to_lowercase() —
+    -- deliberately NOT full Unicode case folding — in lockstep with
+    -- crate::graph::tokenize; SQL LOWER() is ASCII-only and must never
+    -- produce this value). Stamped by every writer via
+    -- engine::thread::normalize_entity_name and backfilled in Rust at open
+    -- (the entity_norm_backfill stage) for migrated stores.
     entity_name_norm TEXT,
     PRIMARY KEY (memory_rid, entity_name)
 );
 CREATE INDEX IF NOT EXISTS idx_memory_entities_entity ON memory_entities(entity_name);
 CREATE INDEX IF NOT EXISTS idx_memory_entities_rid ON memory_entities(memory_rid);
+-- Known scale caveat (deferred deliberately — see PR #190 review): this
+-- (entity_name_norm, memory_rid) index matches a name across ALL
+-- namespaces before the memories join filters namespace; a true
+-- tenant-bounded lookup would need namespace in the entity lookup index.
 CREATE INDEX IF NOT EXISTS idx_memory_entities_norm ON memory_entities(entity_name_norm, memory_rid);
 
 -- FTS5 for full-text search on memories
@@ -3082,7 +3088,13 @@ ALTER TABLE memory_entities ADD COLUMN entity_name_norm TEXT;
 -- 'MÜNSTER' would become 'mÜnster' — corrupting every non-ASCII entity
 -- name and diverging from crate::graph::tokenize's Unicode lowercasing.
 -- The ENGINE backfills post-migration in Rust (open()'s
--- entity_norm_backfill stage) with str::to_lowercase().
+-- entity_norm_backfill stage) with str::to_lowercase() — Unicode
+-- lowercase, deliberately NOT full Unicode case folding, in lockstep
+-- with crate::graph::tokenize.
+-- Known scale caveat (deferred deliberately — see PR #190 review): the
+-- (entity_name_norm, memory_rid) index matches a name across ALL
+-- namespaces before the memories join filters namespace; a true
+-- tenant-bounded lookup would need namespace in the entity lookup index.
 CREATE INDEX IF NOT EXISTS idx_memory_entities_norm
     ON memory_entities(entity_name_norm, memory_rid);
 ";

--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -596,8 +596,13 @@ impl YantrikDB {
         {
             let conn = self.conn.lock();
             conn.execute(
-                "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) VALUES (?1, ?2)",
-                params![memory_rid, entity_name],
+                "INSERT OR IGNORE INTO memory_entities \
+                 (memory_rid, entity_name, entity_name_norm) VALUES (?1, ?2, ?3)",
+                params![
+                    memory_rid,
+                    entity_name,
+                    crate::engine::thread::normalize_entity_name(entity_name)
+                ],
             )?;
         } // conn dropped
 
@@ -661,8 +666,13 @@ impl YantrikDB {
             let conn = self.conn.lock();
             for c in &candidates {
                 conn.execute(
-                    "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) VALUES (?1, ?2)",
-                    params![c.rid, c.entity],
+                    "INSERT OR IGNORE INTO memory_entities \
+                     (memory_rid, entity_name, entity_name_norm) VALUES (?1, ?2, ?3)",
+                    params![
+                        c.rid,
+                        c.entity,
+                        crate::engine::thread::normalize_entity_name(&c.entity)
+                    ],
                 )?;
             }
         } // conn dropped
@@ -741,8 +751,13 @@ impl YantrikDB {
             let conn = self.conn.lock();
             for c in &candidates {
                 conn.execute(
-                    "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) VALUES (?1, ?2)",
-                    params![c.rid, c.entity],
+                    "INSERT OR IGNORE INTO memory_entities \
+                     (memory_rid, entity_name, entity_name_norm) VALUES (?1, ?2, ?3)",
+                    params![
+                        c.rid,
+                        c.entity,
+                        crate::engine::thread::normalize_entity_name(&c.entity)
+                    ],
                 )?;
             }
         } // conn dropped

--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -604,6 +604,7 @@ impl YantrikDB {
                     crate::engine::thread::normalize_entity_name(entity_name)
                 ],
             )?;
+            crate::engine::thread::repair_entity_norm(&conn, memory_rid, entity_name)?;
         } // conn dropped
 
         // Phase 2: Lock graph_index write for in-memory update
@@ -674,6 +675,7 @@ impl YantrikDB {
                         crate::engine::thread::normalize_entity_name(&c.entity)
                     ],
                 )?;
+                crate::engine::thread::repair_entity_norm(&conn, &c.rid, &c.entity)?;
             }
         } // conn dropped
 
@@ -759,6 +761,7 @@ impl YantrikDB {
                         crate::engine::thread::normalize_entity_name(&c.entity)
                     ],
                 )?;
+                crate::engine::thread::repair_entity_norm(&conn, &c.rid, &c.entity)?;
             }
         } // conn dropped
 

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -913,22 +913,42 @@ impl YantrikDB {
         // but MIGRATE_V48_TO_V49 cannot backfill it in SQL: LOWER() is
         // ASCII-only and would diverge from crate::graph::tokenize's
         // Unicode lowercasing on non-ASCII names. So the engine backfills
-        // here, post-migration: guarded (only NULL rows are touched, so
-        // every open after the first is a single indexed probe), batched
-        // in one transaction, idempotent on crash/replay.
+        // here, post-migration, in KEYSET-PAGED batches: a large upgraded
+        // store must never materialize its whole entity join in RAM, so
+        // rows are fetched 10k at a time by ascending rowid and each batch
+        // commits in its own transaction. Crash-safe and idempotent:
+        // committed rows are no longer NULL and are never revisited, and
+        // on a store with nothing to do (every open after the first) the
+        // loop is a single indexed probe.
+        //
+        // Index tradeoff, documented deliberately: MIGRATE_V48_TO_V49
+        // creates idx_memory_entities_norm BEFORE this backfill runs, so
+        // the one-time backfill pays per-row index maintenance. Creating
+        // the index after the backfill would save that churn, but would
+        // split the index's existence across two owners (migration SQL vs
+        // engine code) and complicate the idempotent-replay contract —
+        // run_migration_idempotent re-runs the migration wholesale on
+        // rewound stores — so the migration keeps the CREATE INDEX.
         {
-            let pending: Vec<(i64, String)> = at("entity_norm_backfill", {
-                (|| {
-                    let mut stmt = conn.prepare(
-                        "SELECT rowid, entity_name FROM memory_entities \
-                         WHERE entity_name_norm IS NULL",
-                    )?;
-                    let rows =
-                        stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?;
-                    rows.collect::<std::result::Result<Vec<_>, _>>()
-                })()
-            })?;
-            if !pending.is_empty() {
+            const BACKFILL_BATCH: i64 = 10_000;
+            let mut last_rowid: i64 = 0;
+            loop {
+                let batch: Vec<(i64, String)> = at("entity_norm_backfill", {
+                    (|| {
+                        let mut stmt = conn.prepare(
+                            "SELECT rowid, entity_name FROM memory_entities \
+                             WHERE entity_name_norm IS NULL AND rowid > ?1 \
+                             ORDER BY rowid LIMIT ?2",
+                        )?;
+                        let rows = stmt.query_map(params![last_rowid, BACKFILL_BATCH], |r| {
+                            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+                        })?;
+                        rows.collect::<std::result::Result<Vec<_>, _>>()
+                    })()
+                })?;
+                let Some(&(batch_last, _)) = batch.last() else {
+                    break;
+                };
                 let tx = at("entity_norm_backfill", conn.unchecked_transaction())?;
                 {
                     let mut update = at(
@@ -938,7 +958,7 @@ impl YantrikDB {
                              WHERE rowid = ?2",
                         ),
                     )?;
-                    for (rowid, name) in &pending {
+                    for (rowid, name) in &batch {
                         at(
                             "entity_norm_backfill",
                             update.execute(params![
@@ -949,6 +969,7 @@ impl YantrikDB {
                     }
                 }
                 at("entity_norm_backfill", tx.commit())?;
+                last_rowid = batch_last;
             }
         }
 

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -113,8 +113,9 @@ use crate::schema::{
     MIGRATE_V32_TO_V33, MIGRATE_V33_TO_V34, MIGRATE_V34_TO_V35, MIGRATE_V35_TO_V36,
     MIGRATE_V36_TO_V37, MIGRATE_V37_TO_V38, MIGRATE_V3_TO_V4, MIGRATE_V40_TO_V41,
     MIGRATE_V41_TO_V42, MIGRATE_V42_TO_V43, MIGRATE_V44_TO_V45, MIGRATE_V45_TO_V46,
-    MIGRATE_V46_TO_V47, MIGRATE_V47_TO_V48, MIGRATE_V4_TO_V5, MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7,
-    MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10, SCHEMA_SQL, SCHEMA_VERSION,
+    MIGRATE_V46_TO_V47, MIGRATE_V47_TO_V48, MIGRATE_V48_TO_V49, MIGRATE_V4_TO_V5, MIGRATE_V5_TO_V6,
+    MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10, SCHEMA_SQL,
+    SCHEMA_VERSION,
 };
 use crate::types::*;
 
@@ -888,6 +889,7 @@ impl YantrikDB {
             (45, MIGRATE_V45_TO_V46),
             (46, MIGRATE_V46_TO_V47),
             (47, MIGRATE_V47_TO_V48),
+            (48, MIGRATE_V48_TO_V49),
         ];
         if let Some(v) = existing_version {
             for &(from_v, sql) in migrations {
@@ -901,6 +903,54 @@ impl YantrikDB {
         }
 
         at("schema_sql", conn.execute_batch(SCHEMA_SQL))?;
+
+        // **v49 entity_name_norm backfill — Rust, not SQL.** The reviewer
+        // finding behind v49: `recall_thread` resolved requested entity
+        // names by scanning `SELECT DISTINCT entity_name FROM
+        // memory_entities` and Unicode-lowercasing EVERY name in Rust per
+        // request — O(V) over the global entity vocabulary, across
+        // namespaces, on every call. The persisted key retires that scan,
+        // but MIGRATE_V48_TO_V49 cannot backfill it in SQL: LOWER() is
+        // ASCII-only and would diverge from crate::graph::tokenize's
+        // Unicode lowercasing on non-ASCII names. So the engine backfills
+        // here, post-migration: guarded (only NULL rows are touched, so
+        // every open after the first is a single indexed probe), batched
+        // in one transaction, idempotent on crash/replay.
+        {
+            let pending: Vec<(i64, String)> = at("entity_norm_backfill", {
+                (|| {
+                    let mut stmt = conn.prepare(
+                        "SELECT rowid, entity_name FROM memory_entities \
+                         WHERE entity_name_norm IS NULL",
+                    )?;
+                    let rows =
+                        stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?;
+                    rows.collect::<std::result::Result<Vec<_>, _>>()
+                })()
+            })?;
+            if !pending.is_empty() {
+                let tx = at("entity_norm_backfill", conn.unchecked_transaction())?;
+                {
+                    let mut update = at(
+                        "entity_norm_backfill",
+                        tx.prepare(
+                            "UPDATE memory_entities SET entity_name_norm = ?1 \
+                             WHERE rowid = ?2",
+                        ),
+                    )?;
+                    for (rowid, name) in &pending {
+                        at(
+                            "entity_norm_backfill",
+                            update.execute(params![
+                                crate::engine::thread::normalize_entity_name(name),
+                                rowid
+                            ]),
+                        )?;
+                    }
+                }
+                at("entity_norm_backfill", tx.commit())?;
+            }
+        }
 
         // Populate seed substitution categories (idempotent)
         rewrap(

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1747,6 +1747,7 @@ impl YantrikDB {
                             crate::engine::thread::normalize_entity_name(entity)
                         ],
                     )?;
+                    crate::engine::thread::repair_entity_norm(&conn, rid, entity)?;
                 }
             }
 

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -1739,8 +1739,13 @@ impl YantrikDB {
                 }
                 for entity in candidates {
                     conn.execute(
-                        "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) VALUES (?1, ?2)",
-                        params![rid, entity],
+                        "INSERT OR IGNORE INTO memory_entities \
+                         (memory_rid, entity_name, entity_name_norm) VALUES (?1, ?2, ?3)",
+                        params![
+                            rid,
+                            entity,
+                            crate::engine::thread::normalize_entity_name(entity)
+                        ],
                     )?;
                 }
             }

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -1375,6 +1375,10 @@ impl YantrikDB {
                         crate::engine::thread::normalize_entity_name(entity)
                     ],
                 )? > 0;
+                // Self-heal AFTER the first-mention read: the repair is a
+                // separate UPDATE precisely so it can never count as a
+                // mention (see repair_entity_norm).
+                crate::engine::thread::repair_entity_norm(&conn, rid, entity)?;
                 let inc: i64 = if first_mention { 1 } else { 0 };
                 conn.execute(
                     "INSERT INTO entities (name, entity_type, first_seen, last_seen, mention_count) \
@@ -1413,6 +1417,7 @@ impl YantrikDB {
                             crate::engine::thread::normalize_entity_name(entity)
                         ],
                     )?;
+                    crate::engine::thread::repair_entity_norm(&conn, rid, entity)?;
                 }
             }
             // graph_index in-memory update (idempotent — add_entity/link dedupe).
@@ -1575,6 +1580,7 @@ impl YantrikDB {
                         crate::engine::thread::normalize_entity_name(entity)
                     ],
                 )?;
+                crate::engine::thread::repair_entity_norm(&conn, rid, entity)?;
             }
         }
 

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -1367,9 +1367,13 @@ impl YantrikDB {
                 // Claim the mention first; Loop B's INSERT OR IGNORE below is a
                 // no-op for anything already claimed here.
                 let first_mention = conn.execute(
-                    "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) \
-                     VALUES (?1, ?2)",
-                    params![rid, entity],
+                    "INSERT OR IGNORE INTO memory_entities \
+                     (memory_rid, entity_name, entity_name_norm) VALUES (?1, ?2, ?3)",
+                    params![
+                        rid,
+                        entity,
+                        crate::engine::thread::normalize_entity_name(entity)
+                    ],
                 )? > 0;
                 let inc: i64 = if first_mention { 1 } else { 0 };
                 conn.execute(
@@ -1401,8 +1405,13 @@ impl YantrikDB {
                 let conn = self.conn();
                 for entity in &candidates {
                     conn.execute(
-                        "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) VALUES (?1, ?2)",
-                        params![rid, entity],
+                        "INSERT OR IGNORE INTO memory_entities \
+                         (memory_rid, entity_name, entity_name_norm) VALUES (?1, ?2, ?3)",
+                        params![
+                            rid,
+                            entity,
+                            crate::engine::thread::normalize_entity_name(entity)
+                        ],
                     )?;
                 }
             }
@@ -1558,8 +1567,13 @@ impl YantrikDB {
                     params![entity, entity_type, ts_secs, was_new_row],
                 )?;
                 conn.execute(
-                    "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name) VALUES (?1, ?2)",
-                    params![rid, entity],
+                    "INSERT OR IGNORE INTO memory_entities \
+                     (memory_rid, entity_name, entity_name_norm) VALUES (?1, ?2, ?3)",
+                    params![
+                        rid,
+                        entity,
+                        crate::engine::thread::normalize_entity_name(entity)
+                    ],
                 )?;
             }
         }

--- a/crates/yantrikdb-core/src/engine/tests/migrations.rs
+++ b/crates/yantrikdb-core/src/engine/tests/migrations.rs
@@ -972,3 +972,131 @@ fn schema_v48_backfill_skips_ciphertext_metadata() {
     assert_eq!(get("absent"), (None, None));
     assert!(index_exists(&conn, "idx_memories_event_time"));
 }
+
+// =====================================================================
+// v49 — the persisted entity normalization key (entity_name_norm).
+//
+// Reviewer finding (#188 follow-up): recall_thread resolved requested
+// entity names by scanning SELECT DISTINCT entity_name FROM
+// memory_entities and Unicode-lowercasing EVERY name in Rust per request
+// — O(V) over the global entity vocabulary on every call. v49 persists
+// the normalized key; the backfill must run in RUST because SQL LOWER()
+// is ASCII-only and would corrupt non-ASCII names.
+// =====================================================================
+
+#[test]
+fn schema_v49_fresh_install_has_entity_norm_column_and_index() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let conn = db.conn();
+    let cols = table_columns(&conn, "memory_entities");
+    assert!(
+        cols.iter().any(|c| c == "entity_name_norm"),
+        "v49: fresh-install memory_entities table missing column entity_name_norm"
+    );
+    assert!(
+        index_exists(&conn, "idx_memory_entities_norm"),
+        "v49: fresh-install missing index idx_memory_entities_norm"
+    );
+}
+
+#[test]
+fn schema_v49_migration_backfills_unicode_lowercase_in_rust() {
+    // A store built at v48 has memory_entities rows with no
+    // entity_name_norm. SQL cannot backfill them: LOWER() is ASCII-only
+    // ('MÜNSTER' -> 'mÜnster'), so open() must do it in Rust (the
+    // entity_norm_backfill stage). Simulate: open at current schema,
+    // insert rows with NULL norm (the exact post-ALTER state a real v48
+    // table reaches), drop the index, rewind meta to 48, and reopen. The
+    // ALTER replays as a no-op (idempotent runner), the index is
+    // recreated, and the backfill must produce the correct Unicode
+    // lowercase.
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+
+    {
+        let _db = YantrikDB::new(path, 8).unwrap();
+    }
+    {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute(
+            "INSERT INTO memory_entities (memory_rid, entity_name) VALUES \
+             ('m1', 'Münster'), ('m2', 'MÜNSTER'), ('m3', 'Alpha')",
+            [],
+        )
+        .unwrap();
+        conn.execute("DROP INDEX idx_memory_entities_norm", [])
+            .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '48')",
+            [],
+        )
+        .unwrap();
+    }
+    {
+        let db = YantrikDB::new(path, 8).unwrap();
+        let conn = db.conn();
+        let get_norm = |rid: &str| -> Option<String> {
+            conn.query_row(
+                "SELECT entity_name_norm FROM memory_entities WHERE memory_rid = ?1",
+                [rid],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            get_norm("m1").as_deref(),
+            Some("münster"),
+            "backfill must be Rust to_lowercase, not ASCII-only SQL LOWER()"
+        );
+        assert_eq!(
+            get_norm("m2").as_deref(),
+            Some("münster"),
+            "'MÜNSTER' must fold to 'münster' — SQL LOWER() would give 'mÜnster'"
+        );
+        assert_eq!(get_norm("m3").as_deref(), Some("alpha"));
+        assert!(
+            index_exists(&conn, "idx_memory_entities_norm"),
+            "v49 migration replay must recreate idx_memory_entities_norm"
+        );
+    }
+}
+
+#[test]
+fn schema_v49_backfill_skips_already_stamped_rows() {
+    // The open()-time backfill is guarded on entity_name_norm IS NULL:
+    // rows already carrying a norm value are never rewritten, and a
+    // rewind-then-reopen replay must not error or clobber them.
+    use tempfile::NamedTempFile;
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_str().unwrap();
+    {
+        let _db = YantrikDB::new(path, 8).unwrap();
+    }
+    {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute(
+            "INSERT INTO memory_entities (memory_rid, entity_name, entity_name_norm) \
+             VALUES ('m1', 'Kept', 'kept')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '48')",
+            [],
+        )
+        .unwrap();
+    }
+    {
+        let _db = YantrikDB::new(path, 8).unwrap();
+    }
+    let conn = rusqlite::Connection::open(path).unwrap();
+    let norm: Option<String> = conn
+        .query_row(
+            "SELECT entity_name_norm FROM memory_entities WHERE memory_rid = 'm1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(norm.as_deref(), Some("kept"));
+}

--- a/crates/yantrikdb-core/src/engine/thread.rs
+++ b/crates/yantrikdb-core/src/engine/thread.rs
@@ -22,10 +22,13 @@
 //!   the `INSERT ... INTO memory_entities` sites in `engine/record.rs`,
 //!   `engine/stats.rs` and `engine/graph_ops.rs`); entity↔text matching
 //!   happens through `crate::graph::tokenize`'s Unicode lowercasing
-//!   instead. This lane matches the same way: requested names are resolved
-//!   against stored `entity_name` values case-insensitively via Rust
-//!   `to_lowercase()` (NOT SQL `LOWER()`, which is ASCII-only and would
-//!   diverge from the tokenizer on non-ASCII names).
+//!   instead. This lane matches the same way, through the PERSISTED
+//!   normalized key: every writer also stamps `entity_name_norm` =
+//!   [`normalize_entity_name`] (Rust `to_lowercase()`, NOT SQL `LOWER()`,
+//!   which is ASCII-only and would diverge from the tokenizer on
+//!   non-ASCII names), so requested names resolve with one indexed lookup
+//!   on `idx_memory_entities_norm` instead of Rust-lowercasing the whole
+//!   entity vocabulary per call (the pre-v49 O(V) DISTINCT scan).
 //! - **Visibility.** Mirrors recall's default read predicates: rows must be
 //!   `consolidation_status = 'active'` (recall's default,
 //!   `include_consolidated = false`), pass the synthesis lifecycle gate
@@ -52,6 +55,21 @@
 use std::collections::{BTreeSet, HashMap};
 
 use crate::base::error::Result;
+
+/// The single source of the persisted `memory_entities.entity_name_norm`
+/// key: Rust `str::to_lowercase()`, the full Unicode lowercase fold.
+///
+/// This MUST stay in lockstep with `crate::graph::tokenize`'s lowercasing:
+/// entity↔text matching is DEFINED by the tokenizer's fold, and the stored
+/// key exists precisely so SQL can perform that match through an index —
+/// SQL `LOWER()` is ASCII-only and is NOT an acceptable substitute. Every
+/// `INSERT INTO memory_entities` writer must bind this value
+/// (engine/record.rs, engine/stats.rs, engine/graph_ops.rs), and open()'s
+/// `entity_norm_backfill` stage uses it for pre-v49 rows; the enforcement
+/// census in `thread_tests` fails if any writer forgets.
+pub(crate) fn normalize_entity_name(name: &str) -> String {
+    name.to_lowercase()
+}
 
 /// One row of a coverage-first thread, in chronological order.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -109,12 +127,13 @@ impl crate::YantrikDB {
             return Ok(empty());
         }
 
-        // Requested-name index, keyed by Unicode lowercase (the tokenizer's
-        // folding). Duplicated requests ("Alpha", "alpha") collapse to the
-        // first spelling so a row never lists the same entity twice.
+        // Requested-name index, keyed by the persisted normalization (the
+        // tokenizer's Unicode fold — see normalize_entity_name). Duplicated
+        // requests ("Alpha", "alpha") collapse to the first spelling so a
+        // row never lists the same entity twice.
         let mut req_by_lower: HashMap<String, usize> = HashMap::new();
         for (i, e) in entities.iter().enumerate() {
-            req_by_lower.entry(e.to_lowercase()).or_insert(i);
+            req_by_lower.entry(normalize_entity_name(e)).or_insert(i);
         }
 
         struct RowAgg {
@@ -128,30 +147,16 @@ impl crate::YantrikDB {
         {
             let conn = self.read_conn();
 
-            // Resolve requested names to the VERBATIM stored entity_name
-            // values in Rust (Unicode-correct case fold; SQL LOWER() is
-            // ASCII-only). Distinct entity_name is bounded by the entity
-            // vocabulary, not the memory count.
-            let mut wanted: HashMap<String, usize> = HashMap::new();
-            {
-                let mut stmt =
-                    conn.prepare_cached("SELECT DISTINCT entity_name FROM memory_entities")?;
-                let names = stmt.query_map([], |r| r.get::<_, String>(0))?;
-                for name in names {
-                    let name = name?;
-                    if let Some(&idx) = req_by_lower.get(&name.to_lowercase()) {
-                        wanted.insert(name, idx);
-                    }
-                }
-            }
-            if wanted.is_empty() {
-                return Ok(empty());
-            }
+            // v49: requested names resolve directly against the PERSISTED
+            // normalized key (entity_name_norm — stamped by every writer,
+            // backfilled at open; see normalize_entity_name). One indexed
+            // lookup on idx_memory_entities_norm over a small fixed
+            // parameter list — the pre-v49 O(V) DISTINCT vocabulary scan
+            // (Unicode-lowercased in Rust per request) is retired.
+            let mut norm_names: Vec<&String> = req_by_lower.keys().collect();
+            norm_names.sort(); // deterministic parameter order
 
-            let mut stored_names: Vec<&String> = wanted.keys().collect();
-            stored_names.sort(); // deterministic parameter order
-
-            let placeholders: String = (0..stored_names.len())
+            let placeholders: String = (0..norm_names.len())
                 .map(|i| format!("?{}", i + 2))
                 .collect::<Vec<_>>()
                 .join(",");
@@ -159,18 +164,18 @@ impl crate::YantrikDB {
             // path (see module docs); the supersedes exclusion runs below,
             // outside the conn guard.
             let sql = format!(
-                "SELECT m.rid, m.text, m.created_at, m.metadata, me.entity_name \
+                "SELECT m.rid, m.text, m.created_at, m.metadata, me.entity_name_norm \
                  FROM memories m \
                  JOIN memory_entities me ON me.memory_rid = m.rid \
                  WHERE m.namespace = ?1 \
                    AND m.consolidation_status = 'active' \
                    AND (m.synthesis_state IS NULL OR m.synthesis_state = 'verified') \
-                   AND me.entity_name IN ({placeholders})"
+                   AND me.entity_name_norm IN ({placeholders})"
             );
             let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> =
-                Vec::with_capacity(stored_names.len() + 1);
+                Vec::with_capacity(norm_names.len() + 1);
             param_values.push(Box::new(namespace.to_string()));
-            for name in &stored_names {
+            for name in &norm_names {
                 param_values.push(Box::new((*name).clone()));
             }
             let params_ref: Vec<&dyn rusqlite::types::ToSql> =
@@ -187,8 +192,8 @@ impl crate::YantrikDB {
                 ))
             })?;
             for row in rows {
-                let (rid, text, created_at, metadata, entity_name) = row?;
-                let idx = wanted[&entity_name];
+                let (rid, text, created_at, metadata, entity_norm) = row?;
+                let idx = req_by_lower[&entity_norm];
                 by_rid
                     .entry(rid)
                     .or_insert_with(|| RowAgg {
@@ -686,5 +691,101 @@ mod thread_tests {
             follower.recall_thread(NS, &["Alpha", "Beta"], 100).unwrap(),
             leader.recall_thread(NS, &["Alpha", "Beta"], 100).unwrap()
         );
+    }
+
+    /// (g) ENFORCEMENT CENSUS — the normalized-key invariant. Rows reach
+    /// `memory_entities` through record (heuristic extraction via the
+    /// materializer), relate() (entity creation + text backfill), and
+    /// replication apply on a follower (apply_ops -> materialize +
+    /// backfill_memory_entities). After exercising all three natural
+    /// paths, EVERY row on BOTH sides must carry entity_name_norm ==
+    /// normalize_entity_name(entity_name). A writer that forgets the
+    /// binding leaves NULL (or a diverging value) and fails here.
+    #[test]
+    fn every_writer_stamps_the_normalized_entity_key() {
+        use crate::engine::thread::normalize_entity_name;
+        use crate::replication::{apply_ops, extract_ops_since};
+
+        let leader = YantrikDB::new(":memory:", 8).unwrap();
+        // Natural path 1: record with entity-bearing text (non-ASCII
+        // included — the exact case SQL LOWER() would corrupt).
+        for i in 0..4 {
+            seed_row(
+                &leader,
+                &format!("c{i}"),
+                &format!("Münster planning with Alpha and Beta round {i}"),
+                &meta_empty(),
+                BASE_MICROS + (i as i64) * 1_000_000,
+                &["Münster", "Alpha"],
+                i as f32,
+            );
+        }
+        // Natural path 2: relate() — creates entities and backfills
+        // memory_entities from row text (graph_ops.rs).
+        leader.relate("Alpha", "Beta", "related_to", 1.0).unwrap();
+        leader.relate("Münster", "Beta", "located_in", 0.7).unwrap();
+        drain(&leader);
+
+        // Natural path 3: replication apply to a follower.
+        let follower = YantrikDB::new(":memory:", 8).unwrap();
+        let ops = extract_ops_since(&leader.conn(), None, None, None, 1000).unwrap();
+        apply_ops(&follower, &ops).unwrap();
+
+        let census = |db: &YantrikDB, side: &str| {
+            let conn = db.conn();
+            let rows: Vec<(String, Option<String>)> = conn
+                .prepare("SELECT entity_name, entity_name_norm FROM memory_entities")
+                .unwrap()
+                .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap();
+            assert!(
+                !rows.is_empty(),
+                "{side}: census precondition — the natural paths must have \
+                 produced memory_entities rows"
+            );
+            let bad = rows
+                .iter()
+                .filter(|(name, norm)| {
+                    norm.as_deref() != Some(normalize_entity_name(name).as_str())
+                })
+                .count();
+            assert_eq!(
+                bad, 0,
+                "{side}: a writer inserted memory_entities without the normalized \
+                 key; every writer must bind normalize_entity_name()"
+            );
+        };
+        census(&leader, "leader");
+        census(&follower, "follower");
+    }
+
+    /// (h) Non-ASCII case-insensitive resolution via the indexed path: the
+    /// stored spelling is 'MÜNSTER'; the request is 'münster'. Under Rust
+    /// to_lowercase both fold to 'münster'; under SQL LOWER() the stored
+    /// key would have been 'mÜnster' and the lookup would return nothing.
+    #[test]
+    fn non_ascii_entity_resolves_case_insensitively_via_indexed_path() {
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+        seed_row(
+            &db,
+            "m_de",
+            "Planning the MÜNSTER rollout",
+            &meta_empty(),
+            BASE_MICROS,
+            &["MÜNSTER"],
+            1.0,
+        );
+        drain(&db);
+
+        let out = db.recall_thread(NS, &["münster"], 10).unwrap();
+        assert_eq!(
+            out.total, 1,
+            "Unicode fold must match, ASCII fold would miss"
+        );
+        assert_eq!(out.items[0].rid, "m_de");
+        assert_eq!(out.items[0].position, 1);
+        assert_eq!(out.items[0].entities, vec!["münster".to_string()]);
     }
 }

--- a/crates/yantrikdb-core/src/engine/thread.rs
+++ b/crates/yantrikdb-core/src/engine/thread.rs
@@ -24,10 +24,12 @@
 //!   happens through `crate::graph::tokenize`'s Unicode lowercasing
 //!   instead. This lane matches the same way, through the PERSISTED
 //!   normalized key: every writer also stamps `entity_name_norm` =
-//!   [`normalize_entity_name`] (Rust `to_lowercase()`, NOT SQL `LOWER()`,
-//!   which is ASCII-only and would diverge from the tokenizer on
-//!   non-ASCII names), so requested names resolve with one indexed lookup
-//!   on `idx_memory_entities_norm` instead of Rust-lowercasing the whole
+//!   [`normalize_entity_name`] — Unicode lowercase via Rust
+//!   `to_lowercase()`, deliberately NOT full Unicode case folding, in
+//!   lockstep with `crate::graph::tokenize` (never SQL `LOWER()`, which
+//!   is ASCII-only and would diverge from the tokenizer on non-ASCII
+//!   names) — so requested names resolve with one indexed lookup on
+//!   `idx_memory_entities_norm` instead of Rust-lowercasing the whole
 //!   entity vocabulary per call (the pre-v49 O(V) DISTINCT scan).
 //! - **Visibility.** Mirrors recall's default read predicates: rows must be
 //!   `consolidation_status = 'active'` (recall's default,
@@ -57,18 +59,48 @@ use std::collections::{BTreeSet, HashMap};
 use crate::base::error::Result;
 
 /// The single source of the persisted `memory_entities.entity_name_norm`
-/// key: Rust `str::to_lowercase()`, the full Unicode lowercase fold.
+/// key: Unicode lowercase via Rust `str::to_lowercase()` — deliberately
+/// NOT full Unicode case folding (no `ß` -> `ss`, no locale tailoring),
+/// in lockstep with `crate::graph::tokenize`, which lowercases the same
+/// way.
 ///
 /// This MUST stay in lockstep with `crate::graph::tokenize`'s lowercasing:
-/// entity↔text matching is DEFINED by the tokenizer's fold, and the stored
-/// key exists precisely so SQL can perform that match through an index —
+/// entity↔text matching is DEFINED by the tokenizer, and the stored key
+/// exists precisely so SQL can perform that match through an index —
 /// SQL `LOWER()` is ASCII-only and is NOT an acceptable substitute. Every
 /// `INSERT INTO memory_entities` writer must bind this value
-/// (engine/record.rs, engine/stats.rs, engine/graph_ops.rs), and open()'s
-/// `entity_norm_backfill` stage uses it for pre-v49 rows; the enforcement
-/// census in `thread_tests` fails if any writer forgets.
+/// (engine/record.rs, engine/stats.rs, engine/graph_ops.rs) and then call
+/// [`repair_entity_norm`]; open()'s `entity_norm_backfill` stage uses it
+/// for pre-v49 rows; the enforcement census in `thread_tests` fails if
+/// any writer forgets.
 pub(crate) fn normalize_entity_name(name: &str) -> String {
     name.to_lowercase()
+}
+
+/// Write-time self-heal for the persisted normalized key. `INSERT OR
+/// IGNORE` never touches a pre-existing `(memory_rid, entity_name)` row,
+/// so a row written before v49 — or carrying a stale norm value — would
+/// otherwise NEVER be repaired by later natural writes, and the
+/// normalized-key invariant would only hold for stores that started
+/// clean. Every `INSERT OR IGNORE INTO memory_entities` writer calls this
+/// right after its insert. The UPDATE's predicate makes it a no-op on
+/// already-correct rows (including the row the insert itself just
+/// wrote), and it deliberately does NOT touch `entities.mention_count` —
+/// first-mention accounting stays exactly on the insert's `changes()`
+/// result (engine/stats.rs).
+pub(crate) fn repair_entity_norm(
+    conn: &rusqlite::Connection,
+    memory_rid: &str,
+    entity_name: &str,
+) -> rusqlite::Result<()> {
+    let norm = normalize_entity_name(entity_name);
+    conn.execute(
+        "UPDATE memory_entities SET entity_name_norm = ?3 \
+         WHERE memory_rid = ?1 AND entity_name = ?2 \
+           AND (entity_name_norm IS NULL OR entity_name_norm != ?3)",
+        rusqlite::params![memory_rid, entity_name, norm],
+    )?;
+    Ok(())
 }
 
 /// One row of a coverage-first thread, in chronological order.
@@ -128,7 +160,7 @@ impl crate::YantrikDB {
         }
 
         // Requested-name index, keyed by the persisted normalization (the
-        // tokenizer's Unicode fold — see normalize_entity_name). Duplicated
+        // tokenizer's Unicode lowercase — see normalize_entity_name). Duplicated
         // requests ("Alpha", "alpha") collapse to the first spelling so a
         // row never lists the same entity twice.
         let mut req_by_lower: HashMap<String, usize> = HashMap::new();
@@ -787,5 +819,67 @@ mod thread_tests {
         assert_eq!(out.items[0].rid, "m_de");
         assert_eq!(out.items[0].position, 1);
         assert_eq!(out.items[0].entities, vec!["münster".to_string()]);
+    }
+    /// (i) SELF-HEAL ON WRITE — INSERT OR IGNORE never touches an existing
+    /// row, so a pre-v49 (or corrupted) NULL-norm row must be repaired by
+    /// the conditional UPDATE every writer runs after its insert
+    /// (repair_entity_norm). Seed the bad rows manually, then drive two
+    /// natural writer paths over the same (rid, entity) pairs.
+    #[test]
+    fn natural_writes_self_heal_a_null_normalized_key() {
+        use crate::engine::thread::normalize_entity_name;
+        let db = YantrikDB::new(":memory:", 8).unwrap();
+
+        // Path A: the record_with_rid materializer (engine/stats.rs). The
+        // memory_entities row pre-exists with NULL norm; the recorded
+        // memory then claims the same (rid, entity) and must repair it.
+        db.conn()
+            .execute(
+                "INSERT INTO memory_entities (memory_rid, entity_name) \
+                 VALUES ('m_pre', 'Münster')",
+                [],
+            )
+            .unwrap();
+        seed_row(
+            &db,
+            "m_pre",
+            "Münster status update",
+            &meta_empty(),
+            BASE_MICROS,
+            &["Münster"],
+            1.0,
+        );
+        drain(&db);
+
+        // Path B: link_memory_entity (engine/graph_ops.rs).
+        db.conn()
+            .execute(
+                "INSERT INTO memory_entities (memory_rid, entity_name) \
+                 VALUES ('m_pre2', 'Alpha')",
+                [],
+            )
+            .unwrap();
+        db.link_memory_entity("m_pre2", "Alpha").unwrap();
+
+        let norm = |rid: &str, name: &str| -> Option<String> {
+            db.conn()
+                .query_row(
+                    "SELECT entity_name_norm FROM memory_entities \
+                     WHERE memory_rid = ?1 AND entity_name = ?2",
+                    [rid, name],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(
+            norm("m_pre", "Münster").as_deref(),
+            Some(normalize_entity_name("Münster").as_str()),
+            "the record materializer must repair a pre-existing NULL norm"
+        );
+        assert_eq!(
+            norm("m_pre2", "Alpha").as_deref(),
+            Some("alpha"),
+            "link_memory_entity must repair a pre-existing NULL norm"
+        );
     }
 }


### PR DESCRIPTION
Fixes the O(V) entity-resolution scan found in #188's post-merge review: `recall_thread` scanned `DISTINCT entity_name` over the global vocabulary and Unicode-lowercased every name per request.

- **Schema v49**: `entity_name_norm` + covering index. SQL backfill is impossible — `LOWER()` is ASCII-only (`'MÜNSTER'` → `'mÜnster'`) and would diverge from the tokenizer — so the constructor runs a guarded, idempotent Rust backfill, stage-tagged `entity_norm_backfill`.
- **Single-source stamping**: `normalize_entity_name()` bound at all six writer sites (replication apply routes verified through stamped paths); census test enforces on leader and follower, **verified in the failing direction** (unbinding one writer: 12 ≠ 0).
- **Resolution** is now a parameterized indexed lookup; the scan is deleted; behavior unchanged (all 8 prior thread tests pass untouched), plus the non-ASCII case-insensitive test that SQL `LOWER` would fail.

Full lib suite: **2074 passed / 0 failed**; `cargo check --all-targets` clean.

Prerequisite for thread-API v2 (autopsy-taxonomy anchors + bounded-work SQL), which follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)