### PR TITLE
docs: explain edge conflict detection placement

### DIFF
--- a/crates/yantrikdb-core/src/distributed/replication.rs
+++ b/crates/yantrikdb-core/src/distributed/replication.rs
@@ -477,7 +477,9 @@ fn materialize_op(db: &YantrikDB, op: &OplogEntry) -> Result<()> {
                     gi.add_entity(dst, dst_type);
                     gi.add_edge(src, dst, weight as f32);
                 }
-                // V2: detect edge conflicts during sync
+                // Conflict detection intentionally stays outside the `changed` gate.
+                // An operation that loses LWW must not mutate the row or cache,
+                // but a losing concurrent edge may still reveal a conflict.
                 let _ = crate::conflict::detect_edge_conflicts(
                     db,
                     src,


### PR DESCRIPTION
Explains why edge conflict detection remains outside the changed gate. An operation that loses LWW must not mutate state, but a losing concurrent edge may still reveal a conflict. No behavior changes. Closes #183.