### PR TITLE
feat(py): adaptive topic budget for thread recall — resolve_thread_topics

### DIFF
--- a/src/yantrikdb/__init__.py
+++ b/src/yantrikdb/__init__.py
@@ -36,6 +36,7 @@ from yantrikdb.organize import (
     validate_concern_items,
 )
 from yantrikdb.rerank import recall_reranked, rerank_hits
+from yantrikdb.thread import resolve_thread_topics
 from yantrikdb.triggers import check_all_triggers
 
 # Backward-compat alias
@@ -76,6 +77,7 @@ __all__ = [
     "check_all_triggers",
     "recall_reranked",
     "rerank_hits",
+    "resolve_thread_topics",
     "Backpressure",
     "BatchDeferredDuringReembed",
     "CorrectionDeferredDuringReembed",

--- a/src/yantrikdb/thread.py
+++ b/src/yantrikdb/thread.py
@@ -1,0 +1,210 @@
+"""Adaptive topic resolution for thread recall.
+
+``resolve_thread_topics`` turns a natural-language focus into the
+``topic_rids`` list that :meth:`recall_thread_v2` unions into a thread. It
+ranks the namespace's query-independent organizer topics by bounded
+semantic recall and picks how many to keep from the shape of the query's
+own score curve — never from a per-query constant tuned to any benchmark.
+
+Parameter provenance (stated plainly so nobody has to reverse-engineer
+the epistemics later):
+
+- ``floor=12`` is DEV-CALIBRATED: it was chosen from a coverage sweep on
+  the 40 burned event-ordering dev queries (BEAM 100k) after the frozen
+  Stage A run failed with the historical fixed budget of 3. Its validity
+  for anything beyond that dev set rests on the sealed BEAM 500k holdout
+  evaluation, not on this module.
+- ``cap=16`` is a hard design ceiling on rid fan-out: it bounds the SQL
+  union width and the resulting thread size. Dev evidence (non-binding):
+  max observed thread length was ~80 rows at 12 topics.
+
+The knee rule is query-only: with ranked scores ``s1 >= s2 >= ... >= sn``
+(n <= cap), a cut is searched only at or after ``floor`` — the largest
+gap ``s_i - s_(i+1)`` for ``i`` in ``[floor, n-1]`` wins, equal largest
+gaps cut LATER (coverage-conservative), and a flat curve above the floor
+(largest gap < 1e-9) keeps all ``n``. When ``n <= floor`` everything is
+kept and the knee diagnostics are ``None``.
+
+Retrieval oversampling (BOUNDED): organizer topics share the store with
+ordinary inference records, so ``recall(top_k=cap)`` can return fewer
+than ``cap`` organizer hits. The resolver requests ``max(64, cap * 4)``
+rows and, while fewer than ``cap`` organizer topics have surfaced AND
+the store may hold more (returned == requested), doubles ``top_k`` and
+re-queries — but never beyond ``candidate_cap`` (default 1024; request
+sequence 64, 128, 256, 512, 1024). The hard stop keeps an organizer-poor
+large store from widening toward the engine's recall maximum, and the
+``candidate_cap_reached`` diagnostic makes the resulting beyond-cap
+false-negative possibility auditable rather than silent.
+``store_exhausted`` records that the store ran out before ``cap`` was
+reached — a valid outcome, not an error.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+# Hard ceiling on both ``cap`` and ``floor`` — bounds rid fan-out.
+MAX_TOPIC_CAP = 16
+# Two adjacent scores closer than this carry no cut evidence.
+FLAT_CURVE_EPSILON = 1e-9
+# First oversampled request; doubled until enough organizer hits surface.
+INITIAL_OVERSAMPLE_TOP_K = 64
+# Hard stop for oversampling growth (candidate_cap upper bound stays
+# under the engine's recall maximum).
+DEFAULT_CANDIDATE_CAP = 1024
+MAX_CANDIDATE_CAP = 10_000
+
+
+def _validated_budget(name: str, value: Any, upper: int) -> int:
+    # bool is an int subclass; a caller passing True/False is a bug, not 1/0.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an int, got {type(value).__name__}")
+    if not 1 <= value <= upper:
+        raise ValueError(f"{name} must be in [1, {upper}], got {value}")
+    return value
+
+
+def resolve_thread_topics(
+    db: Any,
+    focus: str,
+    namespace: str = "default",
+    *,
+    cap: int = 16,
+    floor: int = 12,
+    candidate_cap: int = DEFAULT_CANDIDATE_CAP,
+) -> dict[str, Any]:
+    """Rank organizer topics for ``focus`` and cut the list at its knee.
+
+    Returns a dict with ``selected_rids`` (what to pass as
+    ``topic_rids``) plus the full audit surface: ``ranked`` is the entire
+    pre-cut list so the knee is recomputable from the return value alone.
+
+    Raises ``TypeError``/``ValueError`` for invalid budgets, a
+    ``ValueError`` naming the namespace when no organizer topic exists in
+    it, and ``ValueError`` for hits whose scores are missing or
+    non-finite (a malformed score cannot be ranked, and silently dropping
+    it would move the knee).
+    """
+    cap = _validated_budget("cap", cap, MAX_TOPIC_CAP)
+    floor = _validated_budget("floor", floor, cap)
+    if isinstance(candidate_cap, bool) or not isinstance(candidate_cap, int):
+        raise TypeError(
+            f"candidate_cap must be an int, got {type(candidate_cap).__name__}"
+        )
+    if not cap <= candidate_cap <= MAX_CANDIDATE_CAP:
+        raise ValueError(
+            f"candidate_cap must be in [{cap}, {MAX_CANDIDATE_CAP}], "
+            f"got {candidate_cap}"
+        )
+
+    ranked: list[dict[str, Any]] = []
+    seen_rids: set[str] = set()
+    top_k = min(max(INITIAL_OVERSAMPLE_TOP_K, cap * 4), candidate_cap)
+    recall_rounds = 0
+    store_exhausted = False
+    candidate_cap_reached = False
+    while True:
+        hits = db.recall(
+            query=focus,
+            top_k=top_k,
+            namespace=namespace,
+            source="inference",
+            include_consolidated=True,
+            skip_reinforce=True,
+        )
+        recall_rounds += 1
+        ranked.clear()
+        seen_rids.clear()
+        for hit in hits:
+            metadata = hit.get("metadata") or {}
+            if metadata.get("organizer_kind") != "query_independent_topic":
+                continue
+            rid = str(hit.get("rid") or "")
+            if not rid or rid in seen_rids:
+                continue
+            score = hit.get("score")
+            if not isinstance(score, (int, float)) or isinstance(score, bool):
+                raise ValueError(
+                    f"organizer hit {rid} has a non-numeric score: {score!r}"
+                )
+            score = float(score)
+            if not math.isfinite(score):
+                raise ValueError(
+                    f"organizer hit {rid} has a non-finite score: {score!r}"
+                )
+            seen_rids.add(rid)
+            ranked.append(
+                {
+                    "rid": rid,
+                    "label": metadata.get("organizer_label"),
+                    "score": score,
+                }
+            )
+        if len(ranked) >= cap:
+            break
+        if len(hits) < top_k:
+            # The store returned everything it has; fewer organizer
+            # topics than ``cap`` exist. Valid outcome.
+            store_exhausted = True
+            break
+        if top_k >= candidate_cap:
+            # Hard stop: more rows may exist beyond candidate_cap, so an
+            # organizer topic could in principle be hiding out there — a
+            # possible false negative, flagged for audit, never widened
+            # toward the engine maximum.
+            candidate_cap_reached = True
+            break
+        top_k = min(top_k * 2, candidate_cap)
+
+    if not ranked:
+        raise ValueError(
+            f"no query-independent organizer topics found in namespace "
+            f"{namespace!r}; run the organizer before thread resolution"
+        )
+
+    # recall returns score-descending order; make the contract explicit and
+    # deterministic under ties (score desc, then rid asc).
+    ranked.sort(key=lambda r: (-r["score"], r["rid"]))
+    ranked = ranked[:cap]
+    n = len(ranked)
+
+    cut_index = n
+    cut_score: float | None = None
+    largest_gap: float | None = None
+    flat_curve = False
+    if n > floor:
+        best_gap = -1.0
+        best_i = None
+        for i in range(floor, n):  # cut candidates: keep ranked[:i]
+            gap = ranked[i - 1]["score"] - ranked[i]["score"]
+            # ``>=`` so equal largest gaps cut LATER (coverage-conservative).
+            if gap >= best_gap:
+                best_gap = gap
+                best_i = i
+        if best_gap < FLAT_CURVE_EPSILON:
+            # No score evidence for a cut anywhere at/after the floor:
+            # keep everything up to the cap.
+            flat_curve = True
+        else:
+            assert best_i is not None
+            cut_index = best_i
+            cut_score = ranked[best_i - 1]["score"]
+            largest_gap = best_gap
+
+    selected = ranked[:cut_index]
+    return {
+        "selected_rids": [r["rid"] for r in selected],
+        "selected_count": cut_index,
+        "cut_index": cut_index,
+        "cut_score": cut_score,
+        "largest_gap": largest_gap,
+        "ranked": ranked,
+        "cap": cap,
+        "floor": floor,
+        "flat_curve": flat_curve,
+        "candidate_cap": candidate_cap,
+        "recall_rounds": recall_rounds,
+        "store_exhausted": store_exhausted,
+        "candidate_cap_reached": candidate_cap_reached,
+    }

--- a/src/yantrikdb/thread.py
+++ b/src/yantrikdb/thread.py
@@ -11,9 +11,11 @@ the epistemics later):
 
 - ``floor=12`` is DEV-CALIBRATED: it was chosen from a coverage sweep on
   the 40 burned event-ordering dev queries (BEAM 100k) after the frozen
-  Stage A run failed with the historical fixed budget of 3. Its validity
-  for anything beyond that dev set rests on the sealed BEAM 500k holdout
-  evaluation, not on this module.
+  Stage A run failed with the historical fixed budget of 3. Its
+  generalization beyond that dev set is UNCONFIRMED: a BEAM 500k holdout
+  seal was invalidated before evaluation (helper contamination,
+  disclosed and voided same-day), so no valid holdout evaluation exists
+  yet — a future untouched, mutually sealed cohort has to supply it.
 - ``cap=16`` is a hard design ceiling on rid fan-out: it bounds the SQL
   union width and the resulting thread size. Dev evidence (non-binding):
   max observed thread length was ~80 rows at 12 topics.

--- a/tests/test_thread_topic_resolver.py
+++ b/tests/test_thread_topic_resolver.py
@@ -1,0 +1,281 @@
+"""Contract tests for ``resolve_thread_topics`` (adaptive topic budget).
+
+The resolver is dev-calibrated (floor=12) and cap-bounded (16); these
+tests pin the QUERY-ONLY knee mechanics, the oversampling/exhaustion
+semantics, the validation surface, and the exact recall invocation —
+using synthetic score curves only. Nothing here reads benchmark data,
+and the module under test must not import any benchmark code.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from yantrikdb.thread import resolve_thread_topics
+
+
+class FakeDB:
+    """Records recall kwargs and serves a scripted organizer ranking."""
+
+    def __init__(self, scores, *, noise_rows=0, labels=None, rids=None,
+                 scripted_batches=None):
+        self.calls = []
+        self._scores = scores
+        self._noise_rows = noise_rows
+        self._labels = labels
+        self._rids = rids
+        self._scripted_batches = scripted_batches
+
+    def _organizer_hits(self):
+        hits = []
+        for i, score in enumerate(self._scores):
+            rid = self._rids[i] if self._rids else f"topic-{i:03d}"
+            label = self._labels[i] if self._labels else f"label {i}"
+            hits.append({
+                "rid": rid,
+                "score": score,
+                "metadata": {
+                    "organizer_kind": "query_independent_topic",
+                    "organizer_label": label,
+                },
+            })
+        return hits
+
+    def recall(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._scripted_batches is not None:
+            return self._scripted_batches[len(self.calls) - 1]
+        # Noise ranks FIRST (score 0.99 beats every organizer topic), the
+        # realistic worst case: raw inference rows bury organizer topics.
+        hits = [
+            {
+                "rid": f"noise-{i:03d}",
+                "score": 0.99,
+                "metadata": {"organizer_kind": "something_else"},
+            }
+            for i in range(self._noise_rows)
+        ]
+        hits.extend(self._organizer_hits())
+        return hits[: kwargs["top_k"]]
+
+
+def descending(n, start=0.9, step=0.01):
+    return [round(start - i * step, 6) for i in range(n)]
+
+
+def test_exact_recall_kwargs_are_pinned():
+    db = FakeDB(descending(16))
+    resolve_thread_topics(db, "the move to Portland", "ns-a")
+    assert db.calls == [{
+        "query": "the move to Portland",
+        "top_k": 64,
+        "namespace": "ns-a",
+        "source": "inference",
+        "include_consolidated": True,
+        "skip_reinforce": True,
+    }]
+
+
+def test_no_benchmark_imports():
+    module = sys.modules["yantrikdb.thread"]
+    assert not [
+        name for name in sys.modules
+        if name.startswith("benchmarks") and module.__name__ in name
+    ]
+    source_deps = getattr(module, "__dict__", {})
+    assert "benchmarks" not in repr(source_deps.keys())
+
+
+def test_knee_cuts_at_largest_gap_after_floor():
+    # Big gap after position 14 (1-based): scores 0..13 tight, then drop.
+    scores = descending(14, start=0.9, step=0.001) + [0.5, 0.49]
+    result = resolve_thread_topics(FakeDB(scores), "q")
+    assert result["selected_count"] == 14
+    assert result["cut_index"] == 14
+    assert result["cut_score"] == scores[13]
+    assert result["largest_gap"] == pytest.approx(scores[13] - scores[14])
+    assert result["flat_curve"] is False
+    assert result["selected_rids"] == [f"topic-{i:03d}" for i in range(14)]
+
+
+def test_knee_never_cuts_before_floor():
+    # The overwhelmingly largest gap is after position 2 — but the floor
+    # forbids cutting there; the winning cut is the largest gap at/after 12.
+    scores = [0.9, 0.89, 0.3, 0.29, 0.28, 0.27, 0.26, 0.25, 0.24, 0.23,
+              0.22, 0.21, 0.15, 0.14, 0.13, 0.12]
+    result = resolve_thread_topics(FakeDB(scores), "q")
+    assert result["selected_count"] == 12
+    assert result["largest_gap"] == pytest.approx(0.21 - 0.15)
+
+
+def test_equal_largest_gaps_cut_later():
+    # Identical gaps of 0.1 after positions 12 and 14 (1-based): the later
+    # cut must win (coverage-conservative).
+    scores = descending(12, start=0.9, step=0.001)
+    scores += [scores[-1] - 0.1]            # gap 0.1 after position 12
+    scores += [scores[-1] - 0.001]
+    scores += [scores[-1] - 0.1]            # gap 0.1 after position 14
+    scores += [scores[-1] - 0.001]
+    result = resolve_thread_topics(FakeDB(scores), "q")
+    assert result["selected_count"] == 14
+
+
+def test_n_at_most_floor_selects_all_with_null_diagnostics():
+    for n in (1, 5, 12):
+        result = resolve_thread_topics(FakeDB(descending(n)), "q")
+        assert result["selected_count"] == n
+        assert result["cut_index"] == n
+        assert result["cut_score"] is None
+        assert result["largest_gap"] is None
+        assert result["flat_curve"] is False
+
+
+def test_flat_curve_above_floor_selects_all():
+    result = resolve_thread_topics(FakeDB([0.5] * 16), "q")
+    assert result["selected_count"] == 16
+    assert result["flat_curve"] is True
+    assert result["cut_score"] is None
+    assert result["largest_gap"] is None
+
+
+def test_cap_bounds_selection_and_ranked():
+    db = FakeDB(descending(30))
+    result = resolve_thread_topics(db, "q")
+    assert len(result["ranked"]) == 16
+    assert result["selected_count"] <= 16
+
+
+def test_ranked_is_full_precut_audit_surface():
+    scores = descending(14, start=0.9, step=0.001) + [0.5, 0.49]
+    result = resolve_thread_topics(FakeDB(scores), "q")
+    # The knee must be recomputable from `ranked` alone.
+    assert [r["score"] for r in result["ranked"]] == scores
+    assert result["selected_count"] < len(result["ranked"])
+    assert {"rid", "label", "score"} <= set(result["ranked"][0])
+
+
+def test_deterministic_under_score_ties():
+    rids = [f"z-{i}" for i in range(8)] + [f"a-{i}" for i in range(8)]
+    db = FakeDB([0.5] * 16, rids=rids)
+    first = resolve_thread_topics(db, "q")
+    second = resolve_thread_topics(FakeDB([0.5] * 16, rids=list(rids)), "q")
+    assert first["selected_rids"] == second["selected_rids"]
+    # Ties break by rid ascending.
+    assert first["selected_rids"] == sorted(rids)
+
+
+def test_duplicate_rids_keep_highest_ranked_occurrence():
+    batches = [[
+        {"rid": "dup", "score": 0.9,
+         "metadata": {"organizer_kind": "query_independent_topic"}},
+        {"rid": "dup", "score": 0.4,
+         "metadata": {"organizer_kind": "query_independent_topic"}},
+        {"rid": "other", "score": 0.3,
+         "metadata": {"organizer_kind": "query_independent_topic"}},
+    ]]
+    result = resolve_thread_topics(FakeDB(None, scripted_batches=batches), "q")
+    assert result["selected_rids"] == ["dup", "other"]
+    assert result["ranked"][0]["score"] == 0.9
+
+
+def test_oversampling_doubles_until_cap_or_exhaustion():
+    # 100 noise rows bury the organizer topics: the first request (64)
+    # yields too few organizer hits AND returned == requested, so the
+    # resolver must double and re-query.
+    db = FakeDB(descending(16), noise_rows=100)
+    result = resolve_thread_topics(db, "q")
+    assert [c["top_k"] for c in db.calls] == [64, 128]
+    assert result["store_exhausted"] is False
+    assert result["candidate_cap_reached"] is False
+    assert result["recall_rounds"] == 2
+    assert len(result["ranked"]) == 16
+
+
+def test_exhaustion_below_cap_is_valid_not_an_error():
+    # Only 13 organizer topics exist in the whole store. Exhaustion is
+    # orthogonal to the knee: all 13 are ranked, and the uniformly
+    # descending curve knees at the floor (12) as usual.
+    db = FakeDB(descending(13))
+    result = resolve_thread_topics(db, "q")
+    assert result["store_exhausted"] is True
+    assert result["candidate_cap_reached"] is False
+    assert len(result["ranked"]) == 13
+    assert result["selected_count"] == 12
+
+
+def test_zero_organizer_hits_raises_naming_namespace():
+    db = FakeDB([])
+    with pytest.raises(ValueError, match="ns-empty"):
+        resolve_thread_topics(db, "q", "ns-empty")
+
+
+def test_budget_validation():
+    db = FakeDB(descending(16))
+    with pytest.raises(ValueError):
+        resolve_thread_topics(db, "q", cap=17)
+    with pytest.raises(ValueError):
+        resolve_thread_topics(db, "q", cap=0)
+    with pytest.raises(ValueError):
+        resolve_thread_topics(db, "q", cap=8, floor=9)
+    with pytest.raises(TypeError):
+        resolve_thread_topics(db, "q", cap=True)
+    with pytest.raises(TypeError):
+        resolve_thread_topics(db, "q", floor=12.0)
+
+
+def test_malformed_scores_are_typed_errors():
+    for bad in (None, "0.5", float("nan"), float("inf"), True):
+        batches = [[
+            {"rid": "t-0", "score": bad,
+             "metadata": {"organizer_kind": "query_independent_topic"}},
+        ]]
+        with pytest.raises(ValueError):
+            resolve_thread_topics(FakeDB(None, scripted_batches=batches), "q")
+
+
+def test_candidate_cap_hard_stop_is_flagged():
+    # Every request comes back full of noise with only a few organizer
+    # topics: the resolver must walk 64,128,256,512,1024 and stop there
+    # with the false-negative flag set, never widening further.
+    class NoisyDB(FakeDB):
+        def recall(self, **kwargs):
+            self.calls.append(kwargs)
+            hits = self._organizer_hits()
+            while len(hits) < kwargs["top_k"]:
+                hits.append({
+                    "rid": f"noise-{len(hits):05d}",
+                    "score": 0.99,
+                    "metadata": {"organizer_kind": "something_else"},
+                })
+            return hits[: kwargs["top_k"]]
+
+    db = NoisyDB(descending(5))
+    result = resolve_thread_topics(db, "q")
+    assert [c["top_k"] for c in db.calls] == [64, 128, 256, 512, 1024]
+    assert result["candidate_cap_reached"] is True
+    assert result["store_exhausted"] is False
+    assert result["recall_rounds"] == 5
+    assert result["selected_count"] == 5
+
+
+def test_candidate_cap_validation():
+    db = FakeDB(descending(16))
+    with pytest.raises(ValueError):
+        resolve_thread_topics(db, "q", candidate_cap=10_001)
+    with pytest.raises(ValueError):
+        resolve_thread_topics(db, "q", cap=16, candidate_cap=15)
+    with pytest.raises(TypeError):
+        resolve_thread_topics(db, "q", candidate_cap=True)
+    # candidate_cap below the default first request clamps the request.
+    db2 = FakeDB(descending(16))
+    resolve_thread_topics(db2, "q", candidate_cap=32)
+    assert [c["top_k"] for c in db2.calls] == [32]
+
+
+def test_floor_overridable_and_knee_respects_it():
+    scores = [0.9, 0.5] + descending(6, start=0.4, step=0.001)
+    result = resolve_thread_topics(FakeDB(scores), "q", cap=8, floor=1)
+    assert result["selected_count"] == 1
+    assert result["largest_gap"] == pytest.approx(0.4)


### PR DESCRIPTION
## What

`resolve_thread_topics(db, focus, namespace, *, cap=16, floor=12, candidate_cap=1024)` — the product-side answer to the frozen Stage A failure (#193): the event-ordering coverage floor was missed because the harness fed `recall_thread_v2` a **fixed 3-topic budget**, while the organizer synthesis layer itself held nearly all recoverable coverage (oracle mean .918).

- **Knee rule, query-only**: rank organizer topics by the same bounded recall the fixed-budget lookup used; cut at the largest score gap **at/after the floor**; equal gaps cut later (coverage-conservative); flat curves keep everything; `n <= floor` keeps all with null knee diagnostics.
- **Honest calibration labels**: `floor=12` is **dev-calibrated** on the 40 burned dev queries (a floor-3 pure-knee variant was empirically rejected on dev at .531). **Generalization beyond dev is unconfirmed**: the intended BEAM 500k holdout seal was invalidated before evaluation (helper contamination, disclosed and voided same-day), so no valid holdout evaluation exists yet — a future untouched, mutually sealed cohort has to supply it. `cap=16` is a hard design ceiling on rid fan-out.
- **Bounded oversampling**: requests walk 64→128→256→512→1024 and hard-stop, flagging `candidate_cap_reached` (auditable beyond-cap false-negative) vs `store_exhausted` (store ran out; valid).
- **Audit surface**: full pre-cut ranked list returned (knee recomputable from the result alone), `recall_rounds`, typed errors for malformed scores and invalid budgets, deterministic tie-breaks, duplicate rids keep the highest-ranked occurrence.

## Provenance

Implementation and tests use synthetic score curves only. No benchmark data was read while building this; the BEAM 500k holdout files were never opened by this workspace. Contract co-designed and countersigned by the second reviewer in the swarm channel (floor-3 rejection → floor-12 revision → candidate_cap precision → holdout-void provenance correction).

## Verification

- 19 new tests green **against the installed release wheel** in a clean venv, covering: exact recall kwargs pinning, knee/floor/tie/flat mechanics, oversampling walk + both stop conditions, validation surface, determinism, and no-benchmark-imports.
- Full python suite: 585 passed / 1 skipped.
- flake8 + pylint (errors) clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)