### PR TITLE
chore: ignore credential-bearing local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,16 @@ packs/training/
 
 # Internal retrieval knowledge — never publish
 docs/ALGORITHMS.md
+.qwen/
+
+# ── Local config that carries credentials ────────────────────────────
+# Kept in step across the YantrikDB repos after a `git add -A` swept a
+# live API key out of `.mcp.json` into a commit on 2026-08-26; only
+# GitHub push protection stopped it being published.
+.mcp.json
+.mcp.local.json
+.env
+.env.*
+!.env.example
+.claude/
+*.local.json


### PR DESCRIPTION
Kept in step across the YantrikDB repos after a careless `git add -A` swept a live API key out of `.mcp.json` into a commit in `yantrikdb-mcp` on 2026-08-26. **Only GitHub's push protection stopped it from being published.**

An audit across the repos found only `yantrikdb-server` fully protected — every other repo was missing at least one of `.mcp.json`, `.env`, `.claude/`, and **7 of 8** did not ignore `.claude/settings.local.json`.

This adds the same block everywhere so the protection does not depend on which repo you happen to be standing in.

`.gitignore` only — no code change.