### PR TITLE
Relation extraction precision: anchor patterns to the adjacent pair, runs ≠ leads, chain hops skip generic links (production census 1,135 → 50 claims, junk 37% → 16%)

### DIFF
--- a/benchmarks/prod_extraction_census.py
+++ b/benchmarks/prod_extraction_census.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Re-ingest a corpus's texts into a fresh store and census what the CURRENT
+engine build extracts: claims by relation, junk share, entity-table quality,
+and claim-chain exposure. Judge-free; run once per build and diff.
+
+Why this exists (2026-09-05): on the production memory store the claims
+table was 57% `leads`, 877 of them minted from the word "runs" ("CT128 runs
+0.15.2"), and 63% of the claims that survive read-side phantom suppression
+were junk edges such as `Python -leads-> R8g`. Claim-chain traversal walks
+exactly those. BEAM cannot see any of this. This census is the instrument
+that can.
+
+Input: a JSON array of {rid, namespace, created_at, memory_type, text}
+(exported from the store with sqlite3 -json). The corpus never needs to
+leave the operator's machines; the census reports aggregates and a small,
+optional sample.
+
+    python benchmarks/prod_extraction_census.py --texts prod_active_texts.json \
+        --label main --out census-main.json [--limit N] [--sample 12]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+def is_junk_endpoint(name: str) -> bool:
+    """Mechanical junk rule, mirrors the engine's read-side rejection plus
+    the concrete shapes seen on production (None, bare numbers, versions)."""
+    n = name.strip()
+    if not n or not any(c.isalpha() for c in n):
+        return True
+    if n in {"None", "null", "NULL"}:
+        return True
+    toks = n.split()
+    if len(toks) > 6:
+        return True
+    allcaps = [t for t in toks if t.isupper() and any(c.isalpha() for c in t)]
+    return len(allcaps) > 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--texts", type=Path, required=True)
+    ap.add_argument("--label", required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--limit", type=int)
+    ap.add_argument("--sample", type=int, default=12)
+    ap.add_argument("--chain-deny", default="co_occurs_with,related_to",
+                    help="relations the chain-hop deny-list excludes (for the exposure count)")
+    args = ap.parse_args()
+
+    import yantrikdb
+
+    rows = json.load(open(args.texts, encoding="utf-8"))
+    if args.limit:
+        rows = rows[: args.limit]
+    store_dir = Path(tempfile.mkdtemp(prefix="census-"))
+    path = store_dir / "census.db"
+    db = yantrikdb.YantrikDB.with_default(str(path))
+    t0 = time.perf_counter()
+    for r in rows:
+        db.record(
+            r["text"], memory_type=r.get("memory_type") or "episodic",
+            namespace=r.get("namespace") or "default",
+            created_at=float(r["created_at"]) if r.get("created_at") else None,
+        )
+    ingest_s = time.perf_counter() - t0
+    # Drain the materializer deterministically (think drains <= 4096 ops per call).
+    t0 = time.perf_counter()
+    drained = 0
+    for _ in range(1 + len(rows) // 2000):
+        db.think({"run_consolidation": False, "run_pattern_mining": False})
+        drained += 1
+    drain_s = time.perf_counter() - t0
+    db.close()
+
+    conn = sqlite3.connect(str(path))
+    claims = conn.execute(
+        "SELECT src, rel_type, dst, extractor, source_memory_rid FROM claims WHERE tombstoned=0"
+    ).fetchall()
+    entities = conn.execute("SELECT name, entity_type, mention_count FROM entities").fetchall()
+    n_mem = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+    conn.close()
+
+    by_rel = Counter(c[1] for c in claims)
+    by_ext = Counter(c[3] for c in claims)
+    junk = [c for c in claims if is_junk_endpoint(c[0]) or is_junk_endpoint(c[2])]
+    clean = [c for c in claims if c not in junk]
+    clean_by_rel = Counter(c[1] for c in clean)
+    deny = set(x.strip() for x in args.chain_deny.split(",") if x.strip())
+    # Chain exposure: edges a hop-2 traversal could follow = clean (both endpoints
+    # pass the read-side predicate), provenance-bearing, not deny-listed.
+    exposure = [c for c in clean if c[4] and c[1] not in deny]
+    exposure_by_rel = Counter(c[1] for c in exposure)
+    ent_junk = sum(1 for e in entities if is_junk_endpoint(e[0]))
+    ent_top = sorted(entities, key=lambda e: -(e[2] or 0))[:12]
+
+    # "runs"-as-leads on this corpus: leads claims whose source text says " runs ".
+    text_by_rid = {}
+    # We cannot map fresh rids back to the input rids without the memory text; use text match.
+    conn = sqlite3.connect(str(path))
+    leads_from_runs = conn.execute(
+        "SELECT COUNT(*) FROM claims c JOIN memories m ON m.rid=c.source_memory_rid "
+        "WHERE c.tombstoned=0 AND c.rel_type='leads' AND lower(m.text) LIKE '% runs %'"
+    ).fetchone()[0]
+    runs_rel = conn.execute(
+        "SELECT COUNT(*) FROM claims WHERE tombstoned=0 AND rel_type='runs'"
+    ).fetchone()[0]
+    place = conn.execute(
+        "SELECT COUNT(*) FROM claims WHERE tombstoned=0 AND rel_type IN ('lives_in','hometown')"
+    ).fetchone()[0]
+    conn.close()
+
+    out = {
+        "label": args.label,
+        "engine_version": yantrikdb.__version__,
+        "engine_file": yantrikdb.__file__,
+        "memories": n_mem,
+        "ingest_seconds": round(ingest_s, 1),
+        "drain_calls": drained,
+        "drain_seconds": round(drain_s, 1),
+        "claims_total": len(claims),
+        "claims_by_extractor": dict(by_ext),
+        "claims_by_rel": dict(by_rel.most_common()),
+        "junk_claims": len(junk),
+        "junk_share": round(len(junk) / len(claims), 4) if claims else None,
+        "clean_claims": len(clean),
+        "clean_by_rel": dict(clean_by_rel.most_common()),
+        "leads_total": by_rel.get("leads", 0),
+        "leads_from_runs_sentences": leads_from_runs,
+        "runs_relation_claims": runs_rel,
+        "place_claims_lives_in_hometown": place,
+        "chain_exposure_edges": len(exposure),
+        "chain_exposure_by_rel": dict(exposure_by_rel.most_common()),
+        "entities_total": len(entities),
+        "entities_junk": ent_junk,
+        "entities_top12": [{"name": e[0], "type": e[1], "mentions": e[2]} for e in ent_top],
+        "sample_clean_leads": [f"{c[0]} -leads-> {c[2]}" for c in clean if c[1] == "leads"][: args.sample],
+        "sample_junk": [f"{c[0]} -{c[1]}-> {c[2]}" for c in junk][: args.sample],
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    json.dump(out, open(args.out, "w", encoding="utf-8"), indent=1)
+    print(json.dumps({k: v for k, v in out.items() if not k.startswith("sample") and k not in ("claims_by_rel", "clean_by_rel", "chain_exposure_by_rel", "entities_top12")}, indent=1))
+    print("top rels:", by_rel.most_common(8))
+    print("chain exposure by rel:", exposure_by_rel.most_common(8))
+    print("top entities:", [(e[0], e[2]) for e in ent_top[:8]])
+    print("clean leads sample:", out["sample_clean_leads"][:6])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/yantrikdb-core/src/engine/claims_lane.rs
+++ b/crates/yantrikdb-core/src/engine/claims_lane.rs
@@ -70,6 +70,18 @@ const PATH_CLAIM_LEX: f64 = 0.9;
 /// Marker inside a path why; the reserve reads it to rank paths below
 /// direct claims without a second why family.
 const PATH_MARKER: &str = "(path via ";
+/// Relations a hop-2 traversal must NOT follow: generic co-occurrence and
+/// catch-all links carry no direction and no meaning, so a chain through
+/// them attaches confident path provenance to noise. Hop-1 still reads
+/// them (a query entity's own co-occurrences are legitimate evidence);
+/// only the traversal is gated. Measured 2026-09-05 on the production
+/// store: `co_occurs_with` was 509 of 2,576 claims.
+const CHAIN_DENY_RELS: &[&str] = &["co_occurs_with", "related_to", "mentions"];
+
+/// May a hop-2 traversal follow this relation? (Deny-list, see above.)
+pub(crate) fn chain_traversable(rel_type: &str) -> bool {
+    !CHAIN_DENY_RELS.contains(&rel_type)
+}
 
 /// A claims-lane candidate: the claim's source record plus the
 /// directional provenance that justifies its admission.
@@ -220,7 +232,8 @@ pub(crate) fn claims_candidates(
         for (src, rel, dst, rid, polarity) in claims_touching(conn, entity, namespace) {
             let neg = if polarity < 0 { "NOT " } else { "" };
             let far = if src == *entity { &dst } else { &src };
-            if !anchor_names.contains(far.as_str())
+            if chain_traversable(&rel)
+                && !anchor_names.contains(far.as_str())
                 && path_seeds.len() < MAX_PATH_SEEDS
                 && !path_seeds.iter().any(|(seed, _, _)| seed == far)
             {
@@ -257,6 +270,9 @@ pub(crate) fn claims_candidates(
         for (src, rel, dst, rid, polarity) in rows {
             if per_seed >= MAX_PATH_PER_SEED || path_admitted >= MAX_PATH_CANDIDATES {
                 break;
+            }
+            if !chain_traversable(&rel) {
+                continue; // generic link: never the second hop of a path
             }
             if !seen.insert(rid.clone()) {
                 continue; // hop-1 provenance, or the hop-1 claim read backwards
@@ -750,6 +766,39 @@ mod tests {
             "hub must not be traversed: {:?}",
             cands.iter().map(|c| &c.why).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn chain_never_follows_a_denied_relation() {
+        // Alice -works_at-> Fennwick (hop 1) ; Fennwick -co_occurs_with-> Lisbon
+        // must NOT become a path: co-occurrence carries no meaning to chain on.
+        let conn = chain_store();
+        conn.execute(
+            "INSERT INTO entities (name, entity_type, first_seen, last_seen, mention_count) \
+             VALUES ('Lisbon', 'place', 0.0, 0.0, 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO claims (claim_id, src, dst, rel_type, created_at, \
+             extractor, source_memory_rid) VALUES ('cX', 'Fennwick Labs', 'Lisbon', \
+             'co_occurs_with', 30.0, 'heuristic_v1', 'mX')",
+            [],
+        )
+        .unwrap();
+        let gi = GraphIndex::build_from_db(&conn).unwrap();
+        let tokens = crate::graph::tokenize("which city does Alice Moreau work in");
+        let cands = claims_candidates(&conn, &gi, &tokens, None);
+        assert!(
+            cands.iter().any(|c| c.rid == "mB"),
+            "real hop-2 still admitted"
+        );
+        assert!(
+            !cands.iter().any(|c| c.rid == "mX"),
+            "co_occurs_with hop must not be followed"
+        );
+        // And a denied hop-1 relation seeds nothing.
+        assert!(!chain_traversable("co_occurs_with") && chain_traversable("works_at"));
     }
 
     #[test]

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -699,6 +699,15 @@ fn contains_phrase_end_bounded(hay: &str, phrase: &str) -> bool {
     false
 }
 
+/// Drop trailing articles so "works at the" still anchors on "works at".
+fn strip_trailing_articles(window: &str) -> String {
+    let mut toks: Vec<&str> = window.split_whitespace().collect();
+    while matches!(toks.last().copied(), Some("the" | "a" | "an")) {
+        toks.pop();
+    }
+    toks.join(" ")
+}
+
 fn boundary_before(hay: &str, at: usize) -> bool {
     at == 0
         || !hay[..at]
@@ -728,8 +737,11 @@ pub fn extract_learned_relations(
     }
     let mut candidates = Vec::new();
     for w in between_windows(text, entities) {
+        if w.has_inner_entity {
+            continue;
+        }
         for (phrase, rel_type) in templates {
-            if ends_with_word_phrase(&w.between_stripped, phrase) {
+            if ends_with_word_phrase(&strip_trailing_articles(&w.between_stripped), phrase) {
                 candidates.push(RelationCandidate {
                     src: w.entity_a.to_string(),
                     rel_type: rel_type.clone(),
@@ -756,6 +768,9 @@ struct BetweenWindow<'a> {
     between_stripped: String,
     polarity: i32,
     modality: &'static str,
+    /// Another entity sits strictly between the pair — the pair is not
+    /// adjacent and a template must not bridge it.
+    has_inner_entity: bool,
 }
 
 /// Every ordered (A before B, within 150 chars) entity pair with a
@@ -804,12 +819,16 @@ fn between_windows<'a>(text: &str, entities: &'a [String]) -> Vec<BetweenWindow<
             } else {
                 "asserted"
             };
+            let has_inner_entity = entity_positions[i + 1..j]
+                .iter()
+                .any(|(p, e)| *p > pos_a && *p + e.len() <= pos_b);
             out.push(BetweenWindow {
                 entity_a,
                 entity_b,
                 between_stripped,
                 polarity: if has_negation { -1 } else { 1 },
                 modality,
+                has_inner_entity,
             });
         }
     }
@@ -885,11 +904,33 @@ pub fn extract_heuristic_relations(text: &str, entities: &[String]) -> Vec<Relat
                 "asserted"
             };
 
+            // ANCHORING (2026-09-05). Forward patterns used to match ANYWHERE
+            // in the window between ANY two entities up to 150 chars apart, so
+            // a verb between two unrelated capitalized tokens minted a claim.
+            // Measured on the production store after the "runs" relabel: 478
+            // chain-visible `runs` claims, sampled "RAG runs COMPETENT",
+            // "Pranab runs UTC", "Without runs Concrete" — the relabel was
+            // right, the precision was the defect. Now a forward pattern
+            // mints only when (a) the window ENDS with the phrase (object
+            // directly follows the verb; trailing articles ignored) and (b)
+            // no other entity sits between subject and object, except an
+            // entity that is itself part of the phrase ("CEO" inside "is the
+            // CEO of"). The subject is the nearest entity before the verb.
+            let inner_entities: Vec<&str> = entity_positions[i + 1..j]
+                .iter()
+                .filter(|(p, e)| *p > pos_a && *p + e.len() <= pos_b)
+                .map(|(_, e)| *e)
+                .collect();
+            let window_anchored = strip_trailing_articles(&between_stripped);
+
             // Match forward patterns: entity_a <pattern> entity_b
             // Uses between_stripped (negation removed) for matching.
             for (patterns, rel_type) in RELATION_PATTERNS {
                 for pattern in *patterns {
-                    if contains_word_phrase(&between_stripped, pattern) {
+                    let inner_ok = inner_entities
+                        .iter()
+                        .all(|e| pattern.contains(&e.to_lowercase()));
+                    if inner_ok && ends_with_word_phrase(&window_anchored, pattern) {
                         candidates.push(RelationCandidate {
                             src: entity_a.to_string(),
                             rel_type: rel_type.to_string(),
@@ -906,7 +947,8 @@ pub fn extract_heuristic_relations(text: &str, entities: &[String]) -> Vec<Relat
             // Anchored patterns: entity_b must directly follow the phrase.
             for (patterns, rel_type) in ANCHORED_RELATION_PATTERNS {
                 for pattern in *patterns {
-                    if ends_with_word_phrase(&between_stripped, pattern) {
+                    if inner_entities.is_empty() && ends_with_word_phrase(&window_anchored, pattern)
+                    {
                         candidates.push(RelationCandidate {
                             src: entity_a.to_string(),
                             rel_type: rel_type.to_string(),
@@ -1797,6 +1839,50 @@ mod tests {
         let entities = vec!["Alice".to_string(), "Acme".to_string()];
         let rels = extract_heuristic_relations("Alice leads Acme", &entities);
         assert_eq!(rels[0].rel_type, "leads");
+    }
+
+    #[test]
+    fn test_forward_patterns_are_anchored_to_the_adjacent_pair() {
+        // A verb somewhere in a long window no longer bridges two unrelated
+        // entities (the production "Pranab runs UTC" shape).
+        let entities = vec![
+            "Pranab".to_string(),
+            "Materializer".to_string(),
+            "UTC".to_string(),
+        ];
+        let rels = extract_heuristic_relations(
+            "Pranab confirmed the Materializer runs the loop every tick at UTC midnight",
+            &entities,
+        );
+        assert!(
+            !rels.iter().any(|r| r.src == "Pranab" && r.dst == "UTC"),
+            "no claim may bridge Pranab and UTC across Materializer: {:?}",
+            rels
+        );
+        // Object must directly follow the verb (articles allowed).
+        let entities = vec!["Alice".to_string(), "Acme".to_string()];
+        let rels = extract_heuristic_relations("Alice works at the Acme office", &entities);
+        assert!(rels.iter().any(|r| r.rel_type == "works_at"), "{:?}", rels);
+        let rels =
+            extract_heuristic_relations("Alice works at home and later visited Acme", &entities);
+        assert!(
+            rels.is_empty(),
+            "verb not adjacent to the object: {:?}",
+            rels
+        );
+        // An inner entity that is part of the phrase itself is fine.
+        let entities = vec![
+            "Alice Chen".to_string(),
+            "CEO".to_string(),
+            "Acme Corp".to_string(),
+        ];
+        let rels = extract_heuristic_relations("Alice Chen is the CEO of Acme Corp", &entities);
+        assert!(
+            rels.iter()
+                .any(|r| r.rel_type == "ceo_of" && r.src == "Alice Chen" && r.dst == "Acme Corp"),
+            "{:?}",
+            rels
+        );
     }
 
     #[test]

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -541,7 +541,16 @@ const RELATION_PATTERNS: &[(&[&str], &str)] = &[
         "founded",
     ),
     (&["founded"], "founded"),
-    (&["leads", "heads", "runs", "manages", "directs"], "leads"),
+    // "runs" is NOT leadership. Measured on the production memory store
+    // (2026-09-05, 6,408 active memories): `leads` was 1,467 of 2,576 claims
+    // and 877 of them came from "runs" — "CT128 runs 0.15.2", "the compactor
+    // runs every 100 ms". On an engineering corpus "runs" means EXECUTES /
+    // IS AT VERSION, which is exactly the functional relation the claim
+    // scanner already models as `runs` (FUNCTIONAL_REL_TYPES: runs,
+    // runs_version) for succession detection. Minting those as `leads`
+    // produced the dominant junk edge class the claim-chain would follow.
+    (&["leads", "heads", "manages", "directs"], "leads"),
+    (&["runs", "is running", "now runs"], "runs"),
     (
         &[
             "works at",
@@ -1774,6 +1783,20 @@ mod tests {
         assert_eq!(rels.len(), 1);
         assert_eq!(rels[0].polarity, -1);
         assert!(extract_learned_relations("Dana mentors Priya", &entities, &[]).is_empty());
+    }
+
+    #[test]
+    fn test_extract_relations_runs_is_a_version_relation_not_leadership() {
+        // The production defect: "CT128 runs 0.15.2" minted `leads`.
+        let entities = vec!["CT128".to_string(), "Yantrikdb".to_string()];
+        let rels = extract_heuristic_relations("CT128 runs Yantrikdb in production", &entities);
+        assert_eq!(rels.len(), 1, "got: {:?}", rels);
+        assert_eq!(rels[0].rel_type, "runs");
+        assert!(rels.iter().all(|r| r.rel_type != "leads"));
+        // Leadership language still mints leads.
+        let entities = vec!["Alice".to_string(), "Acme".to_string()];
+        let rels = extract_heuristic_relations("Alice leads Acme", &entities);
+        assert_eq!(rels[0].rel_type, "leads");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A production-corpus probe (the operator's live memory store, 6,408 active memories, 2,576 claims) found the claims layer mostly noise and the just-merged claim-chain traversal (#209) pointed straight at it. This PR fixes the two mechanisms the probe attributed and ships the instrument that found them.

**What the probe found (BEAM cannot see any of this):**
- `leads` was 1,467 of 2,576 claims (57%). 877 of them came from the word "runs" — `CT128 runs 0.15.2`, `the compactor runs every 100 ms`. On an engineering corpus "runs" means *executes / is at version*, not leadership.
- After read-side phantom suppression, 287 claims survive store-wide and 180 of those are junk `leads` edges (`Python -leads-> R8g`, `Pranab -leads-> None`, `Draft -leads-> Extra`). Claim-chain traversal follows exactly those.
- Place facts: the pre-#209 extractor minted zero `lives_in` / `hometown` claims on this corpus; #209's anchored place templates mint 17 on a fresh re-ingest (the population-of-zero defect confirmed at scale — that part #209 already fixes; 113 sentences match a place phrase by substring, 17 are extractable claims).

## Changes

- **Every forward relation pattern is anchored to the adjacent entity pair.** A pattern mints only when the between-window ENDS with the phrase (object directly follows the verb, trailing articles ignored) and no other entity sits between subject and object, except one that is part of the phrase itself ("CEO" inside "is the CEO of"). Previously a verb anywhere in a 150-char window between any two capitalized tokens minted a claim — the structural cause of the noise.
- **`runs` is its own relation.** `RELATION_PATTERNS` mints `runs` for "runs" / "is running" / "now runs"; leads / heads / manages / directs still mint `leads`. `runs` is already in `FUNCTIONAL_REL_TYPES`, so `CT128 runs 0.15.2` → `runs 0.18.0` becomes a detectable succession instead of junk leadership.
- **Chain hops skip generic links.** `CHAIN_DENY_RELS = {co_occurs_with, related_to, mentions}`: hop-2 traversal never follows them (hop-1 still reads them as direct evidence about a query entity).
- **`benchmarks/prod_extraction_census.py`**: re-ingest an exported text corpus into a fresh store under the current build and census claims by relation, junk share, entity-table quality and chain exposure. Judge-free; run once per build and diff. The corpus never leaves the operator's machines; the script reports aggregates.

## Before / after on the production corpus (same 6,415 texts, fresh store per build)

| Measure | main (before) | `runs` relabel only | + anchoring (this PR) |
|---|---:|---:|---:|
| claims minted | 1,135 | 1,099 | **50** |
| `leads` claims | 865 | 142 | 5 |
| `runs` claims | 0 | 711 | 20 |
| junk claims (mechanical rule: no-letter endpoint, `None`, >6 tokens, >2 all-caps tokens) | 418 | 390 | 8 |
| junk share | 36.8% | 35.5% | **16%** |
| clean claims a chain hop could follow | 717 | 709 | **42** |
| `lives_in` / `hometown` claims | 17 | 17 | 13 |

The middle column is the honest intermediate: relabeling "runs" fixed the label and moved the noise (sampled `runs` claims after it: "RAG runs COMPETENT", "Pranab runs UTC", "Without runs Concrete"). Anchoring is what removes it. What survives reads mostly like real facts (`Mina Chen -leads-> Asterion Labs`, twelve `lives_in`); the remaining junk is numeric-subject claims (`35 -runs-> Qwen3`) that the read side already rejects as anchors. Four place claims were lost to the adjacency rule — the accepted cost of a claims layer that is mostly right instead of mostly wrong, now that chain traversal and the conflict scanners consume it.

**BEAM footprint** (judge-free context diff, ydb-0151 environment, same provider both arms): the anchored build changes the retrieved set on 52/400 queries vs current main (mean Jaccard 0.985, +0.35 chunks, lexical gold coverage +0.005 on the changed rows). Fewer claims means the claims lane nominates fewer candidates, so the footprint is larger than #209's 24/400. Paired judged run on exactly those 52 queries (`deepseek-v4-flash:0731-cloud` answer + judge, one draw each, order alternated; manifest `580f8178…`, result `084508ac…`): main 0.6959 vs anchored 0.7042, **+0.008**, bootstrap 95% CI [−0.055, +0.072], 7 wins / 39 ties / 6 losses. Projected onto the full line that is about +0.1 points — no harm, no lift claimed. Per category on the changed rows: knowledge_update +0.20 (5), instruction +0.125 (4), event_ordering +0.115 (4), temporal −0.07 (7), abstention −0.25 (4), the rest flat; single draws, none of these is a claim.

## Verification

- `cargo test -p yantrikdb --lib`: 2126 passed; `cargo fmt --check --all` clean.
- New tests: `test_forward_patterns_are_anchored_to_the_adjacent_pair`, `test_extract_relations_runs_is_a_version_relation_not_leadership`, `chain_never_follows_a_denied_relation`.

## Not in this PR

- Bare-number entities are still minted at write time (`born_in 1985` and `runs 0.15.2` need numeric objects; the read side already rejects no-letter names as subjects and the graph-index heal excludes them). The proper fix is value-object capture — a numeric object after a pattern without minting an entity — and is a separate design.
- Historical entity-table rows (`NOT` 1,348 mentions, `Pranab's` 883 as a separate entity from `Pranab`) are clutter from older extractors; they are inert at read but not cleaned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
