### PR TITLE
release: v0.19.0

### DIFF
--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -213,6 +213,38 @@ can run a periodic deadlock check.
 
 ---
 
+## Rule 9 — One SQLite library per process: never open the store with another one while the engine is open
+
+The engine links its own SQLite (`rusqlite` `bundled`). A second SQLite
+library in the same process — Python's stdlib `sqlite3`, a system
+`libsqlite3` loaded by some other extension — opening the same store
+file is a corruption hazard, not a locking inconvenience. Both libraries
+serialise writers with POSIX advisory locks, and the kernel scopes those
+locks per *process*: library B's unlock releases library A's lock, so a
+write from B and a materializer write from A interleave their WAL
+commits (sqlite.org/howtocorrupt.html, "multiple copies of SQLite linked
+into the same application").
+
+Measured 2026-09-06 on the 0.18.0 and 0.19.0 wheels under CPU contention:
+an in-process `sqlite3.connect(...).execute("UPDATE memories SET metadata
+= ...")` while the materializer was draining left the row holding an
+`entities` page (rid = the entity name, text = a timestamp) in 2-8 % of
+runs. The py3.10 CI job saw it as `Invalid column type Real at index: 1,
+name: text` from `recall_thread`.
+
+Rules:
+
+- Raw SQL against a store the engine currently has open goes through a
+  **separate process** (`sqlite3` CLI, a `subprocess`), never an
+  in-process second library. Tests use `_raw_sql_in_subprocess` in
+  `tests/test_thread_v2.py`.
+- Alternatively `close()` the engine first; sequential use of two
+  libraries is fine.
+- Separate processes (dashboard, census scripts, backups via `.backup`)
+  are safe: the kernel serialises them.
+
+---
+
 ## Cross-stack rule — engine pressure suppresses enrichment, NEVER decay
 
 This rule lives in yantrikdb-server's tick loop (it's the consumer of

--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.18.0"
+version = "0.19.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.18.0"
+version = "0.19.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_thread_v2.py
+++ b/tests/test_thread_v2.py
@@ -34,6 +34,40 @@ def _seed(db, text, turn, seed):
     return rid
 
 
+def _raw_sql_in_subprocess(path, sql, params):
+    """Run one raw write against an engine store from a separate process.
+
+    NOT an in-process ``sqlite3.connect``: the engine links its own SQLite
+    and its materializer thread may be mid-write. Two SQLite libraries in
+    one process both use POSIX advisory locks, which the kernel scopes per
+    process, so their writers never serialise and a WAL commit from one
+    can land on top of the other's (sqlite.org/howtocorrupt.html, "multiple
+    copies of SQLite linked into the same application"). Measured on the
+    0.18.0 and 0.19.0 wheels under CPU contention: 2-8 % of runs left the
+    memory row holding an entities page (rid = the entity name, text = a
+    timestamp), and the py3.10 CI job hit it twice in one day. A child
+    process holds its own locks, so the kernel serialises it against the
+    engine like any other client.
+    """
+    import json
+    import subprocess
+    import sys
+
+    prog = "; ".join([
+        "import json, sqlite3, sys",
+        "path, sql, params = json.loads(sys.argv[1])",
+        "c = sqlite3.connect(path)",
+        "c.execute(sql, params)",
+        "c.commit()",
+        "c.close()",
+    ])
+    subprocess.run(
+        [sys.executable, "-c", prog, json.dumps([path, sql, params])],
+        check=True,
+        timeout=60,
+    )
+
+
 class TestThreadV2Binding:
     def test_typed_classes_are_exported(self):
         import yantrikdb as y
@@ -80,23 +114,19 @@ class TestThreadV2Binding:
         """(batch 11 test 3) On a stale-marker store: v2 raises the typed
         maintenance error even entity-only; legacy v1 still succeeds with
         decrypt-derived semantics. The two surfaces must never converge."""
-        import sqlite3
-
         import yantrikdb as y
 
         path = str(tmp_path / "stale.db")
         db = YantrikDB(path, 8)
         rid = _seed(db, "Alpha event five", 5, 1.0)
-        # Raw SQL rewrite (a second connection — exactly the raw-write
+        # Raw SQL rewrite from ANOTHER PROCESS (exactly the raw-write
         # staleness the marker triggers exist to catch): turn 5 -> 7.
-        raw = sqlite3.connect(path)
-        raw.execute(
+        _raw_sql_in_subprocess(
+            path,
             "UPDATE memories SET metadata = "
             "json_set(metadata, '$.source_turn', 7) WHERE rid = ?",
-            (rid,),
+            [rid],
         )
-        raw.commit()
-        raw.close()
 
         # (a) v2, entity-only: typed MaintenanceRequired.
         with pytest.raises(y.SourceTurnMaintenanceRequiredError):


### PR DESCRIPTION
Version bump ×3 on top of #209, #210 and #211. Schema v51.

Gates before tag (recorded in the release notes and the PR checks): fmt, pylint E/F, slim `cargo test --no-default-features --no-run`, core lib suite, root wheel → clean-venv Python suite, WSL cp310-abi3 manylinux wheel with content markers, CT128 verify-on-copy (copy migrates v50→v51 and the claims heal is rehearsed on the real store copy), and the hermes co-iteration gate v1.5.0 (0.18.0 vs 0.19.0 wheel) on LXC 120.

Release notes: see the GitHub Release once tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)