### PR TITLE
packs: a pack sealed before a column existed must still mount

### DIFF
--- a/crates/yantrikdb-core/src/engine/cache.rs
+++ b/crates/yantrikdb-core/src/engine/cache.rs
@@ -6,18 +6,59 @@ use crate::types::ScoringRow;
 use super::YantrikDB;
 
 impl YantrikDB {
+    /// Columns that exist on `table` right now.
+    ///
+    /// Needed because this loader runs against two very different databases:
+    /// the host's (always migrated to the current schema before use) and a
+    /// **mounted pack's** (opened read-only from a file some other engine
+    /// sealed, and never migratable — see `pack::mount_pack_opts`).
+    fn existing_columns(
+        conn: &rusqlite::Connection,
+        table: &str,
+    ) -> Result<std::collections::HashSet<String>> {
+        let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+        let mut out = std::collections::HashSet::new();
+        for row in rows {
+            out.insert(row?);
+        }
+        Ok(out)
+    }
+
     /// Load scoring-relevant fields for all non-tombstoned memories into a HashMap.
+    ///
+    /// **The projection is schema-aware, and has to be.** A mounted pack
+    /// carries whatever schema its publisher's engine wrote and can never be
+    /// migrated (it is opened `query_only`, and rewriting a signed publisher
+    /// artifact is not an option). Columns added after that seal are therefore
+    /// legitimately absent: the v41→v42 synthesis triplet is missing from every
+    /// pack published by an engine at or below 0.15.x. A fixed projection made
+    /// all of them fail to mount with `no such column: synthesis_state` — a
+    /// break the host path could never surface, because a host database is
+    /// always migrated before this runs. Absent columns read as NULL, which is
+    /// exactly what v42 migrates existing host rows to.
     pub(crate) fn load_scoring_cache(
         conn: &rusqlite::Connection,
     ) -> Result<HashMap<String, ScoringRow>> {
-        let mut stmt = conn.prepare(
+        let present = Self::existing_columns(conn, "memories")?;
+        let project = |name: &str| -> String {
+            if present.contains(name) {
+                name.to_string()
+            } else {
+                format!("NULL AS {name}")
+            }
+        };
+        let sql = format!(
             "SELECT rid, created_at, importance, half_life, last_access, \
              valence, consolidation_status, type, namespace, access_count, \
-             certainty, domain, source, emotional_state, synthesis_state, \
-             synthesis_axis, synthesis_granularity \
+             certainty, domain, source, emotional_state, {}, {}, {} \
              FROM memories \
              WHERE consolidation_status != 'tombstoned'",
-        )?;
+            project("synthesis_state"),
+            project("synthesis_axis"),
+            project("synthesis_granularity"),
+        );
+        let mut stmt = conn.prepare(&sql)?;
 
         let rows = stmt.query_map([], |row| {
             Ok((

--- a/crates/yantrikdb-core/tests/pack_mount.rs
+++ b/crates/yantrikdb-core/tests/pack_mount.rs
@@ -289,6 +289,90 @@ fn bounded_recall_excludes_mounted_pack_rows() {
     );
 }
 
+/// **A pack sealed before a column existed must still mount.** Packs published
+/// by engines at or below 0.15.x carry schema v41, which predates the v41→v42
+/// synthesis triplet; the pack file is opened read-only and can never be
+/// migrated. Before the projection became schema-aware, every one of them
+/// failed at mount with `no such column: synthesis_state`, and the host path
+/// could not surface it because a host database is always migrated first.
+///
+/// The fixture drops those columns from a sealed pack, which is exactly the
+/// shape a pre-v42 publisher wrote (and leaves the content digest — taken over
+/// rid and text — intact, so the pack still verifies).
+#[test]
+fn pack_sealed_before_the_synthesis_columns_still_mounts() {
+    let dir = tmpdir("pre-v42");
+    let pack = dir.join("physics.ydbpack");
+    build_pack(
+        &dir,
+        pack.to_str().unwrap(),
+        "E0",
+        &[("gluons bind quarks", 3), ("quarks carry color charge", 4)],
+    );
+
+    {
+        // Rebuild `memories` without any synthesis_* column — the pre-v42
+        // shape. (A plain DROP COLUMN cannot remove the CHECK-constrained
+        // ones, and v42 adds five columns, not three.)
+        let conn = rusqlite::Connection::open(&pack).unwrap();
+        let kept: Vec<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(memories)").unwrap();
+            let rows = stmt
+                .query_map([], |r| r.get::<_, String>(1))
+                .unwrap()
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .unwrap();
+            rows.into_iter()
+                .filter(|c| !c.starts_with("synthesis_"))
+                .collect()
+        };
+        assert!(kept.iter().any(|c| c == "rid"), "sanity: rid survives");
+        let cols = kept.join(", ");
+        conn.execute_batch(&format!(
+            "PRAGMA foreign_keys=OFF;
+             CREATE TABLE memories_pre_v42 AS SELECT {cols} FROM memories;
+             DROP TABLE memories;
+             ALTER TABLE memories_pre_v42 RENAME TO memories;"
+        ))
+        .unwrap();
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('memories') \n                 WHERE name GLOB 'synthesis_*'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 0, "fixture must have no synthesis columns");
+    }
+
+    let db = host(&dir, "E0");
+    let id = db
+        .mount_pack(pack.to_str().unwrap())
+        .expect("a pre-v42 pack must still mount");
+    assert_eq!(db.mounted_packs()[0].rows, 2);
+
+    // And it must actually serve content, not merely mount.
+    let texts = recall_texts(&db, &vec_on(3, 0.05), 5);
+    assert!(
+        texts.iter().any(|t| t.contains("gluons")),
+        "pre-v42 pack mounted but returned nothing: {texts:?}"
+    );
+
+    // The rows behave like ordinary (non-synthesized) rows, which is what
+    // v42 migrates existing host rows to.
+    let hits = db
+        .recall_from_packs_for(
+            &[&id],
+            &vec_on(3, 0.05),
+            5,
+            None,
+            &yantrikdb::PackRecallOptions::default(),
+        )
+        .unwrap();
+    assert!(!hits.is_empty());
+    assert!(hits.iter().all(|h| h.pack.as_ref().unwrap().pack_id == id));
+}
+
 #[test]
 fn mount_then_recall_finds_pack_content() {
     let dir = tmpdir("recall");


### PR DESCRIPTION
**Every pack published before 0.16 has been unmountable since 0.16.0**, including the ones on packs.yantrikdb.com. Found by Codex while integrating the pack line into yantrik-mind; confirmed on 0.18.

## The break

`load_scoring_cache` projects the v41→v42 synthesis triplet unconditionally. It is shared by two databases with different guarantees:

- the **host's** — always migrated before it runs, so the columns are always there and the break is invisible;
- a **mounted pack's** — opened `query_only` from a file some other engine sealed, never migratable. Columns added after that seal are legitimately absent, and the mount dies with `no such column: synthesis_state`.

Reproduced against a real PyPI `yantrikdb==0.15.6`: seal a pack with its bundled `potion-base-2M` identity (schema 41, zero `synthesis_*` columns) → mounting on the built 0.18 wheel fails. With this change the same artifact mounts, ranks and serves through both `recall` and `recall_from_packs_for`.

## The fix

The projection is built from the columns that exist; absent ones read as `NULL` — exactly what v42 migrates existing host rows to. The publisher's signed artifact is never rewritten.

Audited every other query that runs against a pack connection — content digest (`rid, text`), index build (`rid, embedding, consolidation_status, storage_tier`), hydration (`rid, text, metadata`), `convert_pack` (incl. `created_at_unix_micros`): all present at schema 41, so the scoring cache was the only break.

## The regression

`pack_sealed_before_the_synthesis_columns_still_mounts` rebuilds `memories` without any `synthesis_*` column — v42 adds **five**, and a plain `DROP COLUMN` cannot remove the CHECK-constrained ones — then asserts mount, row count, recall and allowlist recall. Verified **red without the fix** with the exact production error, green with it.

Gates: fmt clean, clippy 0 errors, core suite 2097 passed, pack_mount 26, pack_allowlist 16, plus the end-to-end mount of the genuine 0.15.6 artifact.

Blocks the v0.18.0 tag.