### PR TITLE
feat(py): select_thread_evidence — retrieve wide, then compress

### DIFF
--- a/src/yantrikdb/__init__.py
+++ b/src/yantrikdb/__init__.py
@@ -36,7 +36,11 @@ from yantrikdb.organize import (
     validate_concern_items,
 )
 from yantrikdb.rerank import recall_reranked, rerank_hits
-from yantrikdb.thread import resolve_thread_topics
+from yantrikdb.thread import (
+    ThreadSelectionPolicyInfeasible,
+    resolve_thread_topics,
+    select_thread_evidence,
+)
 from yantrikdb.triggers import check_all_triggers
 
 # Backward-compat alias
@@ -78,6 +82,8 @@ __all__ = [
     "recall_reranked",
     "rerank_hits",
     "resolve_thread_topics",
+    "select_thread_evidence",
+    "ThreadSelectionPolicyInfeasible",
     "Backpressure",
     "BatchDeferredDuringReembed",
     "CorrectionDeferredDuringReembed",

--- a/src/yantrikdb/thread.py
+++ b/src/yantrikdb/thread.py
@@ -248,6 +248,28 @@ def _validated_selection_int(name: str, value: Any, *, minimum: int) -> int:
     return value
 
 
+def _validated_scores(raw: Any, expected: int) -> list[float]:
+    """Validate a scorer's output: exact count, finite non-bool numbers."""
+    scores = list(raw)
+    if len(scores) != expected:
+        raise ValueError(
+            f"scorer returned {len(scores)} scores for {expected} rows"
+        )
+    result = []
+    for index, value in enumerate(scores):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"scorer returned a non-numeric score at row {index}: {value!r}"
+            )
+        value = float(value)
+        if not math.isfinite(value):
+            raise ValueError(
+                f"scorer returned a non-finite score at row {index}: {value!r}"
+            )
+        result.append(value)
+    return result
+
+
 def _cross_encoder_scores(focus: str, texts: list[str]) -> list[float]:
     from yantrikdb.rerank import DEFAULT_MODEL, _cross_encoder
 
@@ -312,15 +334,11 @@ def select_thread_evidence(
         scorer_id = "cross-encoder"
         from yantrikdb.rerank import DEFAULT_MODEL as scorer_model
 
-        scores = _cross_encoder_scores(focus, texts)
+        scores = _validated_scores(_cross_encoder_scores(focus, texts), len(items))
     elif callable(scorer):
         scorer_id = getattr(scorer, "__name__", "callable")
         scorer_model = None
-        scores = [float(s) for s in scorer(focus, texts)]
-        if len(scores) != len(items):
-            raise ValueError(
-                "scorer returned a score count that does not match the rows"
-            )
+        scores = _validated_scores(scorer(focus, texts), len(items))
     else:
         raise TypeError(
             f"scorer must be 'cross-encoder' or a callable, got {scorer!r}"
@@ -331,10 +349,12 @@ def select_thread_evidence(
 
     reserved: set[int] = set()
     if min_per_topic is not None:
+        # DISTINCT indices per topic: a row listing the same topic twice
+        # (['A', 'A']) must count once, or floor feasibility silently lies.
         by_topic: dict[str, list[int]] = {}
         for index, item in enumerate(items):
-            for topic_rid in item.get("topic_rids") or []:
-                by_topic.setdefault(str(topic_rid), []).append(index)
+            for topic_rid in {str(t) for t in item.get("topic_rids") or []}:
+                by_topic.setdefault(topic_rid, []).append(index)
         for topic_rid, indices in sorted(by_topic.items()):
             if len(indices) < min_per_topic:
                 raise ThreadSelectionPolicyInfeasible(
@@ -358,7 +378,15 @@ def select_thread_evidence(
             chosen.add(index)
     selected = sorted(chosen)  # chronological presentation
 
-    total = int(thread.get("total") or len(items))
+    total = thread.get("total", len(items))
+    if isinstance(total, bool) or not isinstance(total, int):
+        raise ValueError(
+            f"thread total must be an int, got {type(total).__name__}"
+        )
+    if total < len(items):
+        raise ValueError(
+            f"thread total {total} is smaller than its {len(items)} items"
+        )
     result = dict(thread)
     result["items"] = [items[i] for i in selected]
     result["returned"] = len(selected)

--- a/src/yantrikdb/thread.py
+++ b/src/yantrikdb/thread.py
@@ -210,3 +210,176 @@ def resolve_thread_topics(
         "store_exhausted": store_exhausted,
         "candidate_cap_reached": candidate_cap_reached,
     }
+
+
+# ── Evidence selection: retrieve wide, then compress ─────────────────
+
+# The 100k dev demonstration measured the conversion failure this stage
+# exists to fix: widening retrieval raised source-turn coverage from
+# .29 to .71 while judged score moved only +.02, because gold-turn
+# PRECISION fell to .07 (92.65% distractor rows) — and precision was the
+# strongest score signal in the zero-call readout (delta-precision to
+# delta-score r=.56/.61, monotone across quartiles). Selection keeps the
+# wide thread's coverage and restores its density: rank rows by
+# relevance to the focus, keep a budget, present chronologically.
+
+# The cross-encoder scorer honors two MEASURED constraints from the
+# rerank module (do not "fix" without re-measuring): score the row's
+# TEXT HEAD (clip 1500 chars), never a matched snippet — snippet-fed
+# reranking scored WORSE than no reranking; and treat scores as a
+# RANKING, not calibrated probabilities.
+SELECTION_CLIP = 1500
+
+
+class ThreadSelectionPolicyInfeasible(ValueError):
+    """A selection policy cannot be satisfied within the budget.
+
+    Raised when ``min_per_topic`` reservations exceed ``budget`` or
+    exceed the rows available for a represented topic. Typed so harness
+    pregates can distinguish policy infeasibility from invalid input.
+    """
+
+
+def _validated_selection_int(name: str, value: Any, *, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an int, got {type(value).__name__}")
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {value}")
+    return value
+
+
+def _cross_encoder_scores(focus: str, texts: list[str]) -> list[float]:
+    from yantrikdb.rerank import DEFAULT_MODEL, _cross_encoder
+
+    ce = _cross_encoder(DEFAULT_MODEL)
+    pairs = [(focus, text[:SELECTION_CLIP]) for text in texts]
+    return [float(s) for s in ce.predict(pairs)]
+
+
+def select_thread_evidence(
+    thread: dict[str, Any],
+    focus: str,
+    *,
+    budget: int,
+    scorer: Any = "cross-encoder",
+    min_per_topic: int | None = None,
+) -> dict[str, Any]:
+    """Select the ``budget`` most focus-relevant rows of a v2 thread.
+
+    Pure selection over a :func:`recall_thread_v2`-shaped dict: never
+    retrieves, never rewrites rows, never invents order. Ranking is by
+    relevance score descending (deterministic tie-break: original
+    chronological position ascending); the KEPT rows are then presented
+    in the thread's original chronological order. The result keeps the
+    input's ``total``, sets ``returned`` to the kept count, and sets
+    ``omitted = total - returned`` so downstream completeness semantics
+    stay true; all selection detail lives in the additive
+    ``selection`` key, from which the ranking and reservations are
+    byte-recomputable without any row text.
+
+    ``scorer`` is ``"cross-encoder"`` (the rerank module's pinned
+    model; typed ImportError if the optional dependency is missing —
+    never a silent fallback) or a callable ``(focus, texts) ->
+    scores`` for injected/deterministic scoring. ``min_per_topic`` is
+    an explicit policy: when set, each represented topic's
+    ``min_per_topic`` top-scored rows are reserved first (deduped
+    across topics; rows without topic provenance create no
+    reservation); infeasible reservations raise
+    :class:`ThreadSelectionPolicyInfeasible`.
+
+    ``budget`` must satisfy ``1 <= budget <= len(items)``; equality is
+    the identity selection (flagged in diagnostics), larger is invalid.
+    No product default budget exists yet: the recommended value will be
+    dev-calibrated and labeled as such, exactly like the resolver's
+    ``floor=12``.
+    """
+    items = thread.get("items")
+    if not isinstance(items, list) or not items:
+        raise ValueError("select_thread_evidence requires a thread with items")
+    budget = _validated_selection_int("budget", budget, minimum=1)
+    if budget > len(items):
+        raise ValueError(
+            f"budget {budget} exceeds thread rows {len(items)}; "
+            "identity selection is budget == len(items)"
+        )
+    if min_per_topic is not None:
+        min_per_topic = _validated_selection_int(
+            "min_per_topic", min_per_topic, minimum=1
+        )
+
+    texts = [str(item.get("text") or "") for item in items]
+    if scorer == "cross-encoder":
+        scorer_id = "cross-encoder"
+        from yantrikdb.rerank import DEFAULT_MODEL as scorer_model
+
+        scores = _cross_encoder_scores(focus, texts)
+    elif callable(scorer):
+        scorer_id = getattr(scorer, "__name__", "callable")
+        scorer_model = None
+        scores = [float(s) for s in scorer(focus, texts)]
+        if len(scores) != len(items):
+            raise ValueError(
+                "scorer returned a score count that does not match the rows"
+            )
+    else:
+        raise TypeError(
+            f"scorer must be 'cross-encoder' or a callable, got {scorer!r}"
+        )
+
+    # Ranking order: score desc, original chronological position asc.
+    ranked_indices = sorted(range(len(items)), key=lambda i: (-scores[i], i))
+
+    reserved: set[int] = set()
+    if min_per_topic is not None:
+        by_topic: dict[str, list[int]] = {}
+        for index, item in enumerate(items):
+            for topic_rid in item.get("topic_rids") or []:
+                by_topic.setdefault(str(topic_rid), []).append(index)
+        for topic_rid, indices in sorted(by_topic.items()):
+            if len(indices) < min_per_topic:
+                raise ThreadSelectionPolicyInfeasible(
+                    f"topic {topic_rid} has {len(indices)} rows, fewer than "
+                    f"min_per_topic={min_per_topic}"
+                )
+            top = sorted(indices, key=lambda i: (-scores[i], i))[:min_per_topic]
+            reserved.update(top)
+        if len(reserved) > budget:
+            raise ThreadSelectionPolicyInfeasible(
+                f"min_per_topic={min_per_topic} reserves {len(reserved)} "
+                f"unique rows, exceeding budget={budget}"
+            )
+
+    selected: list[int] = sorted(reserved)
+    chosen = set(reserved)
+    for index in ranked_indices:
+        if len(chosen) >= budget:
+            break
+        if index not in chosen:
+            chosen.add(index)
+    selected = sorted(chosen)  # chronological presentation
+
+    total = int(thread.get("total") or len(items))
+    result = dict(thread)
+    result["items"] = [items[i] for i in selected]
+    result["returned"] = len(selected)
+    result["omitted"] = total - len(selected)
+    result["selection"] = {
+        "scorer": scorer_id,
+        "scorer_model": scorer_model,
+        "clip": SELECTION_CLIP if scorer_id == "cross-encoder" else None,
+        "budget": budget,
+        "min_per_topic": min_per_topic,
+        "identity_selection": budget == len(items),
+        "selected_indices": selected,
+        "reserved_indices": sorted(reserved),
+        "rows": [
+            {
+                "index": index,
+                "rid": str(items[index].get("rid") or ""),
+                "score": scores[index],
+                "topic_rids": list(items[index].get("topic_rids") or []),
+            }
+            for index in range(len(items))
+        ],
+    }
+    return result

--- a/tests/test_select_thread_evidence.py
+++ b/tests/test_select_thread_evidence.py
@@ -202,7 +202,7 @@ def test_scorer_validation():
     def short_scorer(focus, texts):
         return [0.5]
 
-    with pytest.raises(ValueError, match="score count"):
+    with pytest.raises(ValueError, match="1 scores for 2 rows"):
         select_thread_evidence(thread, "f", budget=1, scorer=short_scorer)
 
 
@@ -227,3 +227,57 @@ def test_no_benchmark_imports():
         name for name in sys.modules
         if name.startswith("benchmarks") and module.__name__ in name
     ]
+
+
+def test_nonfinite_and_bool_scores_are_typed_errors():
+    thread = make_thread(3)
+    for bad in (float("nan"), float("inf"), float("-inf"), True, "0.5", None):
+        def bad_scorer(focus, texts, _bad=bad):
+            return [0.5, _bad, 0.1]
+
+        with pytest.raises(ValueError, match="row 1"):
+            select_thread_evidence(thread, "f", budget=1, scorer=bad_scorer)
+
+
+def test_cross_encoder_output_is_validated(monkeypatch):
+    # CE returning a short / non-finite vector must fail the same way as
+    # a callable scorer — the validator is shared.
+    import yantrikdb.thread as thread_mod
+
+    thread = make_thread(3)
+    monkeypatch.setattr(
+        thread_mod, "_cross_encoder_scores", lambda focus, texts: [0.5]
+    )
+    with pytest.raises(ValueError, match="1 scores for 3 rows"):
+        select_thread_evidence(thread, "f", budget=1, scorer="cross-encoder")
+    monkeypatch.setattr(
+        thread_mod,
+        "_cross_encoder_scores",
+        lambda focus, texts: [0.5, float("nan"), 0.1],
+    )
+    with pytest.raises(ValueError, match="row 1"):
+        select_thread_evidence(thread, "f", budget=1, scorer="cross-encoder")
+
+
+def test_duplicate_topic_ids_count_once_for_feasibility():
+    # One row lists topic A twice: floor=2 must be infeasible, not
+    # silently satisfied by a single unique row.
+    thread = make_thread(3, topic_map={0: ["A", "A"]})
+    with pytest.raises(ThreadSelectionPolicyInfeasible, match="fewer than"):
+        select_thread_evidence(
+            thread, "f", budget=3, scorer=scores_by_index({}),
+            min_per_topic=2,
+        )
+
+
+def test_malformed_total_is_rejected_not_coerced():
+    thread = make_thread(3)
+    thread["total"] = "10"
+    with pytest.raises(ValueError, match="total must be an int"):
+        select_thread_evidence(thread, "f", budget=2, scorer=scores_by_index({}))
+    thread["total"] = True
+    with pytest.raises(ValueError, match="total must be an int"):
+        select_thread_evidence(thread, "f", budget=2, scorer=scores_by_index({}))
+    thread["total"] = 2  # fewer than the 3 items present
+    with pytest.raises(ValueError, match="smaller than"):
+        select_thread_evidence(thread, "f", budget=2, scorer=scores_by_index({}))

--- a/tests/test_select_thread_evidence.py
+++ b/tests/test_select_thread_evidence.py
@@ -1,0 +1,229 @@
+"""Contract tests for ``select_thread_evidence`` (retrieve-wide-then-compress).
+
+Synthetic threads and injected deterministic scorers only — no benchmark
+data, no model downloads, and the module under test never imports
+benchmark code.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from yantrikdb.thread import (
+    ThreadSelectionPolicyInfeasible,
+    select_thread_evidence,
+)
+
+
+def make_thread(n, topic_map=None, total=None):
+    items = []
+    for i in range(n):
+        items.append({
+            "rid": f"row-{i:03d}",
+            "text": f"turn {i} text",
+            "created_at": 1000.0 + i,
+            "source_turn": i,
+            "position": i + 1,
+            "entities": [],
+            "routes": ["topic"],
+            "phrases": [],
+            "topic_rids": (topic_map or {}).get(i, []),
+        })
+    return {
+        "items": items,
+        "total": total if total is not None else n,
+        "returned": n,
+        "omitted": (total - n) if total is not None else 0,
+    }
+
+
+def scores_by_index(mapping, default=0.0):
+    def scorer(focus, texts):
+        return [mapping.get(i, default) for i in range(len(texts))]
+    scorer.__name__ = "fixture_scorer"
+    return scorer
+
+
+def test_selects_top_budget_and_presents_chronologically():
+    # Highest scores on late rows: selection is by score, presentation
+    # must return to chronological order.
+    thread = make_thread(6)
+    result = select_thread_evidence(
+        thread, "focus", budget=3,
+        scorer=scores_by_index({5: 0.9, 1: 0.8, 3: 0.7, 0: 0.1}),
+    )
+    assert [i["rid"] for i in result["items"]] == ["row-001", "row-003", "row-005"]
+    assert result["selection"]["selected_indices"] == [1, 3, 5]
+
+
+def test_completeness_semantics_preserved():
+    # A thread already truncated upstream: total stays, omitted grows.
+    thread = make_thread(4, total=10)
+    result = select_thread_evidence(
+        thread, "focus", budget=2, scorer=scores_by_index({0: 1.0, 1: 0.9}),
+    )
+    assert result["total"] == 10
+    assert result["returned"] == 2
+    assert result["omitted"] == 8
+
+
+def test_tie_break_is_chronological_position():
+    thread = make_thread(4)
+    result = select_thread_evidence(
+        thread, "focus", budget=2, scorer=scores_by_index({}, default=0.5),
+    )
+    assert result["selection"]["selected_indices"] == [0, 1]
+
+
+def test_identity_selection_flagged():
+    thread = make_thread(3)
+    result = select_thread_evidence(
+        thread, "focus", budget=3, scorer=scores_by_index({}),
+    )
+    assert result["selection"]["identity_selection"] is True
+    assert result["returned"] == 3
+    assert result["omitted"] == 0
+
+
+def test_budget_above_rows_is_invalid():
+    thread = make_thread(3)
+    with pytest.raises(ValueError, match="identity selection"):
+        select_thread_evidence(thread, "focus", budget=4, scorer=scores_by_index({}))
+
+
+def test_budget_and_policy_validation():
+    thread = make_thread(3)
+    with pytest.raises(ValueError):
+        select_thread_evidence(thread, "f", budget=0, scorer=scores_by_index({}))
+    with pytest.raises(TypeError):
+        select_thread_evidence(thread, "f", budget=True, scorer=scores_by_index({}))
+    with pytest.raises(TypeError):
+        select_thread_evidence(
+            thread, "f", budget=2, scorer=scores_by_index({}), min_per_topic=1.0,
+        )
+    with pytest.raises(ValueError):
+        select_thread_evidence(
+            thread, "f", budget=2, scorer=scores_by_index({}), min_per_topic=0,
+        )
+
+
+def test_min_per_topic_reserves_top_scored_per_topic():
+    # Topic A on rows 0,1; topic B on rows 2,3; global ranking would pick
+    # rows 4,5 — the floor must reserve A's and B's best first.
+    thread = make_thread(
+        6, topic_map={0: ["A"], 1: ["A"], 2: ["B"], 3: ["B"]},
+    )
+    result = select_thread_evidence(
+        thread, "focus", budget=3,
+        scorer=scores_by_index({4: 0.9, 5: 0.8, 1: 0.5, 3: 0.4, 0: 0.1, 2: 0.1}),
+        min_per_topic=1,
+    )
+    # Reserved: row 1 (A's best), row 3 (B's best); remainder: row 4.
+    assert result["selection"]["reserved_indices"] == [1, 3]
+    assert result["selection"]["selected_indices"] == [1, 3, 4]
+
+
+def test_min_per_topic_multi_topic_rows_dedupe():
+    # One row carries both topics: a single reservation satisfies both.
+    thread = make_thread(4, topic_map={1: ["A", "B"], 2: ["A"], 3: ["B"]})
+    result = select_thread_evidence(
+        thread, "focus", budget=2,
+        scorer=scores_by_index({1: 0.9, 0: 0.8, 2: 0.1, 3: 0.1}),
+        min_per_topic=1,
+    )
+    assert result["selection"]["reserved_indices"] == [1]
+    assert result["selection"]["selected_indices"] == [0, 1]
+
+
+def test_min_per_topic_infeasible_budget():
+    thread = make_thread(4, topic_map={0: ["A"], 1: ["B"], 2: ["C"]})
+    with pytest.raises(ThreadSelectionPolicyInfeasible, match="exceeding budget"):
+        select_thread_evidence(
+            thread, "focus", budget=2, scorer=scores_by_index({}),
+            min_per_topic=1,
+        )
+
+
+def test_min_per_topic_infeasible_topic_rows():
+    thread = make_thread(3, topic_map={0: ["A"]})
+    with pytest.raises(ThreadSelectionPolicyInfeasible, match="fewer than"):
+        select_thread_evidence(
+            thread, "focus", budget=3, scorer=scores_by_index({}),
+            min_per_topic=2,
+        )
+
+
+def test_topicless_rows_create_no_reservation():
+    thread = make_thread(4, topic_map={0: ["A"]})
+    result = select_thread_evidence(
+        thread, "focus", budget=2,
+        scorer=scores_by_index({3: 0.9, 0: 0.5}),
+        min_per_topic=1,
+    )
+    assert result["selection"]["reserved_indices"] == [0]
+    assert result["selection"]["selected_indices"] == [0, 3]
+
+
+def test_diagnostics_are_recomputable_without_text():
+    thread = make_thread(4, topic_map={2: ["T"]})
+    result = select_thread_evidence(
+        thread, "focus", budget=2,
+        scorer=scores_by_index({2: 0.9, 0: 0.4, 1: 0.3, 3: 0.1}),
+    )
+    rows = result["selection"]["rows"]
+    assert [r["index"] for r in rows] == [0, 1, 2, 3]
+    assert all({"index", "rid", "score", "topic_rids"} <= set(r) for r in rows)
+    assert "text" not in rows[0]
+    # Recompute the ranking from diagnostics alone.
+    ranked = sorted(rows, key=lambda r: (-r["score"], r["index"]))
+    assert [r["index"] for r in ranked][:2] == [2, 0]
+    assert result["selection"]["selected_indices"] == [0, 2]
+
+
+def test_determinism_repeat():
+    thread = make_thread(8, topic_map={1: ["A"], 5: ["A"]})
+    scorer = scores_by_index({1: 0.7, 5: 0.7, 2: 0.6})
+    first = select_thread_evidence(
+        thread, "focus", budget=3, scorer=scorer, min_per_topic=1,
+    )
+    second = select_thread_evidence(
+        thread, "focus", budget=3, scorer=scorer, min_per_topic=1,
+    )
+    assert first == second
+
+
+def test_scorer_validation():
+    thread = make_thread(2)
+    with pytest.raises(TypeError, match="scorer must be"):
+        select_thread_evidence(thread, "f", budget=1, scorer=123)
+
+    def short_scorer(focus, texts):
+        return [0.5]
+
+    with pytest.raises(ValueError, match="score count"):
+        select_thread_evidence(thread, "f", budget=1, scorer=short_scorer)
+
+
+def test_empty_thread_raises():
+    with pytest.raises(ValueError, match="requires a thread with items"):
+        select_thread_evidence({"items": []}, "f", budget=1)
+
+
+def test_input_thread_not_mutated():
+    thread = make_thread(4)
+    before = [i["rid"] for i in thread["items"]]
+    select_thread_evidence(
+        thread, "focus", budget=2, scorer=scores_by_index({3: 1.0}),
+    )
+    assert [i["rid"] for i in thread["items"]] == before
+    assert "selection" not in thread
+
+
+def test_no_benchmark_imports():
+    module = sys.modules["yantrikdb.thread"]
+    assert not [
+        name for name in sys.modules
+        if name.startswith("benchmarks") and module.__name__ in name
+    ]


### PR DESCRIPTION
## What

The selection stage the 100k dev demonstration proved missing: wide thread retrieval raised evidence coverage .29→.71 but judged score moved only +0.019, because gold-turn **precision** collapsed to .07 (92.65% distractors) — and the zero-call readout found precision the strongest score signal measured in this project (Δprecision→Δscore r=.56/.61, monotone quartiles), position second, coverage third once wide, raw length ~null.

`select_thread_evidence(thread, focus, *, budget, scorer, min_per_topic)`:
- Ranks a wide `recall_thread_v2` result's rows by relevance to the focus (cross-encoder scorer honoring the rerank module's **measured** constraints: text head clipped at 1500 chars, scores used as ranking), keeps `budget` rows, presents them in original chronological order.
- v2 dict shape preserved (`total` unchanged, `returned`/`omitted` true); all selection detail additive under `selection`, byte-recomputable from per-row index/rid/score/topic_rids without any row text.
- `min_per_topic` is an explicit policy with typed `ThreadSelectionPolicyInfeasible` on both infeasibility cases; multi-topic rows dedupe reservations; topic-less rows reserve nothing.
- No product default budget — the recommendation ships later, dev-calibrated and labeled as such (same discipline as the resolver's `floor=12`).
- Disclosed contract deviation: no embedding fallback scorer — the binding exposes no text-embed surface; `scorer` is `"cross-encoder"` or an injected callable, and a missing optional dependency is a typed error, never a silent fallback.

Contract co-designed and countersigned in the swarm channel (four edge clarifications folded: completeness semantics, multi-topic dedupe + PolicyInfeasible, validation/identity rules, recomputable diagnostics).

## Verification

16 new tests green **against the installed release wheel** (43 with the thread/resolver suites): ranked-selection + chronological presentation, completeness semantics, tie-breaks, identity flag, reservation/dedupe/infeasibility, recomputable diagnostics, determinism repeat, typed errors, input non-mutation, no benchmark imports. flake8 + pylint(E) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)