### PR TITLE
reextract_claims: one-time heal that re-runs the current extractor over an existing store (CT128 deploy prerequisite)

### DIFF
--- a/benchmarks/prod_reextract_sim.py
+++ b/benchmarks/prod_reextract_sim.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Deploy simulation: open a store built by an OLDER engine with the current
+build, run the re-extraction heal, and census the claims table before and
+after — judge-free, on the operator's own machine.
+
+This is the CT128 scenario end to end: schema migration on open, legacy
+extractor claims present, current extractor applied by `reextract_claims`.
+
+    python benchmarks/prod_reextract_sim.py --store legacy_store/memory.db --out sim.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sqlite3
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from prod_extraction_census import is_junk_endpoint  # noqa: E402
+
+
+def census(path: Path) -> dict:
+    conn = sqlite3.connect(str(path))
+    claims = conn.execute(
+        "SELECT src, rel_type, dst, extractor FROM claims WHERE tombstoned=0"
+    ).fetchall()
+    ver = conn.execute("SELECT value FROM meta WHERE key='schema_version'").fetchone()
+    conn.close()
+    ext = [c for c in claims if c[3] in ("heuristic_v1", "learned_v1")]
+    junk = [c for c in ext if is_junk_endpoint(c[0]) or is_junk_endpoint(c[2])]
+    by_rel = Counter(c[1] for c in ext)
+    return {
+        "schema_version": ver[0] if ver else None,
+        "claims_total": len(claims),
+        "extractor_claims": len(ext),
+        "other_claims": len(claims) - len(ext),
+        "junk_extractor_claims": len(junk),
+        "junk_share": round(len(junk) / len(ext), 4) if ext else None,
+        "by_rel": dict(by_rel.most_common(10)),
+        "sample": [f"{c[0]} -{c[1]}-> {c[2]}" for c in ext[:8]],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--store", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--keep-copy", action="store_true", help="work on a copy, leave the input untouched")
+    args = ap.parse_args()
+
+    import yantrikdb
+
+    work = args.store
+    if args.keep_copy:
+        work = args.store.with_name("memory-healed.db")
+        for suffix in ("", "-wal", "-shm"):
+            src = args.store.with_name(args.store.name + suffix)
+            if src.exists():
+                shutil.copy(src, work.with_name(work.name + suffix))
+    before = census(work)
+
+    t0 = time.perf_counter()
+    db = yantrikdb.YantrikDB.with_default(str(work))  # migrates on open
+    open_s = time.perf_counter() - t0
+    dry = db.reextract_claims(dry_run=True)
+    t0 = time.perf_counter()
+    report = db.reextract_claims()
+    heal_s = time.perf_counter() - t0
+    db.close()
+    after = census(work)
+
+    out = {
+        "engine_version": yantrikdb.__version__,
+        "engine_file": yantrikdb.__file__,
+        "open_seconds": round(open_s, 1),
+        "heal_seconds": round(heal_s, 1),
+        "dry_run": dry,
+        "report": {k: v for k, v in report.items() if k not in ("before_by_rel", "after_by_rel")},
+        "before": before,
+        "after": after,
+    }
+    json.dump(out, open(args.out, "w", encoding="utf-8"), indent=1)
+    print(json.dumps({k: out[k] for k in ("engine_version", "open_seconds", "heal_seconds")}))
+    print("report:", out["report"])
+    for tag in ("before", "after"):
+        c = out[tag]
+        print(f"{tag}: schema v{c['schema_version']} claims={c['claims_total']} extractor={c['extractor_claims']} "
+              f"junk={c['junk_extractor_claims']} ({c['junk_share']}) by_rel={list(c['by_rel'].items())[:6]}")
+        print("   sample:", c["sample"][:5])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/prod_reextract_sim.py
+++ b/benchmarks/prod_reextract_sim.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import sqlite3
 import sys
 import time
@@ -57,11 +56,18 @@ def main() -> int:
 
     work = args.store
     if args.keep_copy:
+        # sqlite's online backup API folds the WAL in and never touches the
+        # -shm mapping (a plain file copy of -shm is refused on Windows).
         work = args.store.with_name("memory-healed.db")
         for suffix in ("", "-wal", "-shm"):
-            src = args.store.with_name(args.store.name + suffix)
-            if src.exists():
-                shutil.copy(src, work.with_name(work.name + suffix))
+            stale = work.with_name(work.name + suffix)
+            if stale.exists():
+                stale.unlink()
+        src_conn = sqlite3.connect(str(args.store))
+        dst_conn = sqlite3.connect(str(work))
+        src_conn.backup(dst_conn)
+        dst_conn.close()
+        src_conn.close()
     before = census(work)
 
     t0 = time.perf_counter()

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -57,6 +57,7 @@ mod recall;
 mod receptivity;
 mod record;
 pub mod reembed;
+pub mod reextract;
 pub mod repair;
 mod replay_engine;
 mod reservation;

--- a/crates/yantrikdb-core/src/engine/reextract.rs
+++ b/crates/yantrikdb-core/src/engine/reextract.rs
@@ -1,0 +1,178 @@
+//! One-time claim re-extraction — the heal that makes an extractor fix
+//! reach a store that already exists.
+//!
+//! The materializer extracts claims when a memory is WRITTEN. An extractor
+//! improvement therefore touches only new writes: the production memory
+//! store measured on 2026-09-05 still carried 2,576 claims minted by the
+//! old patterns (57% junk `leads`, "Pranab runs UTC") after the anchored
+//! extractor shipped, and the claim-chain and conflict scanners kept
+//! reading them. `reextract_claims` drops every claim the extractors
+//! minted (`heuristic_v1`, `learned_v1`) and re-runs the materializer's
+//! own extraction over every active memory — one definition, two callers.
+//!
+//! Scope, deliberately: extractor-minted claims ONLY. `relate()` rows
+//! (`manual`) and writer-stated claims (`agent_stated`) are assertions,
+//! not derivations, and are never touched. Extractor claims are node-local
+//! derived state (their `hlc` is NULL, they do not replicate), so deleting
+//! and regenerating them is safe; nothing else references a heuristic
+//! claim by id. The in-memory graph index is rebuilt at the end so
+//! expansion stops seeing the deleted edges.
+
+use std::collections::BTreeMap;
+
+use rusqlite::params;
+
+use crate::error::Result;
+
+/// Extractor labels whose claims are derived from text and safe to regenerate.
+pub const REEXTRACT_EXTRACTORS: &[&str] = &["heuristic_v1", "learned_v1"];
+/// Memories processed per write-lock hold.
+const REEXTRACT_BATCH: usize = 500;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct ReextractReport {
+    pub namespace: Option<String>,
+    pub dry_run: bool,
+    pub memories_scanned: usize,
+    pub claims_removed: usize,
+    pub claims_written: usize,
+    /// Extractor-minted claims by relation before the heal.
+    pub before_by_rel: BTreeMap<String, i64>,
+    /// Extractor-minted claims by relation after the heal (equals `before`
+    /// on a dry run).
+    pub after_by_rel: BTreeMap<String, i64>,
+}
+
+impl super::YantrikDB {
+    fn extracted_claims_by_rel(&self, namespace: Option<&str>) -> Result<BTreeMap<String, i64>> {
+        let conn = self.conn();
+        let sql = format!(
+            "SELECT rel_type, COUNT(*) FROM claims WHERE tombstoned = 0 \
+             AND extractor IN ('heuristic_v1','learned_v1') {} GROUP BY rel_type",
+            if namespace.is_some() {
+                "AND namespace = ?1"
+            } else {
+                ""
+            }
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows: Vec<(String, i64)> = if let Some(ns) = namespace {
+            stmt.query_map(params![ns], |r| Ok((r.get(0)?, r.get(1)?)))?
+                .collect::<std::result::Result<_, _>>()?
+        } else {
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+                .collect::<std::result::Result<_, _>>()?
+        };
+        Ok(rows.into_iter().collect())
+    }
+
+    /// Drop every extractor-minted claim (optionally in one namespace) and
+    /// re-extract from every active memory with the current extractor. See
+    /// the module note for scope and safety. `dry_run` reports the current
+    /// state and touches nothing.
+    pub fn reextract_claims(
+        &self,
+        namespace: Option<&str>,
+        dry_run: bool,
+    ) -> Result<ReextractReport> {
+        let before_by_rel = self.extracted_claims_by_rel(namespace)?;
+        let mut report = ReextractReport {
+            namespace: namespace.map(str::to_string),
+            dry_run,
+            memories_scanned: 0,
+            claims_removed: 0,
+            claims_written: 0,
+            after_by_rel: before_by_rel.clone(),
+            before_by_rel,
+        };
+
+        // Count what would be scanned even on a dry run.
+        {
+            let conn = self.conn();
+            let sql = format!(
+                "SELECT COUNT(*) FROM memories WHERE consolidation_status = 'active' {}",
+                if namespace.is_some() {
+                    "AND namespace = ?1"
+                } else {
+                    ""
+                }
+            );
+            report.memories_scanned = if let Some(ns) = namespace {
+                conn.query_row(&sql, params![ns], |r| r.get::<_, i64>(0))? as usize
+            } else {
+                conn.query_row(&sql, [], |r| r.get::<_, i64>(0))? as usize
+            };
+        }
+        if dry_run {
+            return Ok(report);
+        }
+
+        // 1. Remove the derived rows.
+        {
+            let conn = self.conn();
+            let sql = format!(
+                "DELETE FROM claims WHERE extractor IN ('heuristic_v1','learned_v1') {}",
+                if namespace.is_some() {
+                    "AND namespace = ?1"
+                } else {
+                    ""
+                }
+            );
+            report.claims_removed = if let Some(ns) = namespace {
+                conn.execute(&sql, params![ns])?
+            } else {
+                conn.execute(&sql, [])?
+            };
+        }
+
+        // 2. Re-extract, keyset-paged so no single lock hold scans the store.
+        let mut last_rowid: i64 = 0;
+        let mut scanned = 0usize;
+        loop {
+            let page: Vec<(i64, String, String, String)> = {
+                let conn = self.conn();
+                let sql = format!(
+                    "SELECT rowid, rid, text, namespace FROM memories \
+                     WHERE consolidation_status = 'active' AND rowid > ?1 {} \
+                     ORDER BY rowid LIMIT ?2",
+                    if namespace.is_some() {
+                        "AND namespace = ?3"
+                    } else {
+                        ""
+                    }
+                );
+                let mut stmt = conn.prepare(&sql)?;
+                let mapper =
+                    |r: &rusqlite::Row| -> rusqlite::Result<(i64, String, String, String)> {
+                        Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?))
+                    };
+                if let Some(ns) = namespace {
+                    stmt.query_map(params![last_rowid, REEXTRACT_BATCH as i64, ns], mapper)?
+                        .collect::<std::result::Result<_, _>>()?
+                } else {
+                    stmt.query_map(params![last_rowid, REEXTRACT_BATCH as i64], mapper)?
+                        .collect::<std::result::Result<_, _>>()?
+                }
+            };
+            if page.is_empty() {
+                break;
+            }
+            for (rowid, rid, stored, ns) in page {
+                last_rowid = rowid;
+                scanned += 1;
+                let text = match self.decrypt_text(&stored) {
+                    Ok(t) => t,
+                    Err(_) => continue, // unreadable row: leave it claimless rather than fail the heal
+                };
+                let heuristic = crate::graph::extract_heuristic_entities(&text);
+                report.claims_written += self.ingest_extracted_claims(&rid, &text, &ns, &heuristic);
+            }
+        }
+        report.memories_scanned = scanned;
+
+        // 3. The in-memory graph index still holds the deleted edges.
+        self.rebuild_graph_index()?;
+        report.after_by_rel = self.extracted_claims_by_rel(namespace)?;
+        Ok(report)
+    }
+}

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -1451,8 +1451,49 @@ impl YantrikDB {
             }
         }
 
-        // Loop C+D: relation extraction + claim ingestion.
+        // Loops C+D+E live in `ingest_extracted_claims` so the one-time
+        // re-extraction heal (`reextract_claims`) runs the SAME code the
+        // materializer runs — one definition, two callers.
         let heuristic_vec: Vec<String> = heuristic_entities.iter().cloned().collect();
+        self.ingest_extracted_claims(rid, text, namespace, &heuristic_vec);
+
+        // Audit telemetry — same shape as the foreground path emitted before.
+        let features = crate::graph::analyze_text_features(text, &heuristic_vec);
+        tracing::info!(
+            target: "yantrikdb::audit::extraction",
+            namespace = %namespace,
+            memory_rid = %rid,
+            domain = %domain,
+            source = %source,
+            extractor_version = "heuristic_v1",
+            char_length = features.char_length,
+            sentence_count = features.sentence_count,
+            entity_count = features.entity_count,
+            entities_matched_in_graph = candidates.len().saturating_sub(heuristic_entities.len()),
+            negation_cue_count = features.negation_cue_count,
+            temporal_cue_count = features.temporal_cue_count,
+            modality_cue_count = features.modality_cue_count,
+            has_compound_markers = features.has_compound_markers,
+            likely_assertion = features.likely_assertion,
+            "extraction audit (materialized post-record)"
+        );
+
+        Ok(())
+    }
+
+    /// Relation extraction + claim ingestion for one memory (the
+    /// materializer's Loops C+D+E): built-in patterns as `heuristic_v1`,
+    /// active learned templates as `learned_v1`, never minting a fact any
+    /// extractor already recorded. Returns the number of claims written.
+    /// Shared by `apply_materialize_record_post` and `reextract_claims`.
+    pub(crate) fn ingest_extracted_claims(
+        &self,
+        rid: &str,
+        text: &str,
+        namespace: &str,
+        heuristic_vec: &[String],
+    ) -> usize {
+        let mut written = 0usize;
         let relations = crate::graph::extract_heuristic_relations(text, &heuristic_vec);
         for rel in &relations {
             let already_exists = {
@@ -1469,22 +1510,25 @@ impl YantrikDB {
             if already_exists {
                 continue;
             }
-            let _ = self.ingest_claim(
-                &rel.src,
-                &rel.rel_type,
-                &rel.dst,
-                namespace,
-                rel.polarity,
-                &rel.modality,
-                None,
-                None,
-                "heuristic_v1",
-                Some("1.0"),
-                &rel.confidence_band,
-                Some(rid),
-                None,
-                None,
-                1.0,
+            written += usize::from(
+                self.ingest_claim(
+                    &rel.src,
+                    &rel.rel_type,
+                    &rel.dst,
+                    namespace,
+                    rel.polarity,
+                    &rel.modality,
+                    None,
+                    None,
+                    "heuristic_v1",
+                    Some("1.0"),
+                    &rel.confidence_band,
+                    Some(rid),
+                    None,
+                    None,
+                    1.0,
+                )
+                .is_ok(),
             );
         }
 
@@ -1513,48 +1557,30 @@ impl YantrikDB {
                 if already_exists {
                     continue;
                 }
-                let _ = self.ingest_claim(
-                    &rel.src,
-                    &rel.rel_type,
-                    &rel.dst,
-                    namespace,
-                    rel.polarity,
-                    &rel.modality,
-                    None,
-                    None,
-                    crate::engine::graph_ops::LEARNED_CLAIM_EXTRACTOR,
-                    Some("1.0"),
-                    &rel.confidence_band,
-                    Some(rid),
-                    None,
-                    None,
-                    1.0,
+                written += usize::from(
+                    self.ingest_claim(
+                        &rel.src,
+                        &rel.rel_type,
+                        &rel.dst,
+                        namespace,
+                        rel.polarity,
+                        &rel.modality,
+                        None,
+                        None,
+                        crate::engine::graph_ops::LEARNED_CLAIM_EXTRACTOR,
+                        Some("1.0"),
+                        &rel.confidence_band,
+                        Some(rid),
+                        None,
+                        None,
+                        1.0,
+                    )
+                    .is_ok(),
                 );
             }
         }
 
-        // Audit telemetry — same shape as the foreground path emitted before.
-        let features = crate::graph::analyze_text_features(text, &heuristic_vec);
-        tracing::info!(
-            target: "yantrikdb::audit::extraction",
-            namespace = %namespace,
-            memory_rid = %rid,
-            domain = %domain,
-            source = %source,
-            extractor_version = "heuristic_v1",
-            char_length = features.char_length,
-            sentence_count = features.sentence_count,
-            entity_count = features.entity_count,
-            entities_matched_in_graph = candidates.len().saturating_sub(heuristic_entities.len()),
-            negation_cue_count = features.negation_cue_count,
-            temporal_cue_count = features.temporal_cue_count,
-            modality_cue_count = features.modality_cue_count,
-            has_compound_markers = features.has_compound_markers,
-            likely_assertion = features.likely_assertion,
-            "extraction audit (materialized post-record)"
-        );
-
-        Ok(())
+        written
     }
 
     /// **Phase 4.3 Commit C — apply a queued `materialize_record_with_rid_post` op.**

--- a/crates/yantrikdb-core/src/engine/tests/mod.rs
+++ b/crates/yantrikdb-core/src/engine/tests/mod.rs
@@ -43,6 +43,8 @@ mod moves;
 mod recall_confidence;
 mod recall_graph;
 mod reembed_router;
+#[cfg(feature = "bundled-embedder")]
+mod reextract_claims;
 mod replication_api;
 mod ryw_visibility;
 mod source_turn_columns;

--- a/crates/yantrikdb-core/src/engine/tests/reextract_claims.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reextract_claims.rs
@@ -1,0 +1,151 @@
+//! The re-extraction heal: legacy extractor claims go, assertions stay.
+
+use crate::{StatedClaim, YantrikDB};
+
+fn rec(db: &YantrikDB, text: &str, ns: &str) -> String {
+    db.record_text(
+        text,
+        "semantic",
+        0.5,
+        0.0,
+        604800.0,
+        &serde_json::json!({}),
+        ns,
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap()
+}
+
+fn rels(db: &YantrikDB, extractor: &str) -> Vec<(String, String, String)> {
+    let conn = db.conn();
+    let mut stmt = conn
+        .prepare("SELECT src, rel_type, dst FROM claims WHERE tombstoned = 0 AND extractor = ?1 ORDER BY src, rel_type, dst")
+        .unwrap();
+    stmt.query_map(rusqlite::params![extractor], |r| {
+        Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+    })
+    .unwrap()
+    .map(|r| r.unwrap())
+    .collect()
+}
+
+fn plant_legacy_junk(db: &YantrikDB, rid: &str, ns: &str) {
+    // What the pre-anchoring extractor left behind: a verb bridging two
+    // unrelated entities, labelled heuristic_v1 with real provenance.
+    let conn = db.conn();
+    conn.execute(
+        "INSERT INTO claims (claim_id, src, dst, rel_type, weight, created_at, extractor, \
+         source_memory_rid, namespace) VALUES ('legacy1', 'Pranab', 'UTC', 'leads', 1.0, 1.0, \
+         'heuristic_v1', ?1, ?2)",
+        rusqlite::params![rid, ns],
+    )
+    .unwrap();
+}
+
+#[test]
+fn heal_replaces_extractor_claims_and_preserves_assertions() {
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let a = rec(
+        &db,
+        "Alice Moreau works at Fennwick Labs as a data engineer.",
+        "default",
+    );
+    let b = rec(
+        &db,
+        "Pranab confirmed the Materializer runs the loop every tick at UTC midnight.",
+        "default",
+    );
+    db.apply_pending_ops_once(100).unwrap();
+    plant_legacy_junk(&db, &b, "default");
+    db.relate("Pranab", "Acme", "works_at", 1.0).unwrap();
+    db.attach_claims(
+        &a,
+        &[StatedClaim {
+            src: "Alice Moreau".into(),
+            rel_type: "mentors".into(),
+            dst: "Fennwick Labs".into(),
+            polarity: 1,
+        }],
+    )
+    .unwrap();
+    let before = rels(&db, "heuristic_v1");
+    assert!(
+        before
+            .iter()
+            .any(|r| r == &("Pranab".into(), "leads".into(), "UTC".into())),
+        "{before:?}"
+    );
+
+    let dry = db.reextract_claims(None, true).unwrap();
+    assert_eq!((dry.claims_removed, dry.claims_written), (0, 0));
+    assert!(
+        rels(&db, "heuristic_v1").iter().any(|r| r.1 == "leads"),
+        "dry run must touch nothing"
+    );
+
+    let report = db.reextract_claims(None, false).unwrap();
+    assert_eq!(report.memories_scanned, 2);
+    assert!(report.claims_removed >= 2, "{report:?}");
+    let after = rels(&db, "heuristic_v1");
+    assert!(
+        !after.iter().any(|r| r.1 == "leads"),
+        "legacy junk must be gone: {after:?}"
+    );
+    assert!(
+        after.iter().any(|r| r
+            == &(
+                "Alice Moreau".into(),
+                "works_at".into(),
+                "Fennwick Labs".into()
+            )),
+        "anchored extraction must regenerate the real fact: {after:?}"
+    );
+    assert_eq!(report.claims_written, after.len());
+    assert!(
+        report.before_by_rel.contains_key("leads") && !report.after_by_rel.contains_key("leads")
+    );
+    // Assertions survive untouched.
+    assert!(rels(&db, "manual")
+        .iter()
+        .any(|r| r == &("Pranab".into(), "works_at".into(), "Acme".into())));
+    assert!(rels(&db, "agent_stated").iter().any(|r| r.1 == "mentors"));
+    // Graph index no longer carries the deleted edge.
+    assert!(!db
+        .get_edges("UTC")
+        .unwrap()
+        .iter()
+        .any(|e| e.rel_type == "leads"));
+}
+
+#[test]
+fn heal_is_namespace_scoped() {
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let a = rec(&db, "Alice works at Acme.", "tenant_a");
+    let b = rec(&db, "Bob works at Globex.", "tenant_b");
+    db.apply_pending_ops_once(100).unwrap();
+    plant_legacy_junk(&db, &a, "tenant_a");
+    {
+        let conn = db.conn();
+        conn.execute(
+            "INSERT INTO claims (claim_id, src, dst, rel_type, weight, created_at, extractor, \
+             source_memory_rid, namespace) VALUES ('legacy2', 'Bob', 'UTC', 'leads', 1.0, 1.0, \
+             'heuristic_v1', ?1, 'tenant_b')",
+            rusqlite::params![b],
+        )
+        .unwrap();
+    }
+    let report = db.reextract_claims(Some("tenant_a"), false).unwrap();
+    assert_eq!(report.memories_scanned, 1);
+    let remaining = rels(&db, "heuristic_v1");
+    assert!(
+        !remaining.iter().any(|r| r.0 == "Pranab" && r.1 == "leads"),
+        "tenant_a junk healed"
+    );
+    assert!(
+        remaining.iter().any(|r| r.0 == "Bob" && r.1 == "leads"),
+        "tenant_b untouched: {remaining:?}"
+    );
+}

--- a/crates/yantrikdb-core/src/lib.rs
+++ b/crates/yantrikdb-core/src/lib.rs
@@ -52,6 +52,7 @@ pub use engine::pack::{
     effective_pack_floor, MountOptions, MountedPack, PackEmbedder, PackInfo, PackManifest,
     PackRecallOptions, PackTrust,
 };
+pub use engine::reextract::{ReextractReport, REEXTRACT_EXTRACTORS};
 pub use engine::repair::{RepairError, RepairReport};
 pub use engine::split::SplitReport;
 pub use engine::tasks::Task;

--- a/crates/yantrikdb-python/src/py_engine/cognition.rs
+++ b/crates/yantrikdb-python/src/py_engine/cognition.rs
@@ -369,6 +369,25 @@ impl PyYantrikDB {
         crate::py_types::json_to_py(py, &val)
     }
 
+    /// Drop every extractor-minted claim (heuristic_v1 / learned_v1),
+    /// optionally in one namespace, and re-extract from every active memory
+    /// with the current extractor. relate() and writer-stated claims are
+    /// never touched. `dry_run=True` reports and changes nothing. Returns
+    /// `{memories_scanned, claims_removed, claims_written, before_by_rel,
+    /// after_by_rel, ...}`.
+    #[pyo3(signature = (namespace=None, dry_run=false))]
+    fn reextract_claims(
+        &self,
+        py: Python<'_>,
+        namespace: Option<&str>,
+        dry_run: bool,
+    ) -> PyResult<PyObject> {
+        let db = self.get_inner()?;
+        let out = db.reextract_claims(namespace, dry_run).map_err(map_err)?;
+        let val = serde_json::to_value(&out).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        crate::py_types::json_to_py(py, &val)
+    }
+
     /// One batch of the v50 source_turn recompute/repair pass — the
     /// maintenance operation `SourceTurnMaintenanceRequiredError` names.
     /// Returns `{"processed", "remaining", "complete"}`; call repeatedly

--- a/tests/test_capability_probes.py
+++ b/tests/test_capability_probes.py
@@ -312,3 +312,21 @@ def test_two_stated_pairs_teach_a_template_that_extracts_from_plain_writes(db):
     assert ("Sam", "mentors", "Jordan") in {(e["src"], e["rel_type"], e["dst"]) for e in db.get_edges("Sam")}
     assert db.forget_learned_relation_patterns() == 1
     assert db.learned_relation_patterns() == []
+
+
+# ── re-extraction heal ───────────────────────────────────────────────────
+
+
+def test_reextract_claims_replaces_legacy_junk_and_keeps_assertions(db):
+    a = db.record("Alice Moreau works at Fennwick Labs as a data engineer.")
+    b = db.record("Pranab confirmed the Materializer runs the loop every tick at UTC midnight.")
+    db.think()
+    db.relate("Pranab", "Acme", "works_at")
+    db.attach_claims(a, [{"subject": "Alice Moreau", "relation": "mentors", "object": "Fennwick Labs"}])
+    before = db.reextract_claims(dry_run=True)
+    assert before["claims_removed"] == 0 and before["memories_scanned"] == 2
+    report = db.reextract_claims()
+    assert report["memories_scanned"] == 2 and report["claims_written"] >= 1
+    edges = {(e["src"], e["rel_type"], e["dst"]) for e in db.get_edges("Alice Moreau")}
+    assert ("Alice Moreau", "works_at", "Fennwick Labs") in edges and ("Alice Moreau", "mentors", "Fennwick Labs") in edges
+    assert ("Pranab", "works_at", "Acme") in {(e["src"], e["rel_type"], e["dst"]) for e in db.get_edges("Pranab")}


### PR DESCRIPTION
## Summary

`reextract_claims` — the one-time heal that makes an extractor fix reach a store that already exists.

The materializer extracts claims when a memory is written, so #209 and #210 improve only new writes. The production memory store measured on 2026-09-05 still holds 2,576 claims minted by the old patterns (57% junk `leads`, "Pranab runs UTC"), and the claim-chain traversal and conflict scanners keep reading them. Deploying the anchored extractor without this heal leaves the live claims layer as noisy as before.

## What it does

`db.reextract_claims(namespace=None, dry_run=False)`:

1. Deletes every extractor-minted claim (`heuristic_v1`, `learned_v1`) — node-local derived state, `hlc` NULL, never replicated, nothing references them by id. `relate()` rows and writer-stated claims are assertions, not derivations, and are never touched.
2. Re-runs extraction over every active memory in keyset-paged batches of 500 (decrypting per row), through the **same** code the write path uses: the materializer's Loops C+D+E are now `ingest_extracted_claims`, one definition, two callers.
3. Rebuilds the in-memory graph index so expansion stops seeing deleted edges.
4. Reports memories scanned, claims removed and written, and by-relation counts before and after. `dry_run=True` reports and changes nothing.

Namespace-scoped when asked, whole store otherwise.

## Deploy simulation (the CT128 rehearsal)

`benchmarks/prod_reextract_sim.py`: a store built with the **published 0.18.0 wheel** from the operator's 6,415 real memory texts (schema v50, old-extractor claims), opened with this build (migrates to v51), healed, and censused before and after.

| | legacy store (0.18.0 wheel) | after `reextract_claims` on this build |
|---|---:|---:|
| schema | v50 | v51 (migrated on open, 2.5 s) |
| extractor-minted claims | 1,493 | 94 |
| of which `leads` | 1,160 | 6 |
| junk (mechanical rule) | 598 (40%) | 20 (21%) |
| top relations | leads, acquired, works_at | runs 29, lives_in 17, works_at 11, ceo_of 7 |
| heal wall time | | 239 s for 6,415 memories |

Report: `memories_scanned 6415, claims_removed 1493, claims_written 66`. The after-count (94) exceeds `claims_written` (66) because opening the legacy store on the new build also let the materializer drain a few leftover ops with the new extractor concurrently — same extractor, benign, but the report counts only what the heal itself wrote.

What remains junk after the heal is entity-quality noise, not relation noise: `STRATEGIC POINT -lives_in-> MASTERING`, `Iran -lives_in-> Hell` come from the entity chunker minting all-caps headings and odd capitalized tokens. That is the next lever (entity admission), not this PR's.

## Verification

- `cargo test -p yantrikdb --lib`: 2128 passed; `cargo fmt --check --all` clean.
- Engine tests: legacy junk replaced by anchored facts with manual and stated claims preserved and the graph index refreshed; namespace scoping; dry run touches nothing.
- Probe suite (`tests/test_capability_probes.py`, 20 probes) green on the rebuilt wheel, including the new heal probe.

## Runbook note for CT128

Back up, deploy, open once (migration), then `reextract_claims()` once. The heal is idempotent: running it again regenerates the same claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
