### PR TITLE
fix(py): organize.py imported datetime.UTC (3.11+) — package supports 3.10; release v0.17.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }}, ${{ matrix.target }})
+    name: Test (${{ matrix.os }}, ${{ matrix.target }}, py${{ matrix.python || '3.13' }})
     runs-on: ${{ matrix.os }}
     # Hard cap so a genuine test hang fails fast instead of running until the
     # 24-hour workflow ceiling. (Note: this bounds a job once it STARTS — it

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,12 @@ jobs:
           # Linux x86_64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+          # Linux x86_64 on the OLDEST supported Python (requires-python >=3.10).
+          # 0.16.0/0.17.0 shipped a `from datetime import UTC` (3.11+) that this
+          # leg would have caught.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            python: "3.10"
           # Linux aarch64
           - os: ubuntu-26.04-arm
             target: aarch64-unknown-linux-gnu
@@ -57,7 +63,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python || '3.13' }}
 
       - name: Install maturin and dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }}, ${{ matrix.target }}, py${{ matrix.python || '3.13' }})
+    name: Test (${{ matrix.os }}, ${{ matrix.target }})${{ matrix.python && format(' [py{0}]', matrix.python) || '' }}
     runs-on: ${{ matrix.os }}
     # Hard cap so a genuine test hang fails fast instead of running until the
     # 24-hour workflow ceiling. (Note: this bounds a job once it STARTS — it

--- a/benchmarks/amb/build_topic_card_contexts.py
+++ b/benchmarks/amb/build_topic_card_contexts.py
@@ -8,8 +8,11 @@ import json
 import math
 import re
 from collections import Counter
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
+
+# `datetime.UTC` is 3.11+; the repository's floor is 3.10 (requires-python >=3.10).
+UTC = timezone.utc
 
 
 TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)

--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.17.0"
+version = "0.17.1"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "Apache-2.0"

--- a/packs/build.py
+++ b/packs/build.py
@@ -31,6 +31,8 @@ import argparse
 import re
 import shutil
 import tempfile
+from pathlib import Path
+
 try:  # py310-ok: tomllib is 3.11+; tomli is the backport
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10
@@ -38,7 +40,6 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
         import tomli as tomllib  # type: ignore[no-redef]
     except ModuleNotFoundError as e:
         raise SystemExit("packs tooling needs Python 3.11+ or `pip install tomli` on 3.10") from e
-from pathlib import Path
 
 from yantrikdb import YantrikDB
 

--- a/packs/build.py
+++ b/packs/build.py
@@ -31,7 +31,13 @@ import argparse
 import re
 import shutil
 import tempfile
-import tomllib
+try:  # py310-ok: tomllib is 3.11+; tomli is the backport
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError as e:
+        raise SystemExit("packs tooling needs Python 3.11+ or `pip install tomli` on 3.10") from e
 from pathlib import Path
 
 from yantrikdb import YantrikDB

--- a/packs/evaluate.py
+++ b/packs/evaluate.py
@@ -261,7 +261,13 @@ def grade(answer: str, expect: list[list[str]], reject: list[str] | None = None)
 def pack_setting(pack: str, key: str, fallback):
     """A retrieval parameter the pack declares for itself."""
     try:
-        import tomllib
+        try:  # py310-ok: tomllib is 3.11+; tomli is the backport
+            import tomllib
+        except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+            try:
+                import tomli as tomllib  # type: ignore[no-redef]
+            except ModuleNotFoundError as e:
+                raise SystemExit("packs tooling needs Python 3.11+ or `pip install tomli` on 3.10") from e
         cfg = tomllib.loads(
             (Path(__file__).resolve().parent / pack / "pack.toml")
             .read_text(encoding="utf-8"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.17.0"
+version = "0.17.1"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/yantrikdb/organize.py
+++ b/src/yantrikdb/organize.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+# `datetime.UTC` is 3.11+; the package supports 3.10 (requires-python >=3.10).
+UTC = timezone.utc
 from typing import Callable, Iterable, Mapping, Sequence
 
 from yantrikdb.consolidate import record_synthesis

--- a/src/yantrikdb/organize.py
+++ b/src/yantrikdb/organize.py
@@ -11,12 +11,12 @@ import math
 import re
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-
-# `datetime.UTC` is 3.11+; the package supports 3.10 (requires-python >=3.10).
-UTC = timezone.utc
 from typing import Callable, Iterable, Mapping, Sequence
 
 from yantrikdb.consolidate import record_synthesis
+
+# `datetime.UTC` is 3.11+; the package supports 3.10 (requires-python >=3.10).
+UTC = timezone.utc
 
 
 @dataclass(frozen=True)

--- a/tests/test_python_floor_compat.py
+++ b/tests/test_python_floor_compat.py
@@ -8,6 +8,10 @@ leg — this scan covers every git-tracked Python file instead.
 
 A line that deliberately uses a 3.11+ name behind a guard must carry the
 ``# py310-ok`` marker on (or within three lines above) the use.
+
+The scanner itself is tested: every pattern must detect its canonical
+offender, a guarded use must be accepted, and clean code must produce nothing —
+otherwise a broken regex would make the repository-wide check vacuously green.
 """
 from __future__ import annotations
 
@@ -15,7 +19,10 @@ import re
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
+GUARD_MARKER = "# py310-ok"
 
 PATTERNS: dict[str, re.Pattern[str]] = {
     "datetime.UTC (3.11+; use timezone.utc)": re.compile(
@@ -35,6 +42,34 @@ PATTERNS: dict[str, re.Pattern[str]] = {
     ),
 }
 
+# One canonical offender per pattern. Each MUST be detected.
+FORBIDDEN_SAMPLES: dict[str, str] = {
+    "datetime.UTC (3.11+; use timezone.utc)": "from datetime import UTC, datetime",
+    "enum.StrEnum (3.11+)": "from enum import StrEnum",
+    "tomllib (3.11+ stdlib; guard with a tomli fallback)": "import tomllib",
+    "typing.Self (3.11+)": "from typing import Self",
+    "ExceptionGroup / except* (3.11+)": "except* ValueError as eg:",
+}
+
+
+def _find_offenders(lines: list[str]) -> list[tuple[int, str, str]]:
+    """Return ``(1-based line number, pattern label, stripped line)`` for every
+    unguarded use of a 3.11+-only name in ``lines``."""
+    found: list[tuple[int, str, str]] = []
+    for i, line in enumerate(lines):
+        code = line.split("#", 1)[0]
+        if not code.strip():
+            continue
+        guarded = any(
+            GUARD_MARKER in lines[j] for j in range(max(0, i - 3), i + 1)
+        )
+        if guarded:
+            continue
+        for label, rx in PATTERNS.items():
+            if rx.search(code):
+                found.append((i + 1, label, line.strip()))
+    return found
+
 
 def _tracked_python_files() -> list[Path]:
     out = subprocess.run(
@@ -44,10 +79,34 @@ def _tracked_python_files() -> list[Path]:
     return [ROOT / line.strip() for line in out.stdout.splitlines() if line.strip()]
 
 
-def _guarded(lines: list[str], idx: int) -> bool:
-    """A use whose own line or one of the three lines above carries
-    ``# py310-ok`` is a deliberate, guarded use."""
-    return any("# py310-ok" in lines[j] for j in range(max(0, idx - 3), idx + 1))
+@pytest.mark.parametrize("label", sorted(PATTERNS))
+def test_scanner_detects_each_forbidden_sample(label: str) -> None:
+    sample = FORBIDDEN_SAMPLES[label]
+    found = _find_offenders(["import os", sample, "x = 1"])
+    assert [(n, lab) for n, lab, _ in found] == [(2, label)], found
+
+
+def test_scanner_accepts_a_guarded_use() -> None:
+    lines = [
+        "try:  # py310-ok: tomllib is 3.11+; tomli is the backport",
+        "    import tomllib",
+        "except ModuleNotFoundError:",
+        "    import tomli as tomllib",
+    ]
+    assert _find_offenders(lines) == []
+
+
+def test_scanner_is_silent_on_clean_code() -> None:
+    lines = [
+        "from datetime import datetime, timezone",
+        "UTC = timezone.utc",
+        "from enum import Enum",
+        "try:",
+        "    x = 1",
+        "except ValueError as e:",
+        "    raise",
+    ]
+    assert _find_offenders(lines) == []
 
 
 def test_no_python_311_only_names_anywhere_in_the_repository() -> None:
@@ -56,13 +115,8 @@ def test_no_python_311_only_names_anywhere_in_the_repository() -> None:
         if path.name == Path(__file__).name:
             continue
         lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        for i, line in enumerate(lines):
-            code = line.split("#", 1)[0]
-            for label, rx in PATTERNS.items():
-                if rx.search(code) and not _guarded(lines, i):
-                    offenders.append(
-                        f"{path.relative_to(ROOT)}:{i + 1}: {label}: {line.strip()}"
-                    )
+        for lineno, label, text in _find_offenders(lines):
+            offenders.append(f"{path.relative_to(ROOT)}:{lineno}: {label}: {text}")
     assert not offenders, (
         "Python 3.11+-only names in a repository whose floor is 3.10:\n  "
         + "\n  ".join(offenders)

--- a/tests/test_python_floor_compat.py
+++ b/tests/test_python_floor_compat.py
@@ -1,0 +1,69 @@
+"""The repository's Python floor is 3.10 (``requires-python = ">=3.10"``).
+
+Names that only exist on 3.11+ have shipped twice: 0.16.0 and 0.17.0 carried
+``from datetime import UTC`` in a module the package imports eagerly, so
+``import yantrikdb`` raised ImportError on 3.10. CI now runs a 3.10 leg for the
+package, but benchmark and pack tooling outside ``src/`` is not imported by that
+leg — this scan covers every git-tracked Python file instead.
+
+A line that deliberately uses a 3.11+ name behind a guard must carry the
+``# py310-ok`` marker on (or within three lines above) the use.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PATTERNS: dict[str, re.Pattern[str]] = {
+    "datetime.UTC (3.11+; use timezone.utc)": re.compile(
+        r"from datetime import[^#\n]*\bUTC\b|datetime\.UTC\b"
+    ),
+    "enum.StrEnum (3.11+)": re.compile(
+        r"from enum import[^#\n]*\bStrEnum\b|enum\.StrEnum\b"
+    ),
+    "tomllib (3.11+ stdlib; guard with a tomli fallback)": re.compile(
+        r"^\s*(import tomllib\b|from tomllib\b)"
+    ),
+    "typing.Self (3.11+)": re.compile(
+        r"from typing import[^#\n]*\bSelf\b|typing\.Self\b"
+    ),
+    "ExceptionGroup / except* (3.11+)": re.compile(
+        r"\bExceptionGroup\b|except\s*\*"
+    ),
+}
+
+
+def _tracked_python_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    )
+    return [ROOT / line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
+def _guarded(lines: list[str], idx: int) -> bool:
+    """A use whose own line or one of the three lines above carries
+    ``# py310-ok`` is a deliberate, guarded use."""
+    return any("# py310-ok" in lines[j] for j in range(max(0, idx - 3), idx + 1))
+
+
+def test_no_python_311_only_names_anywhere_in_the_repository() -> None:
+    offenders: list[str] = []
+    for path in _tracked_python_files():
+        if path.name == Path(__file__).name:
+            continue
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for i, line in enumerate(lines):
+            code = line.split("#", 1)[0]
+            for label, rx in PATTERNS.items():
+                if rx.search(code) and not _guarded(lines, i):
+                    offenders.append(
+                        f"{path.relative_to(ROOT)}:{i + 1}: {label}: {line.strip()}"
+                    )
+    assert not offenders, (
+        "Python 3.11+-only names in a repository whose floor is 3.10:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
`src/yantrikdb/organize.py` did `from datetime import UTC` — a Python 3.11+ name — while `requires-python = ">=3.10"`. The module is imported eagerly from `yantrikdb/__init__.py`, so **`import yantrikdb` raises `ImportError` on Python 3.10**. Introduced in 0.16.0 (#145), shipped again in 0.17.0.

Found by downstream CI the moment it picked up 0.17.0: yantrikdb-mcp's publish (py3.10 legs) and langchain-yantrikdb's py3.10 legs fail with exactly this ImportError; neither repo uses `datetime.UTC` itself. Core's own CI runs a single Python (3.13), which is why it never saw it — a 3.10 leg is added on this branch.

Fix: `UTC = timezone.utc` (identical semantics). Verified: `import yantrikdb` + organize/concern/thread/rollup tests (157 passed) against the installed 0.17.0 engine with the patched module.

Intended release: **0.17.1** (patch), pending operator go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)