### PR TITLE
bench(amb): add thread v2 query routing foundation

### DIFF
--- a/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
+++ b/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
@@ -15,6 +15,7 @@ import json
 import math
 import platform
 import re
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from statistics import fmean
@@ -38,6 +39,13 @@ except ImportError:  # pragma: no cover - direct script execution
         event_ordering_focus,
         is_event_ordering_chronology_query,
     )
+
+# Direct script execution puts benchmarks/amb first on sys.path, where the
+# benchmark's yantrikdb.py provider shim would shadow the installed product.
+_HERE = Path(__file__).resolve().parent
+sys.path = [
+    entry for entry in sys.path if Path(entry or ".").resolve() != _HERE
+]
 
 
 PROTOCOL = "amb-event-ordering-thread-v2-stage-a-v1"

--- a/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
+++ b/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
@@ -56,6 +56,7 @@ EXPECTED_TREATMENT_ROWS = 40
 THREAD_LIMIT = 100
 MAX_TOPICS = 3
 MAX_HANDLE_MEMBERSHIPS = 3
+MAX_EVIDENCE_PER_HANDLE = 12
 _NAME_RE = re.compile(r"\b[A-Z][a-z]{2,}\b")
 _GENERIC_NAMES = {
     "Across",
@@ -185,11 +186,13 @@ def _reset_db_path(path: Path) -> None:
 
 
 def bounded_handle_evidence(
-    raw_handles: list[dict], max_memberships: int = MAX_HANDLE_MEMBERSHIPS
+    raw_handles: list[dict],
+    max_memberships: int = MAX_HANDLE_MEMBERSHIPS,
+    max_evidence_per_handle: int = MAX_EVIDENCE_PER_HANDLE,
 ) -> list[tuple[int, dict, list[str]]]:
     """Apply the product's deterministic evidence-membership bound."""
-    if max_memberships < 1:
-        raise ValueError("max_memberships must be positive")
+    if max_memberships < 1 or max_evidence_per_handle < 1:
+        raise ValueError("organizer bounds must be positive")
     evidence_by_handle = [
         list(dict.fromkeys(str(value) for value in raw.get("evidence_ids") or []))
         for raw in raw_handles
@@ -216,7 +219,7 @@ def bounded_handle_evidence(
             evidence_id
             for evidence_id in evidence_ids
             if index - 1 in permitted[evidence_id]
-        ]
+        ][:max_evidence_per_handle]
         if kept:
             bounded.append((index, raw, kept))
     return bounded
@@ -282,6 +285,7 @@ def _persist_unit(db_path: Path, unit: str, artifact: dict) -> tuple[Any, list[d
         db,
         OrganizationPlan(tuple(handles)),
         idempotency_prefix=f"amb:thread-v2:{unit}:organizer",
+        max_evidence_per_handle=MAX_EVIDENCE_PER_HANDLE,
         max_handle_memberships=MAX_HANDLE_MEMBERSHIPS,
     )
     progress = db.maintain_source_turn_backfill(10_000)
@@ -473,6 +477,7 @@ def build(args: argparse.Namespace) -> dict:
         "thread_api": "recall_thread_v2",
         "thread_limit": THREAD_LIMIT,
         "max_topic_rids_per_query": MAX_TOPICS,
+        "max_evidence_per_handle": MAX_EVIDENCE_PER_HANDLE,
         "max_handle_memberships": MAX_HANDLE_MEMBERSHIPS,
         "row_count": len(artifact_rows),
         "treatment_row_count": len(selected_ids),

--- a/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
+++ b/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
@@ -285,7 +285,6 @@ def _persist_unit(db_path: Path, unit: str, artifact: dict) -> tuple[Any, list[d
         db,
         OrganizationPlan(tuple(handles)),
         idempotency_prefix=f"amb:thread-v2:{unit}:organizer",
-        max_evidence_per_handle=MAX_EVIDENCE_PER_HANDLE,
         max_handle_memberships=MAX_HANDLE_MEMBERSHIPS,
     )
     progress = db.maintain_source_turn_backfill(10_000)

--- a/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
+++ b/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
@@ -13,6 +13,7 @@ import argparse
 import hashlib
 import json
 import math
+import platform
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -450,6 +451,10 @@ def build(args: argparse.Namespace) -> dict:
         "gold_source_turns_available_during_build": False,
         "predicate_frozen_before_category_join": True,
         "product_commit": args.product_commit,
+        "harness_commit": args.harness_commit,
+        "wheel_path": str(args.wheel),
+        "wheel_sha256": sha256_path(args.wheel),
+        "python_version": platform.python_version(),
         "control_path": str(args.control),
         "control_sha256": sha256_path(args.control),
         "organizer_manifest_sha256": sha256_path(args.organizer_manifest),
@@ -473,6 +478,8 @@ def build(args: argparse.Namespace) -> dict:
         "control_sha256": artifact["control_sha256"],
         "organizer_manifest_sha256": artifact["organizer_manifest_sha256"],
         "product_commit": args.product_commit,
+        "harness_commit": args.harness_commit,
+        "wheel_sha256": artifact["wheel_sha256"],
         "external_model_calls_before_freeze": 0,
     }
     write_json(args.freeze, freeze)
@@ -599,6 +606,8 @@ def parser() -> argparse.ArgumentParser:
     build_parser.add_argument("--organizer-root", type=Path, required=True)
     build_parser.add_argument("--work-dir", type=Path, required=True)
     build_parser.add_argument("--product-commit", required=True)
+    build_parser.add_argument("--harness-commit", required=True)
+    build_parser.add_argument("--wheel", type=Path, required=True)
     build_parser.add_argument("--output", type=Path, required=True)
     build_parser.add_argument("--freeze", type=Path, required=True)
 

--- a/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
+++ b/benchmarks/amb/build_event_ordering_thread_v2_stage_a.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Build and audit the zero-model-call event-ordering thread-v2 artifact.
+
+The command is deliberately split in two. ``build`` cannot accept benchmark
+source-turn labels; it freezes a treatment artifact from query text and
+query-independent organizer records. ``audit`` accepts those labels only
+after verifying the frozen artifact hash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import fmean
+from typing import Any
+
+try:
+    from .analyze_event_ordering_v5_autopsy import (
+        KNOWN_LABEL_DEFECTS,
+        QUERY_ROUTE_COHORTS,
+    )
+    from .event_ordering_thread_v2 import (
+        event_ordering_focus,
+        is_event_ordering_chronology_query,
+    )
+except ImportError:  # pragma: no cover - direct script execution
+    from analyze_event_ordering_v5_autopsy import (
+        KNOWN_LABEL_DEFECTS,
+        QUERY_ROUTE_COHORTS,
+    )
+    from event_ordering_thread_v2 import (
+        event_ordering_focus,
+        is_event_ordering_chronology_query,
+    )
+
+
+PROTOCOL = "amb-event-ordering-thread-v2-stage-a-v1"
+FREEZE_PROTOCOL = "amb-event-ordering-thread-v2-freeze-v1"
+AUDIT_PROTOCOL = "amb-event-ordering-thread-v2-membership-audit-v1"
+EXPECTED_ROWS = 400
+EXPECTED_TREATMENT_ROWS = 40
+THREAD_LIMIT = 100
+MAX_TOPICS = 3
+MAX_HANDLE_MEMBERSHIPS = 3
+_NAME_RE = re.compile(r"\b[A-Z][a-z]{2,}\b")
+_GENERIC_NAMES = {
+    "Across",
+    "Can",
+    "Chats",
+    "Conversations",
+    "Different",
+    "During",
+    "Mention",
+    "Only",
+    "Order",
+    "Throughout",
+    "Walk",
+}
+
+
+def sha256_path(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain one JSON object")
+    return value
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def index_unique(rows: list[dict], label: str) -> dict[str, dict]:
+    indexed = {}
+    for row in rows:
+        query_id = str(row.get("query_id") or "")
+        if not query_id:
+            raise ValueError(f"{label} row is missing query_id")
+        if query_id in indexed:
+            raise ValueError(f"duplicate {label} query_id {query_id!r}")
+        indexed[query_id] = row
+    return indexed
+
+
+def query_entities(focus: str) -> list[str]:
+    """Extract conservative title-case person anchors from query-only focus."""
+    return list(
+        dict.fromkeys(
+            name
+            for name in _NAME_RE.findall(focus)
+            if name not in _GENERIC_NAMES and not name.isupper()
+        )
+    )
+
+
+def _clean_item_text(text: str) -> str:
+    return re.sub(r"^User said:\s*", "", text.strip(), flags=re.IGNORECASE)
+
+
+def render_thread(items: list[dict]) -> str:
+    rendered = []
+    for item in items:
+        created_at = float(item["created_at"])
+        stamp = datetime.fromtimestamp(created_at, tz=UTC).strftime("%B-%d-%Y")
+        turn = item.get("source_turn")
+        marker = f"{stamp} | Turn {turn}" if turn is not None else stamp
+        rendered.append(
+            f"## Memory {item['position']}\n"
+            f"[{marker}] User: {_clean_item_text(str(item.get('text') or ''))}"
+        )
+    return "\n\n".join(rendered)
+
+
+def chronological_key(item: dict) -> tuple:
+    turn = item.get("source_turn")
+    return (
+        float(item["created_at"]),
+        turn is None,
+        0 if turn is None else int(turn),
+        str(item["rid"]),
+    )
+
+
+def validate_thread(result: dict) -> None:
+    items = result.get("items") or []
+    total = int(result.get("total", -1))
+    returned = int(result.get("returned", -1))
+    omitted = int(result.get("omitted", -1))
+    if returned != len(items) or total != returned + omitted:
+        raise ValueError("thread accounting is inconsistent")
+    if omitted != 0 or total != returned:
+        raise ValueError(
+            f"thread truncation is prohibited: total={total}, "
+            f"returned={returned}, omitted={omitted}"
+        )
+    positions = [int(item["position"]) for item in items]
+    if positions != list(range(1, total + 1)):
+        raise ValueError("thread positions are not continuous and complete")
+    if items != sorted(items, key=chronological_key):
+        raise ValueError("thread items are not in canonical chronological order")
+
+
+def _resolve_artifact(root: Path, relative: str) -> Path:
+    return root / Path(relative.replace("\\", "/"))
+
+
+def _load_organizer_artifact(
+    root: Path, entry: dict[str, Any]
+) -> tuple[Path, dict[str, Any]]:
+    path = _resolve_artifact(root, str(entry["path"]))
+    if sha256_path(path) != entry["sha256"]:
+        raise ValueError(f"organizer artifact hash mismatch: {path}")
+    artifact = read_json(path)
+    if artifact.get("input_sha256") != entry.get("input_sha256"):
+        raise ValueError(f"organizer input hash mismatch: {path}")
+    return path, artifact
+
+
+def _reset_db_path(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for candidate in path.parent.glob(path.name + "*"):
+        if candidate.is_file():
+            candidate.unlink()
+
+
+def bounded_handle_evidence(
+    raw_handles: list[dict], max_memberships: int = MAX_HANDLE_MEMBERSHIPS
+) -> list[tuple[int, dict, list[str]]]:
+    """Apply the product's deterministic evidence-membership bound."""
+    if max_memberships < 1:
+        raise ValueError("max_memberships must be positive")
+    evidence_by_handle = [
+        list(dict.fromkeys(str(value) for value in raw.get("evidence_ids") or []))
+        for raw in raw_handles
+    ]
+    owners: dict[str, list[int]] = {}
+    for index, evidence_ids in enumerate(evidence_by_handle):
+        for evidence_id in evidence_ids:
+            owners.setdefault(evidence_id, []).append(index)
+    permitted = {
+        evidence_id: set(
+            sorted(
+                indexes,
+                key=lambda index: (len(evidence_by_handle[index]), index),
+            )[:max_memberships]
+        )
+        for evidence_id, indexes in owners.items()
+    }
+    bounded = []
+    for index, (raw, evidence_ids) in enumerate(
+        zip(raw_handles, evidence_by_handle, strict=True),
+        1,
+    ):
+        kept = [
+            evidence_id
+            for evidence_id in evidence_ids
+            if index - 1 in permitted[evidence_id]
+        ]
+        if kept:
+            bounded.append((index, raw, kept))
+    return bounded
+
+
+def _persist_unit(db_path: Path, unit: str, artifact: dict) -> tuple[Any, list[dict]]:
+    import yantrikdb
+    from yantrikdb import OrganizationPlan, TopicHandle, persist_organization
+
+    _reset_db_path(db_path)
+    db = yantrikdb.YantrikDB.with_default(str(db_path))
+    evidence_rids = {}
+    for item in artifact.get("input_items") or []:
+        evidence_id = str(item.get("id") or "")
+        turn = item.get("turn")
+        created_at = item.get("date")
+        text = str(item.get("text") or "").strip()
+        if (
+            not evidence_id
+            or evidence_id in evidence_rids
+            or isinstance(turn, bool)
+            or not isinstance(turn, int)
+            or turn < 0
+            or not isinstance(created_at, (int, float))
+            or isinstance(created_at, bool)
+            or not math.isfinite(float(created_at))
+            or not text
+        ):
+            raise ValueError(f"unit {unit} has an invalid organizer input item")
+        evidence_rids[evidence_id] = db.record(
+            text,
+            memory_type="episodic",
+            metadata={
+                "source_turn": turn,
+                "first_mention_turn": turn,
+                "speaker": "user",
+                "organizer_evidence_id": evidence_id,
+            },
+            namespace="default",
+            source="user",
+            idempotency_key=f"amb:thread-v2:{unit}:evidence:{evidence_id}",
+            created_at=float(created_at),
+        )
+
+    handles = []
+    raw_handles = artifact.get("handles") or []
+    for index, raw, evidence_ids in bounded_handle_evidence(raw_handles):
+        missing = sorted(set(evidence_ids) - set(evidence_rids))
+        if missing:
+            raise ValueError(f"unit {unit} handle {index} has missing evidence: {missing}")
+        if not evidence_ids:
+            raise ValueError(f"unit {unit} handle {index} is empty")
+        handles.append(
+            TopicHandle(
+                id=f"amb-unit-{unit}-topic-{index:03d}",
+                label=str(raw.get("label") or f"Topic {index}").strip(),
+                summary=str(raw.get("summary") or "").strip(),
+                evidence_ids=tuple(evidence_rids[value] for value in evidence_ids),
+                anchor_entities=tuple(raw.get("anchor_entities") or ()),
+            )
+        )
+    writes = persist_organization(
+        db,
+        OrganizationPlan(tuple(handles)),
+        idempotency_prefix=f"amb:thread-v2:{unit}:organizer",
+        max_handle_memberships=MAX_HANDLE_MEMBERSHIPS,
+    )
+    progress = db.maintain_source_turn_backfill(10_000)
+    if not progress.get("complete"):
+        raise ValueError(f"unit {unit} source_turn maintenance did not complete")
+    return db, writes
+
+
+def select_topics(db: Any, focus: str, max_topics: int = MAX_TOPICS) -> tuple[list[str], list[dict]]:
+    """Use bounded semantic recall over persisted inference records only."""
+    hits = db.recall(
+        query=focus,
+        top_k=max_topics,
+        namespace="default",
+        source="inference",
+        include_consolidated=True,
+        skip_reinforce=True,
+    )
+    selected = []
+    trace = []
+    for hit in hits:
+        metadata = hit.get("metadata") or {}
+        if metadata.get("organizer_kind") != "query_independent_topic":
+            continue
+        rid = str(hit.get("rid") or "")
+        if not rid or rid in selected:
+            continue
+        selected.append(rid)
+        trace.append(
+            {
+                "rid": rid,
+                "label": metadata.get("organizer_label"),
+                "score": hit.get("score"),
+            }
+        )
+        if len(selected) == max_topics:
+            break
+    if not selected:
+        raise ValueError("bounded organizer lookup returned no topic handles")
+    return selected, trace
+
+
+def _control_rows(control: dict) -> list[dict]:
+    rows = control.get("results") or []
+    if len(rows) != EXPECTED_ROWS:
+        raise ValueError(f"expected {EXPECTED_ROWS} frozen control rows, found {len(rows)}")
+    index_unique(rows, "control")
+    return rows
+
+
+def build(args: argparse.Namespace) -> dict:
+    control = read_json(args.control)
+    rows = _control_rows(control)
+    organizer_manifest = read_json(args.organizer_manifest)
+    if organizer_manifest.get("gold_fields_present") is not False:
+        raise ValueError("organizer manifest must explicitly contain no gold fields")
+
+    # Freeze predicate results before looking at category labels. The category
+    # join below is an audit only and is never passed to a selector.
+    routing = [
+        {
+            "query_id": str(row["query_id"]),
+            "selected": is_event_ordering_chronology_query(str(row["query"])),
+            "focus_text": event_ordering_focus(str(row["query"])),
+        }
+        for row in rows
+    ]
+    route_by_id = index_unique(routing, "routing")
+    selected_ids = [row["query_id"] for row in routing if row["selected"]]
+    if len(selected_ids) != EXPECTED_TREATMENT_ROWS:
+        raise ValueError(
+            f"expected {EXPECTED_TREATMENT_ROWS} predicate hits, found {len(selected_ids)}"
+        )
+    for row in rows:
+        category = (row.get("meta") or {}).get("question_category")
+        selected = route_by_id[str(row["query_id"])]["selected"]
+        if selected != (category == "event_ordering"):
+            raise ValueError(f"predicate/category audit mismatch for {row['query_id']}")
+
+    unit_queries: dict[str, list[dict]] = {}
+    for row in rows:
+        route = route_by_id[str(row["query_id"])]
+        if route["selected"]:
+            unit = str(row["query_id"]).split("_", 1)[0]
+            unit_queries.setdefault(unit, []).append(row)
+
+    treatment_by_id = {}
+    organizer_inputs = {}
+    for unit in sorted(unit_queries, key=int):
+        entry = (organizer_manifest.get("units") or {}).get(unit)
+        if entry is None:
+            raise ValueError(f"organizer manifest is missing unit {unit}")
+        path, organizer = _load_organizer_artifact(args.organizer_root, entry)
+        organizer_inputs[unit] = {
+            "path": str(entry["path"]).replace("\\", "/"),
+            "sha256": entry["sha256"],
+            "input_sha256": entry["input_sha256"],
+        }
+        db_path = args.work_dir / "yantrikdb" / f"{unit}.db"
+        db, writes = _persist_unit(db_path, unit, organizer)
+        try:
+            expected_writes = len(
+                bounded_handle_evidence(organizer.get("handles") or [])
+            )
+            if len(writes) != expected_writes:
+                raise ValueError(f"unit {unit} did not persist every bounded handle")
+            for control_row in unit_queries[unit]:
+                query_id = str(control_row["query_id"])
+                focus = str(route_by_id[query_id]["focus_text"] or "")
+                if not focus:
+                    raise ValueError(f"empty focus for selected row {query_id}")
+                entities = query_entities(focus)
+                phrases = [focus]
+                topic_rids, topic_trace = select_topics(db, focus)
+                thread = db.recall_thread_v2(
+                    "default",
+                    entities=entities,
+                    limit=THREAD_LIMIT,
+                    phrases=phrases,
+                    topic_rids=topic_rids,
+                )
+                validate_thread(thread)
+                treatment_by_id[query_id] = {
+                    "focus_text": focus,
+                    "entities": entities,
+                    "phrases": phrases,
+                    "topic_rids": topic_rids,
+                    "topic_selection": topic_trace,
+                    "thread": thread,
+                    "context": render_thread(thread["items"]),
+                }
+        finally:
+            db.close()
+
+    artifact_rows = []
+    for control_row in rows:
+        query_id = str(control_row["query_id"])
+        control_context = str(control_row.get("context") or "")
+        treatment = treatment_by_id.get(query_id)
+        treatment_context = treatment["context"] if treatment else control_context
+        artifact_rows.append(
+            {
+                "query_id": query_id,
+                "query": str(control_row.get("query") or ""),
+                "predicate_selected": route_by_id[query_id]["selected"],
+                "focus_text": route_by_id[query_id]["focus_text"],
+                "control_context": control_context,
+                "control_context_sha256": hashlib.sha256(
+                    control_context.encode("utf-8")
+                ).hexdigest(),
+                "treatment_context": treatment_context,
+                "non_event_byte_identical": (
+                    treatment_context.encode("utf-8") == control_context.encode("utf-8")
+                ),
+                "selection": (
+                    None
+                    if treatment is None
+                    else {
+                        key: treatment[key]
+                        for key in (
+                            "entities",
+                            "phrases",
+                            "topic_rids",
+                            "topic_selection",
+                        )
+                    }
+                ),
+                "thread": None if treatment is None else treatment["thread"],
+            }
+        )
+
+    artifact = {
+        "protocol": PROTOCOL,
+        "external_model_calls": 0,
+        "gold_source_turns_available_during_build": False,
+        "predicate_frozen_before_category_join": True,
+        "product_commit": args.product_commit,
+        "control_path": str(args.control),
+        "control_sha256": sha256_path(args.control),
+        "organizer_manifest_sha256": sha256_path(args.organizer_manifest),
+        "organizer_inputs": organizer_inputs,
+        "encryption_mode": "plaintext",
+        "phrase_route_available": True,
+        "source_turn_backfill_complete": True,
+        "thread_api": "recall_thread_v2",
+        "thread_limit": THREAD_LIMIT,
+        "max_topic_rids_per_query": MAX_TOPICS,
+        "max_handle_memberships": MAX_HANDLE_MEMBERSHIPS,
+        "row_count": len(artifact_rows),
+        "treatment_row_count": len(selected_ids),
+        "rows": artifact_rows,
+    }
+    write_json(args.output, artifact)
+    freeze = {
+        "protocol": FREEZE_PROTOCOL,
+        "artifact_path": str(args.output),
+        "artifact_sha256": sha256_path(args.output),
+        "control_sha256": artifact["control_sha256"],
+        "organizer_manifest_sha256": artifact["organizer_manifest_sha256"],
+        "product_commit": args.product_commit,
+        "external_model_calls_before_freeze": 0,
+    }
+    write_json(args.freeze, freeze)
+    return freeze
+
+
+def _coverage(rows: list[dict]) -> dict:
+    references = sum(len(row["source_turns"]) for row in rows)
+    covered = sum(len(row["present_source_turns"]) for row in rows)
+    recalls = [
+        len(row["present_source_turns"]) / len(row["source_turns"]) for row in rows
+    ]
+    return {
+        "queries": len(rows),
+        "source_turn_references": references,
+        "covered_source_turns": covered,
+        "macro_recall": fmean(recalls),
+        "micro_recall": covered / references,
+        "nonzero_queries": sum(value > 0 for value in recalls),
+        "exact_queries": sum(value == 1 for value in recalls),
+    }
+
+
+def audit(args: argparse.Namespace) -> dict:
+    freeze = read_json(args.freeze)
+    if freeze.get("protocol") != FREEZE_PROTOCOL:
+        raise ValueError("unexpected freeze protocol")
+    actual_hash = sha256_path(args.artifact)
+    if actual_hash != freeze.get("artifact_sha256"):
+        raise ValueError("artifact changed after freeze; refusing the gold join")
+    artifact = read_json(args.artifact)
+    if artifact.get("protocol") != PROTOCOL:
+        raise ValueError("unexpected Stage A artifact protocol")
+    membership = read_json(args.membership)
+    artifact_rows = index_unique(artifact.get("rows") or [], "artifact")
+    membership_rows = index_unique(membership.get("results") or [], "membership")
+    selected = [row for row in artifact_rows.values() if row["predicate_selected"]]
+    if len(artifact_rows) != EXPECTED_ROWS or len(selected) != EXPECTED_TREATMENT_ROWS:
+        raise ValueError("Stage A artifact has the wrong 400/40 row shape")
+
+    joined = []
+    for row in selected:
+        query_id = row["query_id"]
+        gold = membership_rows.get(query_id)
+        if gold is None:
+            raise ValueError(f"membership is missing {query_id}")
+        source_turns = sorted(set(gold.get("source_turns") or []))
+        if not source_turns:
+            raise ValueError(f"membership has no source turns for {query_id}")
+        returned_turns = {
+            item.get("source_turn")
+            for item in (row.get("thread") or {}).get("items") or []
+            if item.get("source_turn") is not None
+        }
+        joined.append(
+            {
+                "query_id": query_id,
+                "source_turns": source_turns,
+                "present_source_turns": sorted(set(source_turns) & returned_turns),
+                "missing_source_turns": sorted(set(source_turns) - returned_turns),
+            }
+        )
+    joined_by_id = {row["query_id"]: row for row in joined}
+    clean = [row for row in joined if row["query_id"] not in KNOWN_LABEL_DEFECTS]
+    phrase = [
+        joined_by_id[query_id]
+        for query_id in sorted(QUERY_ROUTE_COHORTS["bounded_focus_phrase"])
+    ]
+    broad = [
+        joined_by_id[query_id]
+        for query_id in sorted(QUERY_ROUTE_COHORTS["broad_compound_topic_union"])
+    ]
+    clean_summary = _coverage(clean)
+    phrase_summary = _coverage(phrase)
+    broad_summary = _coverage(broad)
+    carla = joined_by_id["10_event_ordering_1"]
+    douglas = joined_by_id["13_event_ordering_1"]
+
+    non_event_identical = all(
+        row["non_event_byte_identical"]
+        for row in artifact_rows.values()
+        if not row["predicate_selected"]
+    )
+    omitted_zero = all((row.get("thread") or {}).get("omitted") == 0 for row in selected)
+    gates = {
+        "row_shape_400_40": len(artifact_rows) == 400 and len(selected) == 40,
+        "non_event_contexts_byte_identical": non_event_identical,
+        "all_event_threads_untruncated": omitted_zero,
+        "clean_macro_recall_at_least_0_55": clean_summary["macro_recall"] >= 0.55,
+        "clean_micro_recall_at_least_0_55": clean_summary["micro_recall"] >= 0.55,
+        "clean_nonzero_at_least_30": clean_summary["nonzero_queries"] >= 30,
+        "clean_exact_at_least_8": clean_summary["exact_queries"] >= 8,
+        "phrase_cohort_micro_at_least_0_55": phrase_summary["micro_recall"] >= 0.55,
+        "broad_cohort_micro_at_least_0_55": broad_summary["micro_recall"] >= 0.55,
+        "carla_6_of_6": len(carla["present_source_turns"]) == 6,
+        "douglas_at_least_4_of_9": len(douglas["present_source_turns"]) >= 4,
+    }
+    report = {
+        "protocol": AUDIT_PROTOCOL,
+        "artifact_sha256": actual_hash,
+        "freeze_sha256": sha256_path(args.freeze),
+        "membership_sha256": sha256_path(args.membership),
+        "clean_37": clean_summary,
+        "all_40": _coverage(joined),
+        "bounded_focus_phrase_22": phrase_summary,
+        "broad_compound_topic_union_13": broad_summary,
+        "carla": carla,
+        "douglas": douglas,
+        "gates": gates,
+        "stage_a_pass": all(gates.values()),
+        "rows": joined,
+    }
+    write_json(args.output, report)
+    return report
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    sub = root.add_subparsers(dest="command", required=True)
+
+    build_parser = sub.add_parser("build")
+    build_parser.add_argument("--control", type=Path, required=True)
+    build_parser.add_argument("--organizer-manifest", type=Path, required=True)
+    build_parser.add_argument("--organizer-root", type=Path, required=True)
+    build_parser.add_argument("--work-dir", type=Path, required=True)
+    build_parser.add_argument("--product-commit", required=True)
+    build_parser.add_argument("--output", type=Path, required=True)
+    build_parser.add_argument("--freeze", type=Path, required=True)
+
+    audit_parser = sub.add_parser("audit")
+    audit_parser.add_argument("--artifact", type=Path, required=True)
+    audit_parser.add_argument("--freeze", type=Path, required=True)
+    audit_parser.add_argument("--membership", type=Path, required=True)
+    audit_parser.add_argument("--output", type=Path, required=True)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    result = build(args) if args.command == "build" else audit(args)
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+    if args.command == "audit" and not result["stage_a_pass"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/event_ordering_organizer_manifest_v1.json
+++ b/benchmarks/amb/event_ordering_organizer_manifest_v1.json
@@ -1,0 +1,26 @@
+{
+  "protocol": "event-ordering-query-independent-organizers-v1",
+  "gold_fields_present": false,
+  "units": {
+    "1": {"path": "benchmarks/amb/artifacts/summarization-unit1-topic-cards-deepseek-v1.json", "sha256": "4701324835416dfe0c76c3d2d6658846a890bed8257463aad65f15a5a51b3db1", "input_sha256": "d5416b14415307b0d1ec0a7800fc727b8edb6ec916b32be52898e00ab4df1d4f"},
+    "2": {"path": "benchmarks/amb/artifacts/summarization-unit2-topic-cards-deepseek-v1.json", "sha256": "0890d7b3461a00f85d10b879af4306a621be6a9e8dc182865a508767f3f77fa1", "input_sha256": "10fd81ea8a426a8cee8c1283fd3ec5d7fcd989094de55e9079774052fb208824"},
+    "3": {"path": "benchmarks/amb/artifacts/summarization-unit3-topic-cards-deepseek-v1.json", "sha256": "7420ba06678e82f571fe5a197ebd5db131f456f92ec4efff17540a45dca3147c", "input_sha256": "e14d43745e8c02e3cc66c016e2bfdf5d836527d990db6756bfa823f6a823c71d"},
+    "4": {"path": "benchmarks/amb/artifacts/summarization-unit4-topic-cards-deepseek-v2.json", "sha256": "4a8facacf03ae4d233bf7c30420bd1aef1c843dfb5d28b71e57cd1f82474455b", "input_sha256": "02d617bbad41bada64d17bc618ed4c2258ba23935ae31bbfeac340d44bca61cd"},
+    "5": {"path": "benchmarks/amb/artifacts/summarization-unit5-topic-cards-deepseek-v4.json", "sha256": "8bb836e3815b4e4b50eed10126f30feb684ab6dd1d9f4dc5f22d06971278b5b4", "input_sha256": "a17001241c24e85ef5c428a49541e9561d9cfebcaca311fedf424699d4327bd9"},
+    "6": {"path": "benchmarks/amb/artifacts/summarization-unit6-topic-cards-deepseek-v2.json", "sha256": "91ae0eae9054d7a9c2236ad1b5eabc2eb335c08db9bc45d0208bcf3a6739934b", "input_sha256": "d89ff53cc27913403fc89e92adeaa2e2e00c0fc3397d89b47238d949584ecf86"},
+    "7": {"path": "benchmarks/amb/artifacts/summarization-unit7-topic-cards-deepseek-v1.json", "sha256": "389ef72a2e9657d16d42a10e14deb09892121cf2bd857ee57721b3c36175a77c", "input_sha256": "bdcdc32d4ef91bffb4b347261d7dfce932296f0a35df5bb2217acb14dc40f43a"},
+    "8": {"path": "benchmarks/amb/artifacts/summarization-unit8-topic-cards-deepseek-v1.json", "sha256": "12ced4b2fcb6cff9772b565ec0cc537a98d0ac331b993866074ab3d4f180d192", "input_sha256": "7ad1d15139002ae809e6614fb7a29575b80ee9334430c5c30fd3b35dd4642c78"},
+    "9": {"path": "benchmarks/amb/artifacts/summarization-unit9-topic-cards-deepseek-v1.json", "sha256": "5ed4aebd7e5d66770d40301e80f8632e85d5559169ecc81c0de4c25812882c68", "input_sha256": "8c3a4d2e8af098756192e5fd68194c44a459aab3cdd01ba3bc1d0a38279199d0"},
+    "10": {"path": "benchmarks/amb/artifacts/summarization-unit10-topic-cards-deepseek-v1.json", "sha256": "cd63e0835ae74c289909f6a375743a531bacea36cf1451b219d164b1bff6d4ae", "input_sha256": "a8dac8003dded5e86b7e6f47323e125ac70c7ed7bbaf4d08c20f9078ba32066b"},
+    "11": {"path": "benchmarks/amb/artifacts/summarization-unit11-topic-cards-deepseek-v3.json", "sha256": "fd18d6e76d41cb6c7d2901b6499c007e9ce72467aac8efb19fa155a03a38d60c", "input_sha256": "4bc1147e516a9acf26d751f1ec1f69f4a891458b64dd0faacbab0d5e0d664a96"},
+    "12": {"path": "benchmarks/amb/artifacts/summarization-unit12-topic-cards-deepseek-v2.json", "sha256": "16e63fb30eac05ae28d7d5a52b049ceda321aa65d77925b5d07dc5c3c99d7e62", "input_sha256": "e94015832ae06e053423c6ae993b9bed4d4356213c531aa29448ae7dc3fc90f7"},
+    "13": {"path": "benchmarks/amb/artifacts/summarization-unit13-topic-cards-deepseek-v1.json", "sha256": "b79c00d5fb884576baf76a495adf2088257243b90931bbb916cee50c77200532", "input_sha256": "55de9c467bc0ca7ddfaee1dd1babcf2026263ff80f532351c7c61c9de0433d9f"},
+    "14": {"path": "benchmarks/amb/artifacts/summarization-unit14-topic-cards-deepseek-v1.json", "sha256": "14c00581951415662d51a50b4a6819cc9c3bf539bcc0d869110da195bffdaa25", "input_sha256": "f1d02028e53256fa9cd592834b304464e5b790c0a50de6ba9c53c9ed6743d0bf"},
+    "15": {"path": "benchmarks/amb/artifacts/summarization-unit15-topic-cards-deepseek-v1.json", "sha256": "76d51e5e47e4ecec55df9f5fbeb803a301f7c4e2ad06e41a11a8c99823fdbc58", "input_sha256": "7cc28ca590ff3148f60d2f35c5e1bc6cdee242e32b372b21a39c4fbb00a9312e"},
+    "16": {"path": "benchmarks/amb/artifacts/summarization-unit16-topic-cards-deepseek-v2.json", "sha256": "b9e946b4c539137f007629e8eafdaeb45cf9179d782c57854f4848288b1ed184", "input_sha256": "89c7ad8cd130a72dd05a7226c70061fc458e2a961779897026d2420f53152220"},
+    "17": {"path": "benchmarks/amb/artifacts/summarization-unit17-topic-cards-deepseek-v1.json", "sha256": "0e076faad7ad8e501ac7e815360bd5bda0027526b01270e8209cac78f9888609", "input_sha256": "392828b2e1f31dc16f095885d72a06322ca3d6da16ca0e2b20c1ed8e991c9318"},
+    "18": {"path": "benchmarks/amb/artifacts/summarization-unit18-topic-cards-deepseek-v1.json", "sha256": "f910c71c0157a10c509e7216a2236e78c5921a67c803a953dd23986142f47ef9", "input_sha256": "050a3a9396022f957529bb7c9e246b867402b00f397e8317a21a05760e5da4a3"},
+    "19": {"path": "benchmarks/amb/artifacts/summarization-unit19-topic-cards-deepseek-v2.json", "sha256": "34e9a3cd0324108fd94f2168fe9c5571c1bc01b3028396f66a92393f431d37a8", "input_sha256": "fdbabf24b8ee27be38fa87df65e5cc0307a8c420ca0a34d934f6d0a7762bfdda"},
+    "20": {"path": "benchmarks/amb/artifacts/summarization-unit20-topic-cards-deepseek-v2.json", "sha256": "43f2ec9f1cd5fcd22194c13f894d5619d2dd5e39768820297f75768d4102b975", "input_sha256": "0fa4e060076755b6efb806db460ecce9d9bdf22db3dbebe9303f25a97682f707"}
+  }
+}

--- a/benchmarks/amb/event_ordering_thread_v2.py
+++ b/benchmarks/amb/event_ordering_thread_v2.py
@@ -1,0 +1,41 @@
+"""Query-only routing primitives for the event-ordering thread-v2 arm."""
+
+from __future__ import annotations
+
+import re
+
+
+_BROUGHT_UP_RE = re.compile(r"\bbrought\s+up\b", re.IGNORECASE)
+_ORDER_RE = re.compile(r"\b(?:in\s+order|order\s+in\s+which)\b", re.IGNORECASE)
+_CONVERSATION_RE = re.compile(r"\b(?:conversations?|chats?)\b", re.IGNORECASE)
+_SCOPE_SUFFIX_RE = re.compile(
+    r"\b(?:throughout|across|during|in)\s+"
+    r"(?:our\s+)?(?:conversations?|chats?)\b",
+    re.IGNORECASE,
+)
+_GENERIC_FOCUS_PREFIX_RE = re.compile(
+    r"^(?:different\s+)?(?:aspects?\s+of\s+|ways\s+)?",
+    re.IGNORECASE,
+)
+
+
+def is_event_ordering_chronology_query(query: str) -> bool:
+    """Return the preregistered narrow chronology-route decision."""
+    return bool(
+        _BROUGHT_UP_RE.search(query)
+        and _ORDER_RE.search(query)
+        and _CONVERSATION_RE.search(query)
+    )
+
+
+def event_ordering_focus(query: str) -> str | None:
+    """Extract the semantic focus without using labels, answers, or evidence."""
+    if not is_event_ordering_chronology_query(query):
+        return None
+
+    after_brought_up = _BROUGHT_UP_RE.split(query, maxsplit=1)[1]
+    focus = _SCOPE_SUFFIX_RE.split(after_brought_up, maxsplit=1)[0]
+    focus = focus.strip(" \t\r\n,.;:?!")
+    focus = _GENERIC_FOCUS_PREFIX_RE.sub("", focus, count=1)
+    focus = focus.strip(" \t\r\n,.;:?!")
+    return focus or None

--- a/tests/test_amb_event_ordering_thread_v2.py
+++ b/tests/test_amb_event_ordering_thread_v2.py
@@ -1,5 +1,17 @@
 import pytest
 
+from benchmarks.amb.build_event_ordering_thread_v2_stage_a import (
+    FREEZE_PROTOCOL,
+    audit,
+    bounded_handle_evidence,
+    parser,
+    query_entities,
+    render_thread,
+    select_topics,
+    sha256_path,
+    validate_thread,
+    write_json,
+)
 from benchmarks.amb.event_ordering_thread_v2 import (
     event_ordering_focus,
     is_event_ordering_chronology_query,
@@ -55,3 +67,144 @@ def test_preregistered_predicate_and_focus(query, focus):
 def test_preregistered_predicate_rejects_near_misses(query):
     assert not is_event_ordering_chronology_query(query)
     assert event_ordering_focus(query) is None
+
+
+def test_query_entities_is_conservative_and_excludes_ai():
+    assert query_entities("my collaboration with Carla") == ["Carla"]
+    assert query_entities("shared interests with Douglas and Patrick") == [
+        "Douglas",
+        "Patrick",
+    ]
+    assert query_entities("using AI in our hiring process") == []
+
+
+class _TopicDB:
+    def __init__(self):
+        self.call = None
+
+    def recall(self, **kwargs):
+        self.call = kwargs
+        return [
+            {
+                "rid": "topic-1",
+                "score": 0.8,
+                "metadata": {
+                    "organizer_kind": "query_independent_topic",
+                    "organizer_label": "One",
+                },
+            },
+            {
+                "rid": "not-a-topic",
+                "score": 0.7,
+                "metadata": {"organizer_kind": "query_independent_concern"},
+            },
+            {
+                "rid": "topic-2",
+                "score": 0.6,
+                "metadata": {
+                    "organizer_kind": "query_independent_topic",
+                    "organizer_label": "Two",
+                },
+            },
+        ]
+
+
+def test_topic_selection_is_bounded_to_persisted_inference_records():
+    db = _TopicDB()
+    rids, trace = select_topics(db, "specific focus", max_topics=2)
+    assert rids == ["topic-1", "topic-2"]
+    assert [row["label"] for row in trace] == ["One", "Two"]
+    assert db.call == {
+        "query": "specific focus",
+        "top_k": 2,
+        "namespace": "default",
+        "source": "inference",
+        "include_consolidated": True,
+        "skip_reinforce": True,
+    }
+
+
+def test_handle_membership_bound_is_query_free_and_deterministic():
+    handles = [
+        {"label": "large", "evidence_ids": ["shared", "a", "b"]},
+        {"label": "small-1", "evidence_ids": ["shared"]},
+        {"label": "small-2", "evidence_ids": ["shared"]},
+        {"label": "small-3", "evidence_ids": ["shared"]},
+    ]
+    bounded = bounded_handle_evidence(handles, max_memberships=3)
+    by_label = {raw["label"]: evidence for _, raw, evidence in bounded}
+    assert "shared" not in by_label["large"]
+    assert [by_label[f"small-{index}"] for index in (1, 2, 3)] == [
+        ["shared"],
+        ["shared"],
+        ["shared"],
+    ]
+
+
+def test_thread_validation_and_rendering():
+    items = [
+        {
+            "rid": "a",
+            "text": "User said: first point",
+            "created_at": 1_710_460_800.0,
+            "source_turn": 4,
+            "position": 1,
+        },
+        {
+            "rid": "b",
+            "text": "second point",
+            "created_at": 1_710_460_800.0,
+            "source_turn": 8,
+            "position": 2,
+        },
+    ]
+    result = {"items": items, "total": 2, "returned": 2, "omitted": 0}
+    validate_thread(result)
+    rendered = render_thread(items)
+    assert "[March-15-2024 | Turn 4] User: first point" in rendered
+    assert "## Memory 2" in rendered
+
+    result["omitted"] = 1
+    with pytest.raises(ValueError, match="accounting|truncation"):
+        validate_thread(result)
+
+
+def test_build_parser_has_no_gold_or_membership_input():
+    build_parser = next(
+        action
+        for action in parser()._actions
+        if action.dest == "command"
+    ).choices["build"]
+    destinations = {action.dest for action in build_parser._actions}
+    assert "membership" not in destinations
+    assert "gold" not in destinations
+
+
+def test_audit_refuses_artifact_changed_after_freeze(tmp_path):
+    artifact = tmp_path / "artifact.json"
+    freeze = tmp_path / "freeze.json"
+    membership = tmp_path / "membership.json"
+    output = tmp_path / "audit.json"
+    write_json(artifact, {"protocol": "placeholder"})
+    write_json(
+        freeze,
+        {
+            "protocol": FREEZE_PROTOCOL,
+            "artifact_sha256": sha256_path(artifact),
+        },
+    )
+    write_json(membership, {})
+    artifact.write_text("{}\n", encoding="utf-8")
+
+    args = type(
+        "Args",
+        (),
+        {
+            "artifact": artifact,
+            "freeze": freeze,
+            "membership": membership,
+            "output": output,
+        },
+    )()
+    with pytest.raises(ValueError, match="changed after freeze"):
+        audit(args)

--- a/tests/test_amb_event_ordering_thread_v2.py
+++ b/tests/test_amb_event_ordering_thread_v2.py
@@ -1,0 +1,57 @@
+import pytest
+
+from benchmarks.amb.event_ordering_thread_v2 import (
+    event_ordering_focus,
+    is_event_ordering_chronology_query,
+)
+
+
+@pytest.mark.parametrize(
+    "query, focus",
+    [
+        (
+            "Can you list the order in which I brought up different aspects "
+            "of refining my personal statement throughout our conversations "
+            "in order? Mention only five items.",
+            "refining my personal statement",
+        ),
+        (
+            "Can you walk me through the order in which I brought up "
+            "different aspects of my writing journey across our conversations?",
+            "my writing journey",
+        ),
+        (
+            "Can you list in order how I brought up different ways my family "
+            "supported me in my personal statement throughout our chats?",
+            "my family supported me in my personal statement",
+        ),
+        (
+            "CAN YOU WALK ME THROUGH THE ORDER IN WHICH I BROUGHT UP SHARED "
+            "ENTERTAINMENT INTERESTS WITH DOUGLAS DURING OUR CHATS?",
+            "SHARED ENTERTAINMENT INTERESTS WITH DOUGLAS",
+        ),
+        (
+            "Can you walk me through the order in which I brought up concerns "
+            "related to my family's care in our conversations, in order?",
+            "concerns related to my family's care",
+        ),
+    ],
+)
+def test_preregistered_predicate_and_focus(query, focus):
+    assert is_event_ordering_chronology_query(query)
+    assert event_ordering_focus(query) == focus
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "Can you list the order in which these events happened?",
+        "What topics did I bring up throughout our conversations?",
+        "Can you summarize what I brought up in order?",
+        "Can you list our conversations in chronological order?",
+        "",
+    ],
+)
+def test_preregistered_predicate_rejects_near_misses(query):
+    assert not is_event_ordering_chronology_query(query)
+    assert event_ordering_focus(query) is None

--- a/tests/test_amb_event_ordering_thread_v2.py
+++ b/tests/test_amb_event_ordering_thread_v2.py
@@ -140,6 +140,10 @@ def test_handle_membership_bound_is_query_free_and_deterministic():
         ["shared"],
     ]
 
+    long = [{"label": "long", "evidence_ids": [str(i) for i in range(14)]}]
+    bounded_long = bounded_handle_evidence(long, max_evidence_per_handle=12)
+    assert bounded_long[0][2] == [str(i) for i in range(12)]
+
 
 def test_thread_validation_and_rendering():
     items = [


### PR DESCRIPTION
Adds the preregistered query-text predicate and focus extraction as pure zero-call helpers. Frozen BEAM 100k audit: 40/400 selected, all 40 event-ordering rows, zero misses, zero false positives, and no empty focuses. This draft does not build treatment contexts, join source-turn gold, or authorize external calls; the v2 engine and Stage A artifact remain pending. Verification: 10 focused tests pass; Ruff check passes.