### PR TITLE
VOID: attempted event-ordering holdout seal (ineligible)

### DIFF
--- a/benchmarks/amb/event_ordering_thread_v3_holdout_manifest.json
+++ b/benchmarks/amb/event_ordering_thread_v3_holdout_manifest.json
@@ -1,0 +1,79 @@
+{
+  "protocol": "amb-event-ordering-thread-v3-holdout-seal-v1",
+  "sealed_at": "2026-08-24",
+  "dataset": "beam",
+  "split": "500k",
+  "holdout_units": [
+    "16",
+    "17",
+    "18",
+    "19",
+    "20",
+    "21",
+    "22",
+    "23",
+    "24",
+    "25",
+    "26",
+    "27",
+    "28",
+    "29",
+    "30",
+    "31",
+    "32",
+    "33",
+    "34",
+    "35"
+  ],
+  "development_units": [
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
+    "11",
+    "12",
+    "13",
+    "14",
+    "15"
+  ],
+  "event_category": "event_ordering",
+  "expected": {
+    "query_rows": 400,
+    "event_rows": 40,
+    "document_rows": 583,
+    "unit_count": 20,
+    "exact_event_query_overlap_with_beam_100k": 0
+  },
+  "source_sha256": {
+    "queries.json.gz": "fe4553ac89ffd7989d7d6dbcf4c3a4a0119244e784cdf13b8566fd11be29a69b",
+    "documents.json.gz": "1033f1a96b199992a4f2aea7a5ac56601902f6091eac98481a1e4bf59c32629e",
+    "categories.json.gz": "88e7abb2073ef3c4b388771d44bd77b44fa7980ffd2edb16638ca345fae57cb9",
+    "stats.json.gz": "825cb3d072331784b07513f1b2f87c3d815ce7b6ee69b0fe19d1a820cc644553"
+  },
+  "subset_sha256": {
+    "all_queries": "583a1878223a571cd9f149c1529eed193a055e8b16804527c75243579c6fa7e5",
+    "event_queries": "cf1d3d3c9041b404e471a1eb80b1eadc35054d6a75c35afb9a90211fd1e111b7",
+    "all_ordered_query_ids": "42b45b2a92841be1062687945cd237a2329a663ec7b3f3e3758887fa1143afb9",
+    "event_ordered_query_ids": "9a82c13d26a62ede29c15539664e536606e8d9b881cb1cb009e3fdd269a0c168",
+    "documents": "a56a4fa212657b5d6e161cb93f485bdc6d1a4fd0a98b31a8e1c14917d485116f"
+  },
+  "canonicalization": {
+    "rows": "source order",
+    "json": "sort_keys=true,separators=(',',':'),ensure_ascii=true",
+    "ordered_ids": "UTF-8 IDs joined by LF without a trailing LF"
+  },
+  "blind": {
+    "holdout_content_inspected_before_seal": false,
+    "gold_inspected_before_seal": false,
+    "mutual_attestation": true,
+    "codex_seal_message_id": "39bc6d5a-d6c1-44d7-8a8d-ec94cf78d06f",
+    "core_countersign_message_id": "3727e922-259f-4b1c-89af-91c1c3d6e99e",
+    "rule": "Units 16-35 remain content-blind until the fresh preregistration is frozen."
+  }
+}

--- a/benchmarks/amb/event_ordering_thread_v3_holdout_manifest.json
+++ b/benchmarks/amb/event_ordering_thread_v3_holdout_manifest.json
@@ -1,6 +1,9 @@
 {
   "protocol": "amb-event-ordering-thread-v3-holdout-seal-v1",
+  "status": "void",
   "sealed_at": "2026-08-24",
+  "voided_at": "2026-08-24",
+  "void_reason": "A delegated audit computed post-seal predicate membership and aggregate source-reference counts, exceeding the hash-only blind rule.",
   "dataset": "beam",
   "split": "500k",
   "holdout_units": [
@@ -72,6 +75,8 @@
     "holdout_content_inspected_before_seal": false,
     "gold_inspected_before_seal": false,
     "mutual_attestation": true,
+    "post_seal_rule_violated": true,
+    "eligible_for_confirmation": false,
     "codex_seal_message_id": "39bc6d5a-d6c1-44d7-8a8d-ec94cf78d06f",
     "core_countersign_message_id": "3727e922-259f-4b1c-89af-91c1c3d6e99e",
     "rule": "Units 16-35 remain content-blind until the fresh preregistration is frozen."

--- a/benchmarks/amb/verify_event_ordering_thread_v3_holdout.py
+++ b/benchmarks/amb/verify_event_ordering_thread_v3_holdout.py
@@ -1,0 +1,171 @@
+"""Verify the sealed BEAM-500k holdout without displaying its contents."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+PROTOCOL = "amb-event-ordering-thread-v3-holdout-seal-v1"
+
+
+def sha256_path(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def read_json(path: Path) -> Any:
+    opener = gzip.open if path.suffix == ".gz" else path.open
+    with opener(path, "rt", encoding="utf-8") if path.suffix == ".gz" else opener(
+        "r", encoding="utf-8"
+    ) as handle:
+        return json.load(handle)
+
+
+def canonical_sha256(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def ordered_ids_sha256(rows: list[dict[str, Any]]) -> str:
+    return hashlib.sha256(
+        "\n".join(str(row["id"]) for row in rows).encode("utf-8")
+    ).hexdigest()
+
+
+def _index_unique(rows: list[dict[str, Any]], label: str) -> None:
+    ids = [str(row.get("id") or "") for row in rows]
+    if any(not value for value in ids) or len(ids) != len(set(ids)):
+        raise ValueError(f"{label} contains missing or duplicate IDs")
+
+
+def verify(
+    manifest: dict[str, Any],
+    queries_path: Path,
+    documents_path: Path,
+    burned_queries_path: Path | None = None,
+    categories_path: Path | None = None,
+    stats_path: Path | None = None,
+) -> dict[str, Any]:
+    if manifest.get("protocol") != PROTOCOL:
+        raise ValueError("unexpected holdout manifest protocol")
+    source_hashes = manifest["source_sha256"]
+    source_paths = {
+        "queries.json.gz": queries_path,
+        "documents.json.gz": documents_path,
+        "categories.json.gz": categories_path,
+        "stats.json.gz": stats_path,
+    }
+    for name, expected_hash in source_hashes.items():
+        path = source_paths.get(name)
+        if path is None:
+            raise ValueError(f"sealed source path was not supplied: {name}")
+        if sha256_path(path) != expected_hash:
+            raise ValueError(f"sealed source hash mismatch: {name}")
+
+    queries = read_json(queries_path)
+    documents = read_json(documents_path)
+    if not isinstance(queries, list) or not isinstance(documents, list):
+        raise ValueError("BEAM query and document sources must be arrays")
+    units = set(manifest["holdout_units"])
+    selected_queries = [
+        row for row in queries if str(row.get("user_id")) in units
+    ]
+    selected_documents = [
+        row for row in documents if str(row.get("user_id")) in units
+    ]
+    event_category = manifest["event_category"]
+    event_queries = [
+        row
+        for row in selected_queries
+        if (row.get("meta") or {}).get("question_category") == event_category
+    ]
+    _index_unique(selected_queries, "holdout queries")
+    _index_unique(event_queries, "holdout event queries")
+    _index_unique(selected_documents, "holdout documents")
+
+    expected = manifest["expected"]
+    actual_counts = {
+        "query_rows": len(selected_queries),
+        "event_rows": len(event_queries),
+        "document_rows": len(selected_documents),
+        "unit_count": len({str(row.get("user_id")) for row in selected_queries}),
+    }
+    for key, value in actual_counts.items():
+        if value != expected[key]:
+            raise ValueError(f"holdout {key} mismatch: expected {expected[key]}, got {value}")
+
+    actual_hashes = {
+        "all_queries": canonical_sha256(selected_queries),
+        "event_queries": canonical_sha256(event_queries),
+        "all_ordered_query_ids": ordered_ids_sha256(selected_queries),
+        "event_ordered_query_ids": ordered_ids_sha256(event_queries),
+        "documents": canonical_sha256(selected_documents),
+    }
+    for key, value in actual_hashes.items():
+        if value != manifest["subset_sha256"][key]:
+            raise ValueError(f"holdout subset hash mismatch: {key}")
+
+    overlap = None
+    if burned_queries_path is not None:
+        burned = read_json(burned_queries_path)
+        if not isinstance(burned, list):
+            raise ValueError("burned query source must be an array")
+        burned_event_text = {
+            str(row.get("query") or "").casefold().strip()
+            for row in burned
+            if (row.get("meta") or {}).get("question_category") == event_category
+        }
+        overlap = sum(
+            str(row.get("query") or "").casefold().strip() in burned_event_text
+            for row in event_queries
+        )
+        if overlap != expected["exact_event_query_overlap_with_beam_100k"]:
+            raise ValueError("holdout event-query overlap mismatch")
+
+    return {
+        "protocol": PROTOCOL,
+        "verified": True,
+        "counts": actual_counts,
+        "subset_sha256": actual_hashes,
+        "exact_event_query_overlap_with_beam_100k": overlap,
+        "content_emitted": False,
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    result.add_argument("--manifest", type=Path, required=True)
+    result.add_argument("--queries", type=Path, required=True)
+    result.add_argument("--documents", type=Path, required=True)
+    result.add_argument("--categories", type=Path, required=True)
+    result.add_argument("--stats", type=Path, required=True)
+    result.add_argument("--burned-queries", type=Path, required=True)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    manifest = read_json(args.manifest)
+    report = verify(
+        manifest,
+        args.queries,
+        args.documents,
+        args.burned_queries,
+        args.categories,
+        args.stats,
+    )
+    print(json.dumps(report, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/amb/verify_event_ordering_thread_v3_holdout.py
+++ b/benchmarks/amb/verify_event_ordering_thread_v3_holdout.py
@@ -57,6 +57,8 @@ def verify(
 ) -> dict[str, Any]:
     if manifest.get("protocol") != PROTOCOL:
         raise ValueError("unexpected holdout manifest protocol")
+    if manifest.get("status") != "active":
+        raise ValueError("holdout seal is not active")
     source_hashes = manifest["source_sha256"]
     source_paths = {
         "queries.json.gz": queries_path,

--- a/tests/test_amb_event_ordering_thread_v3_holdout.py
+++ b/tests/test_amb_event_ordering_thread_v3_holdout.py
@@ -1,0 +1,135 @@
+import gzip
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "benchmarks" / "amb" / "verify_event_ordering_thread_v3_holdout.py"
+SPEC = importlib.util.spec_from_file_location("thread_v3_holdout", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def _write_gzip(path: Path, value) -> None:
+    with gzip.open(path, "wt", encoding="utf-8") as handle:
+        json.dump(value, handle)
+
+
+def _source_sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fixture(tmp_path: Path):
+    queries = [
+        {
+            "id": "2_event_ordering_0",
+            "query": "fresh order question",
+            "user_id": "2",
+            "meta": {"question_category": "event_ordering"},
+        },
+        {
+            "id": "2_summary_0",
+            "query": "fresh summary question",
+            "user_id": "2",
+            "meta": {"question_category": "summarization"},
+        },
+        {
+            "id": "1_event_ordering_0",
+            "query": "development question",
+            "user_id": "1",
+            "meta": {"question_category": "event_ordering"},
+        },
+    ]
+    documents = [
+        {"id": "2_s0", "content": "sealed", "user_id": "2"},
+        {"id": "1_s0", "content": "development", "user_id": "1"},
+    ]
+    burned = [
+        {
+            "id": "9_event_ordering_0",
+            "query": "old order question",
+            "user_id": "9",
+            "meta": {"question_category": "event_ordering"},
+        }
+    ]
+    query_path = tmp_path / "queries.json.gz"
+    document_path = tmp_path / "documents.json.gz"
+    burned_path = tmp_path / "burned.json.gz"
+    _write_gzip(query_path, queries)
+    _write_gzip(document_path, documents)
+    _write_gzip(burned_path, burned)
+    holdout_queries = queries[:2]
+    holdout_event = queries[:1]
+    holdout_documents = documents[:1]
+    manifest = {
+        "protocol": MODULE.PROTOCOL,
+        "holdout_units": ["2"],
+        "event_category": "event_ordering",
+        "expected": {
+            "query_rows": 2,
+            "event_rows": 1,
+            "document_rows": 1,
+            "unit_count": 1,
+            "exact_event_query_overlap_with_beam_100k": 0,
+        },
+        "source_sha256": {
+            "queries.json.gz": _source_sha(query_path),
+            "documents.json.gz": _source_sha(document_path),
+        },
+        "subset_sha256": {
+            "all_queries": MODULE.canonical_sha256(holdout_queries),
+            "event_queries": MODULE.canonical_sha256(holdout_event),
+            "all_ordered_query_ids": MODULE.ordered_ids_sha256(holdout_queries),
+            "event_ordered_query_ids": MODULE.ordered_ids_sha256(holdout_event),
+            "documents": MODULE.canonical_sha256(holdout_documents),
+        },
+    }
+    return manifest, query_path, document_path, burned_path
+
+
+def test_verify_accepts_exact_sealed_holdout_without_emitting_content(tmp_path):
+    manifest, queries, documents, burned = _fixture(tmp_path)
+
+    report = MODULE.verify(manifest, queries, documents, burned)
+
+    assert report["verified"] is True
+    assert report["content_emitted"] is False
+    assert report["counts"] == {
+        "query_rows": 2,
+        "event_rows": 1,
+        "document_rows": 1,
+        "unit_count": 1,
+    }
+    assert report["exact_event_query_overlap_with_beam_100k"] == 0
+    assert "fresh order question" not in json.dumps(report)
+
+
+def test_verify_rejects_source_drift_before_parsing(tmp_path):
+    manifest, queries, documents, burned = _fixture(tmp_path)
+    manifest["source_sha256"]["queries.json.gz"] = "0" * 64
+
+    with pytest.raises(ValueError, match="queries.json.gz"):
+        MODULE.verify(manifest, queries, documents, burned)
+
+
+def test_verify_rejects_subset_order_drift(tmp_path):
+    manifest, queries, documents, burned = _fixture(tmp_path)
+    manifest["subset_sha256"]["all_ordered_query_ids"] = "0" * 64
+
+    with pytest.raises(ValueError, match="all_ordered_query_ids"):
+        MODULE.verify(manifest, queries, documents, burned)
+
+
+def test_verify_rejects_overlap_with_burned_event_queries(tmp_path):
+    manifest, queries, documents, burned = _fixture(tmp_path)
+    burned_rows = MODULE.read_json(burned)
+    burned_rows[0]["query"] = "fresh order question"
+    _write_gzip(burned, burned_rows)
+
+    with pytest.raises(ValueError, match="overlap mismatch"):
+        MODULE.verify(manifest, queries, documents, burned)

--- a/tests/test_amb_event_ordering_thread_v3_holdout.py
+++ b/tests/test_amb_event_ordering_thread_v3_holdout.py
@@ -68,6 +68,7 @@ def _fixture(tmp_path: Path):
     holdout_documents = documents[:1]
     manifest = {
         "protocol": MODULE.PROTOCOL,
+        "status": "active",
         "holdout_units": ["2"],
         "event_category": "event_ordering",
         "expected": {
@@ -132,4 +133,12 @@ def test_verify_rejects_overlap_with_burned_event_queries(tmp_path):
     _write_gzip(burned, burned_rows)
 
     with pytest.raises(ValueError, match="overlap mismatch"):
+        MODULE.verify(manifest, queries, documents, burned)
+
+
+def test_verify_rejects_void_seal(tmp_path):
+    manifest, queries, documents, burned = _fixture(tmp_path)
+    manifest["status"] = "void"
+
+    with pytest.raises(ValueError, match="not active"):
         MODULE.verify(manifest, queries, documents, burned)


### PR DESCRIPTION
## Status: VOID — ineligible for confirmation\n\nThis PR originally attempted to seal BEAM-500k units 16–35 as a 400-row / 40-event holdout.\n\nThe seal was invalidated the same day, before any evaluation or model call, because a previously dispatched helper computed predicate membership and aggregate source-reference counts after sealing. Although it printed no query, gold-answer, document, or turn text, that exceeded the mutually agreed hash-only blind rule.\n\nCommit 3df35d records the invalidation in the manifest (status=void, ligible=false) and makes the verifier fail closed for this cohort. The cohort must not be used for confirmatory claims; it is development data at most.\n\nSuccessor: none yet. Any replacement must use an untouched source, include helper-quiescence attestations from both reviewers, and permit only the frozen seal script to read source files before the freeze.