### PR TITLE
feat(extract): entity admission — values and headings never become nodes; reextract_entities heal (#213)

### DIFF
--- a/benchmarks/prod_extraction_census.py
+++ b/benchmarks/prod_extraction_census.py
@@ -93,7 +93,12 @@ def main() -> int:
 
     by_rel = Counter(c[1] for c in claims)
     by_ext = Counter(c[3] for c in claims)
-    junk = [c for c in claims if is_junk_endpoint(c[0]) or is_junk_endpoint(c[2])]
+    # A value object (no letters, has a digit) is a legitimate claim OBJECT
+    # since #213 (`CT128 -runs-> 0.19.0`); only a junk SUBJECT, or a junk
+    # object that is not a value, counts against the build.
+    def _is_value(x):
+        return bool(x) and not any(ch.isalpha() for ch in x) and any(ch.isdigit() for ch in x)
+    junk = [c for c in claims if is_junk_endpoint(c[0]) or (is_junk_endpoint(c[2]) and not _is_value(c[2]))]
     clean = [c for c in claims if c not in junk]
     clean_by_rel = Counter(c[1] for c in clean)
     deny = set(x.strip() for x in args.chain_deny.split(",") if x.strip())
@@ -162,6 +167,8 @@ def main() -> int:
         "entities_top12": [{"name": e[0], "type": e[1], "mentions": e[2]} for e in ent_top],
         "sample_clean_leads": [f"{c[0]} -leads-> {c[2]}" for c in clean if c[1] == "leads"][: args.sample],
         "sample_junk": [f"{c[0]} -{c[1]}-> {c[2]}" for c in junk][: args.sample],
+        # Every extractor claim, so two runs can be diffed claim by claim.
+        "all_claims": sorted(f"{c[0]} -{c[1]}-> {c[2]}" for c in claims),
     }
     args.out.parent.mkdir(parents=True, exist_ok=True)
     json.dump(out, open(args.out, "w", encoding="utf-8"), indent=1)

--- a/benchmarks/prod_extraction_census.py
+++ b/benchmarks/prod_extraction_census.py
@@ -102,6 +102,20 @@ def main() -> int:
     exposure = [c for c in clean if c[4] and c[1] not in deny]
     exposure_by_rel = Counter(c[1] for c in exposure)
     ent_junk = sum(1 for e in entities if is_junk_endpoint(e[0]))
+    # Issue #213 admission classes (counts only; names never leave the box).
+    names = [e[0] for e in entities]
+    ent_classes = {
+        "all_caps": sum(1 for n in names if len(n) >= 2 and n == n.upper() and n != n.lower()),
+        "has_digit": sum(1 for n in names if any(ch.isdigit() for ch in n)),
+        "no_letters": sum(1 for n in names if not any(ch.isalpha() for ch in n)),
+        "four_plus_words": sum(1 for n in names if len(n.split()) >= 4),
+        "long_40": sum(1 for n in names if len(n) >= 40),
+        "possessive": sum(1 for n in names if n.endswith("'s") or n.endswith("’s")),
+    }
+    claims_allcaps_endpoint = sum(
+        1 for c in claims
+        if any(len(x) >= 2 and x == x.upper() and x != x.lower() for x in (c[0], c[2]))
+    )
     ent_top = sorted(entities, key=lambda e: -(e[2] or 0))[:12]
 
     # "runs"-as-leads on this corpus: leads claims whose source text says " runs ".
@@ -143,6 +157,8 @@ def main() -> int:
         "chain_exposure_by_rel": dict(exposure_by_rel.most_common()),
         "entities_total": len(entities),
         "entities_junk": ent_junk,
+        "entities_classes": ent_classes,
+        "claims_with_allcaps_endpoint": claims_allcaps_endpoint,
         "entities_top12": [{"name": e[0], "type": e[1], "mentions": e[2]} for e in ent_top],
         "sample_clean_leads": [f"{c[0]} -leads-> {c[2]}" for c in clean if c[1] == "leads"][: args.sample],
         "sample_junk": [f"{c[0]} -{c[1]}-> {c[2]}" for c in junk][: args.sample],

--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -633,7 +633,7 @@ impl YantrikDB {
             )?;
             for &entity in entity_names {
                 let entity_tokens = crate::graph::tokenize(entity);
-                if entity_tokens.is_empty() {
+                if entity_tokens.is_empty() || !crate::graph::admit_entity(entity) {
                     continue;
                 }
                 let rows: Vec<(String, String)> = stmt
@@ -901,8 +901,15 @@ impl YantrikDB {
                 ],
             )?;
 
-            // Ensure entities exist
+            // Ensure entities exist — for endpoints the entity table admits.
+            // A value object (`0.19.0`, `1985`) is a legitimate claim OBJECT
+            // but never a node: the claim row carries it, the read side
+            // refuses it as an anchor, and issue #213 measured what happens
+            // when every endpoint becomes a node (11% bare numbers).
             for (entity, etype) in [(&*src_resolved, src_type), (&*dst_resolved, dst_type)] {
+                if !crate::graph::admit_entity(entity) {
+                    continue;
+                }
                 conn.execute(
                     "INSERT INTO entities (name, entity_type, first_seen, last_seen) \
                      VALUES (?1, ?2, ?3, ?4) \
@@ -1291,10 +1298,15 @@ impl super::YantrikDB {
                 );
                 continue;
             }
-            if crate::graph::is_rejected_entity_name(src)
-                || crate::graph::is_rejected_entity_name(dst)
-            {
-                reject("subject or object is not an admissible entity name (stopword, heading or bare number)".into(), &mut report);
+            // The subject must be a node the table admits; the object may
+            // also be a value (`0.19.0`, `1985`): `CT128 runs 0.19.0` is the
+            // succession-bearing claim shape and its object is not a thing.
+            if !crate::graph::admit_entity(src) {
+                reject("subject is not an admissible entity name (stopword, heading, possessive or bare number)".into(), &mut report);
+                continue;
+            }
+            if !crate::graph::admit_entity(dst) && !crate::graph::is_value_object(dst) {
+                reject("object is neither an admissible entity name nor a value (a number, version or year)".into(), &mut report);
                 continue;
             }
             if src.eq_ignore_ascii_case(dst) {

--- a/crates/yantrikdb-core/src/engine/reextract.rs
+++ b/crates/yantrikdb-core/src/engine/reextract.rs
@@ -176,3 +176,139 @@ impl super::YantrikDB {
         Ok(report)
     }
 }
+
+/// Report of [`YantrikDB::reextract_entities`].
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct EntityAdmissionReport {
+    pub dry_run: bool,
+    pub entities_scanned: usize,
+    /// Names that fail [`crate::graph::admit_entity`] today.
+    pub inadmissible: usize,
+    /// Inadmissible names kept because a manual or writer-stated claim
+    /// references them — an assertion outranks a heuristic.
+    pub kept_by_claims: usize,
+    pub entities_removed: usize,
+    pub links_removed: usize,
+    /// Extractor-minted claims dropped because an endpoint was removed.
+    pub claims_removed: usize,
+    /// Junk-class counts before the heal (`all_caps`, `has_digit`,
+    /// `no_letters`, `four_plus_words`, `long`).
+    pub before_classes: BTreeMap<String, i64>,
+    /// The same counts after (equals `before` on a dry run).
+    pub after_classes: BTreeMap<String, i64>,
+}
+
+const ENTITY_HEAL_BATCH: usize = 500;
+
+impl super::YantrikDB {
+    fn entity_classes(&self) -> Result<BTreeMap<String, i64>> {
+        let conn = self.conn();
+        let mut out = BTreeMap::new();
+        let q = |sql: &str| -> Result<i64> { Ok(conn.query_row(sql, [], |r| r.get::<_, i64>(0))?) };
+        out.insert("total".into(), q("SELECT COUNT(*) FROM entities")?);
+        out.insert(
+            "all_caps".into(),
+            q("SELECT COUNT(*) FROM entities WHERE name = upper(name) AND name <> lower(name) AND length(name) >= 2")?,
+        );
+        out.insert(
+            "has_digit".into(),
+            q("SELECT COUNT(*) FROM entities WHERE name GLOB '*[0-9]*'")?,
+        );
+        out.insert(
+            "no_letters".into(),
+            q("SELECT COUNT(*) FROM entities WHERE NOT name GLOB '*[A-Za-z]*'")?,
+        );
+        out.insert(
+            "four_plus_words".into(),
+            q("SELECT COUNT(*) FROM entities WHERE (length(name) - length(replace(name,' ',''))) >= 3")?,
+        );
+        out.insert(
+            "long".into(),
+            q("SELECT COUNT(*) FROM entities WHERE length(name) >= 40")?,
+        );
+        Ok(out)
+    }
+
+    /// One-time heal for the entity table: re-apply today's admission
+    /// predicate ([`crate::graph::admit_entity`]) to every stored entity
+    /// and remove the ones it refuses — with their `memory_entities` links
+    /// and any extractor-minted claim that used them as an endpoint — then
+    /// rebuild the graph index so expansion stops seeing the dropped nodes.
+    ///
+    /// Nothing revisits admitted nodes otherwise: the extractor gate in
+    /// #213 protects new writes only, and a store written by an older
+    /// extractor keeps every heading and bare number it ever minted as a
+    /// hop the claims lane can follow. This is the entity-table twin of
+    /// [`Self::reextract_claims`], and like it is idempotent.
+    ///
+    /// An inadmissible name referenced by a `manual` or `agent_stated`
+    /// claim is KEPT: a writer asserted it, and an assertion outranks the
+    /// heuristic. The entity table is store-wide (no namespace column), so
+    /// the heal is too. `dry_run` reports and changes nothing.
+    pub fn reextract_entities(&self, dry_run: bool) -> Result<EntityAdmissionReport> {
+        let before_classes = self.entity_classes()?;
+        let mut report = EntityAdmissionReport {
+            dry_run,
+            entities_scanned: 0,
+            inadmissible: 0,
+            kept_by_claims: 0,
+            entities_removed: 0,
+            links_removed: 0,
+            claims_removed: 0,
+            after_classes: before_classes.clone(),
+            before_classes,
+        };
+        let names: Vec<String> = {
+            let conn = self.conn();
+            let mut stmt = conn.prepare("SELECT name FROM entities ORDER BY name")?;
+            let rows: Vec<String> = stmt
+                .query_map([], |r| r.get::<_, String>(0))?
+                .collect::<std::result::Result<_, _>>()?;
+            rows
+        };
+        report.entities_scanned = names.len();
+        let mut doomed: Vec<String> = Vec::new();
+        {
+            let conn = self.conn();
+            let mut asserted = conn.prepare(
+                "SELECT COUNT(*) FROM claims WHERE tombstoned = 0 \
+                 AND extractor NOT IN ('heuristic_v1','learned_v1') \
+                 AND (src = ?1 OR dst = ?1)",
+            )?;
+            for name in &names {
+                if crate::graph::admit_entity(name) {
+                    continue;
+                }
+                report.inadmissible += 1;
+                let refs: i64 = asserted.query_row(params![name], |r| r.get(0))?;
+                if refs > 0 {
+                    report.kept_by_claims += 1;
+                    continue;
+                }
+                doomed.push(name.clone());
+            }
+        }
+        if dry_run {
+            return Ok(report);
+        }
+        for batch in doomed.chunks(ENTITY_HEAL_BATCH) {
+            let conn = self.conn();
+            for name in batch {
+                report.links_removed += conn.execute(
+                    "DELETE FROM memory_entities WHERE entity_name = ?1",
+                    params![name],
+                )?;
+                report.claims_removed += conn.execute(
+                    "DELETE FROM claims WHERE extractor IN ('heuristic_v1','learned_v1') \
+                     AND (src = ?1 OR dst = ?1)",
+                    params![name],
+                )?;
+                report.entities_removed +=
+                    conn.execute("DELETE FROM entities WHERE name = ?1", params![name])?;
+            }
+        }
+        self.rebuild_graph_index()?;
+        report.after_classes = self.entity_classes()?;
+        Ok(report)
+    }
+}

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -1494,8 +1494,22 @@ impl YantrikDB {
         heuristic_vec: &[String],
     ) -> usize {
         let mut written = 0usize;
-        let relations = crate::graph::extract_heuristic_relations(text, &heuristic_vec);
+        // Value objects (`0.19.0`, `1985`) are never entities but must stay
+        // available as relation OBJECTS, or `runs`/`born_in` claims vanish
+        // with the entity junk they used to ride on (issue #213).
+        let mut candidates: Vec<String> = heuristic_vec.to_vec();
+        for v in crate::graph::extract_value_candidates(text) {
+            if !candidates.contains(&v) {
+                candidates.push(v);
+            }
+        }
+        let relations = crate::graph::extract_heuristic_relations(text, &candidates);
         for rel in &relations {
+            // A value can be an object, never a subject: `2026 -leads-> X`
+            // anchors nothing at read time and is refused there anyway.
+            if crate::graph::is_rejected_entity_name(&rel.src) {
+                continue;
+            }
             let already_exists = {
                 let conn = self.conn();
                 conn.query_row(
@@ -1541,8 +1555,11 @@ impl YantrikDB {
             Self::active_relation_templates(&conn, namespace)
         };
         if !templates.is_empty() {
-            let learned = crate::graph::extract_learned_relations(text, &heuristic_vec, &templates);
+            let learned = crate::graph::extract_learned_relations(text, &candidates, &templates);
             for rel in &learned {
+                if crate::graph::is_rejected_entity_name(&rel.src) {
+                    continue;
+                }
                 let already_exists = {
                     let conn = self.conn();
                     conn.query_row(

--- a/crates/yantrikdb-core/src/engine/tests/mod.rs
+++ b/crates/yantrikdb-core/src/engine/tests/mod.rs
@@ -45,6 +45,7 @@ mod recall_graph;
 mod reembed_router;
 #[cfg(feature = "bundled-embedder")]
 mod reextract_claims;
+#[cfg(feature = "bundled-embedder")]
 mod reextract_entities;
 mod replication_api;
 mod ryw_visibility;

--- a/crates/yantrikdb-core/src/engine/tests/mod.rs
+++ b/crates/yantrikdb-core/src/engine/tests/mod.rs
@@ -45,6 +45,7 @@ mod recall_graph;
 mod reembed_router;
 #[cfg(feature = "bundled-embedder")]
 mod reextract_claims;
+mod reextract_entities;
 mod replication_api;
 mod ryw_visibility;
 mod source_turn_columns;

--- a/crates/yantrikdb-core/src/engine/tests/reextract_entities.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reextract_entities.rs
@@ -1,0 +1,197 @@
+//! The entity-table heal (issue #213): inadmissible nodes go, asserted ones stay.
+
+use crate::{StatedClaim, YantrikDB};
+
+fn rec(db: &YantrikDB, text: &str) -> String {
+    db.record_text(
+        text,
+        "semantic",
+        0.5,
+        0.0,
+        604800.0,
+        &serde_json::json!({}),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap()
+}
+
+fn entity_names(db: &YantrikDB) -> Vec<String> {
+    let conn = db.conn();
+    let mut stmt = conn
+        .prepare("SELECT name FROM entities ORDER BY name")
+        .unwrap();
+    stmt.query_map([], |r| r.get::<_, String>(0))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect()
+}
+
+fn count(db: &YantrikDB, sql: &str) -> i64 {
+    db.conn().query_row(sql, [], |r| r.get(0)).unwrap()
+}
+
+/// What an older extractor left behind: headings, bare numbers and a
+/// possessive straggler minted as nodes, with links and a heuristic claim
+/// riding on them.
+fn plant_legacy_entities(db: &YantrikDB, rid: &str) {
+    let conn = db.conn();
+    for (name, ty) in [
+        ("STRATEGIC POINT", "tech"),
+        ("MASTERING", "tech"),
+        ("1348", "tech"),
+        ("0.15.2", "tech"),
+        ("Pranab's", "unknown"),
+        ("Recall Return Unrelated Records Root Cause", "unknown"),
+    ] {
+        conn.execute(
+            "INSERT OR IGNORE INTO entities (name, entity_type, first_seen, last_seen, mention_count) \
+             VALUES (?1, ?2, 1.0, 1.0, 1)",
+            rusqlite::params![name, ty],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO memory_entities (memory_rid, entity_name, entity_name_norm) \
+             VALUES (?1, ?2, lower(?2))",
+            rusqlite::params![rid, name],
+        )
+        .unwrap();
+    }
+    conn.execute(
+        "INSERT INTO claims (claim_id, src, dst, rel_type, weight, created_at, extractor, \
+         source_memory_rid, namespace) VALUES ('legacy_e1', 'STRATEGIC POINT', 'MASTERING', \
+         'lives_in', 1.0, 1.0, 'heuristic_v1', ?1, 'default')",
+        rusqlite::params![rid],
+    )
+    .unwrap();
+}
+
+#[test]
+fn heal_removes_inadmissible_nodes_and_their_links_but_keeps_asserted_ones() {
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let a = rec(&db, "Alice Moreau works at Fennwick Labs in Berlin.");
+    db.apply_pending_ops_once(100).unwrap();
+    plant_legacy_entities(&db, &a);
+    // A writer asserted a claim on one shouted name: that node must survive.
+    db.conn()
+        .execute(
+            "INSERT OR IGNORE INTO entities (name, entity_type, first_seen, last_seen, mention_count) \
+             VALUES ('ACME HOLDINGS INTERNATIONAL', 'unknown', 1.0, 1.0, 1)",
+            [],
+        )
+        .unwrap();
+    db.relate(
+        "Alice Moreau",
+        "ACME HOLDINGS INTERNATIONAL",
+        "works_at",
+        1.0,
+    )
+    .unwrap();
+
+    let before = entity_names(&db);
+    assert!(before.iter().any(|n| n == "STRATEGIC POINT"), "{before:?}");
+    assert!(before.iter().any(|n| n == "1348"), "{before:?}");
+
+    let dry = db.reextract_entities(true).unwrap();
+    assert!(dry.dry_run);
+    assert_eq!(dry.entities_removed, 0);
+    assert_eq!(dry.kept_by_claims, 1, "the asserted shouted name is kept");
+    assert_eq!(dry.inadmissible, 7);
+    assert_eq!(entity_names(&db), before, "a dry run changes nothing");
+
+    let report = db.reextract_entities(false).unwrap();
+    assert_eq!(report.entities_removed, 6, "{report:?}");
+    assert_eq!(report.kept_by_claims, 1);
+    assert_eq!(
+        report.claims_removed, 1,
+        "the heuristic claim on a dropped node goes too"
+    );
+    assert!(report.links_removed >= 6, "{report:?}");
+    let after = entity_names(&db);
+    for gone in ["STRATEGIC POINT", "MASTERING", "1348", "0.15.2", "Pranab's"] {
+        assert!(
+            !after.iter().any(|n| n == gone),
+            "{gone:?} survived: {after:?}"
+        );
+    }
+    for kept in [
+        "Alice Moreau",
+        "Fennwick Labs",
+        "Berlin",
+        "ACME HOLDINGS INTERNATIONAL",
+    ] {
+        assert!(after.iter().any(|n| n == kept), "{kept:?} lost: {after:?}");
+    }
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM memory_entities WHERE entity_name = 'STRATEGIC POINT'"
+        ),
+        0
+    );
+    assert_eq!(
+        count(
+            &db,
+            "SELECT COUNT(*) FROM claims WHERE claim_id = 'legacy_e1'"
+        ),
+        0
+    );
+    assert_eq!(report.after_classes["no_letters"], 0);
+    assert!(report.before_classes["no_letters"] >= 2);
+
+    // Idempotent: a second pass finds nothing to do.
+    let again = db.reextract_entities(false).unwrap();
+    assert_eq!(again.entities_removed, 0);
+    assert_eq!(again.claims_removed, 0);
+}
+
+#[test]
+fn new_writes_never_mint_values_or_headings_but_values_still_serve_as_objects() {
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let rid = rec(
+        &db,
+        "STRATEGIC POINT: CT128 runs 0.19.0 since 2026. Alice Moreau was born in 1985.",
+    );
+    db.apply_pending_ops_once(100).unwrap();
+    let names = entity_names(&db);
+    for bad in ["STRATEGIC POINT", "0.19.0", "2026", "1985"] {
+        assert!(!names.iter().any(|n| n == bad), "{bad:?} minted: {names:?}");
+    }
+    assert!(names.iter().any(|n| n == "CT128"), "{names:?}");
+    let edges: Vec<(String, String, String)> = {
+        let conn = db.conn();
+        let mut stmt = conn
+            .prepare("SELECT src, rel_type, dst FROM claims WHERE tombstoned = 0 AND source_memory_rid = ?1")
+            .unwrap();
+        stmt.query_map(rusqlite::params![rid], |r| {
+            Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+        })
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect()
+    };
+    assert!(
+        edges.contains(&("CT128".into(), "runs".into(), "0.19.0".into())),
+        "value object lost as a relation object: {edges:?}"
+    );
+    assert!(
+        edges.contains(&("Alice Moreau".into(), "born_in".into(), "1985".into())),
+        "{edges:?}"
+    );
+    // A stated claim on a value object is still grounded and stored.
+    let rep = db
+        .attach_claims(
+            &rid,
+            &[StatedClaim {
+                src: "CT128".into(),
+                rel_type: "runs".into(),
+                dst: "0.19.0".into(),
+                polarity: 1,
+            }],
+        )
+        .unwrap();
+    assert_eq!(rep.accepted.len(), 1, "{rep:?}");
+}

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -503,13 +503,31 @@ pub fn admit_entity(name: &str) -> bool {
 /// extractor needs them as OBJECTS so `born_in 1985` and `runs 0.19.0` keep
 /// minting claims; those claims then feed succession detection (`runs` is
 /// functional), which is the whole reason the value is worth keeping.
-/// A value object: no letters, at least one digit (`0.19.0`, `1985`, `3.6`).
+/// A value object: a number, version, year or ISO date — digit groups
+/// joined by `.` or `-` only (`0.19.0`, `1985`, `3.6`, `2026-08-01`).
 /// Admissible as a claim OBJECT, never as a subject or an entity node.
+///
+/// The shape is deliberately narrow. The first cut admitted anything
+/// with a digit and no letter, and a production census then showed
+/// `Bell -founded-> 67%`, `Builder -runs-> 2+`, `Idempotent -runs-> */5`,
+/// `MTP -runs-> ~121-127` minted as claims: a symbol-bearing token is a
+/// fragment of prose or a cron line, not a value a succession can key on.
 pub fn is_value_object(name: &str) -> bool {
     let name = name.trim();
-    !name.is_empty()
-        && !name.chars().any(|c| c.is_alphabetic())
-        && name.chars().any(|c| c.is_ascii_digit())
+    if name.is_empty() || !name.chars().any(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    let mut prev_sep = true;
+    for c in name.chars() {
+        if c.is_ascii_digit() {
+            prev_sep = false;
+        } else if (c == '.' || c == '-') && !prev_sep {
+            prev_sep = true;
+        } else {
+            return false;
+        }
+    }
+    !prev_sep
 }
 
 pub fn extract_value_candidates(text: &str) -> Vec<String> {
@@ -2764,6 +2782,14 @@ mod entity_admission_tests {
         );
         let values = extract_value_candidates(text);
         assert_eq!(values, vec!["0.19.0".to_string(), "2026".to_string()]);
+        for good in ["1985", "0.19.0", "3.6", "2026-08-01", "12"] {
+            assert!(is_value_object(good), "{good:?} refused");
+        }
+        for bad in [
+            "67%", "2+", "24/7", "*/5", "~12", "+4.6%", "~121-127", "1.", "-3", "v2", "",
+        ] {
+            assert!(!is_value_object(bad), "{bad:?} admitted as a value");
+        }
         let mut cands = ents.clone();
         cands.extend(values);
         let rels = extract_heuristic_relations(text, &cands);

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -412,6 +412,126 @@ fn strip_code(text: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(out)
 }
 
+/// Longest name (in chars) the entity table admits. Beyond this a
+/// capitalized run is a title or a sentence, not a name.
+pub const ENTITY_MAX_CHARS: usize = 40;
+/// Most words a name may have. Real names are one to three words; four
+/// consecutive capitalized words is a heading or a sentence start.
+pub const ENTITY_MAX_WORDS: usize = 4;
+/// Longest single ALL-CAPS token admitted as an acronym (`FAISS`, `CT128`,
+/// `ONNX`). Longer shouted words (`MASTERING`, `STRATEGIC`) are headings.
+pub const ACRONYM_MAX_CHARS: usize = 6;
+/// Longest token inside a multi-token ALL-CAPS run (`NASA JPL`) — two or
+/// three short acronyms are a name; `STRATEGIC POINT` is a heading.
+pub const ACRONYM_RUN_TOKEN_MAX_CHARS: usize = 5;
+
+/// Entity admission — the single predicate that decides whether a
+/// capitalized run becomes a node in the entity table.
+///
+/// Every admitted entity is a node the claims lane, chain traversal,
+/// entity threads and `expand_entities` can follow, so a bad admission is
+/// not clutter: it is a hop that leads nowhere and a conflict keyed on
+/// nothing. Measured on a 6,964-row production store (2026-09-06, issue
+/// #213): 43,617 entities, 48% ALL-CAPS, 37% carrying digits, 11% bare
+/// numbers or versions, 19% four-plus words, and 55 of the 99 surviving
+/// heuristic claims had an all-caps endpoint. The relation extractor was
+/// precise by then (#210); the residual junk was all admission.
+///
+/// Rules, each answering one measured class:
+/// - no alphabetic character (`2026`, `0.19.0`, `15`): never a node. These
+///   are VALUES; see [`extract_value_candidates`] — they stay available as
+///   relation objects (`CT128 -runs-> 0.19.0`) without becoming entities.
+/// - all function words / bare months, or a prose run: rejected (as before).
+/// - more than [`ENTITY_MAX_WORDS`] words or [`ENTITY_MAX_CHARS`] chars: a
+///   heading or a sentence, not a name.
+/// - one ALL-CAPS token longer than [`ACRONYM_MAX_CHARS`]: a shouted word.
+/// - every token ALL-CAPS and any token longer than
+///   [`ACRONYM_RUN_TOKEN_MAX_CHARS`]: a shouted heading (`STRATEGIC POINT`);
+///   `NASA JPL` stays.
+/// - a trailing possessive clitic (`Pranab's`, typographic too) is a
+///   straggler from an older extractor: refused, the owner is its own node.
+pub fn admit_entity(name: &str) -> bool {
+    let name = name.trim();
+    // A possessive straggler is the grammar around a name, not a name: the
+    // chunker canonicalises `Sol's` to `Sol` for fresh text, so a stored
+    // `Pranab's` can only be an older extractor's leftover, and its owner
+    // already exists as its own node.
+    if name.ends_with("'s") || name.ends_with("\u{2019}s") || name.ends_with('\'') {
+        return false;
+    }
+    if is_rejected_entity_name(name) {
+        return false;
+    }
+    // Strip function words from both ends before judging the core: the
+    // chunker already does this for fresh text, but stored names from older
+    // extractors (`NOT 1348`, `THE Most`) arrive here whole through the
+    // heal, and a function word must not lend a number its letters.
+    let mut toks: Vec<&str> = name.split_whitespace().collect();
+    while toks.first().is_some_and(|t| is_entity_stopword(t)) {
+        toks.remove(0);
+    }
+    while toks
+        .last()
+        .is_some_and(|t| is_entity_stopword(t) && t.chars().count() > 1)
+    {
+        toks.pop();
+    }
+    if toks.is_empty() || !toks.iter().any(|t| t.chars().any(|c| c.is_alphabetic())) {
+        return false;
+    }
+    if toks.len() > ENTITY_MAX_WORDS || name.chars().count() >= ENTITY_MAX_CHARS {
+        return false;
+    }
+    let caps: Vec<bool> = toks.iter().map(|t| is_all_caps_token(t)).collect();
+    if toks.len() == 1 && caps[0] && toks[0].chars().count() > ACRONYM_MAX_CHARS {
+        return false;
+    }
+    if toks.len() > 1
+        && caps.iter().all(|&c| c)
+        && toks
+            .iter()
+            .any(|t| t.chars().count() > ACRONYM_RUN_TOKEN_MAX_CHARS)
+    {
+        return false;
+    }
+    true
+}
+
+/// Value objects: tokens that name a quantity, version or year rather than
+/// a thing — no letters, at least one digit (`0.19.0`, `2026`, `1985`,
+/// `3.6`). They are never entities (see [`admit_entity`]) but the relation
+/// extractor needs them as OBJECTS so `born_in 1985` and `runs 0.19.0` keep
+/// minting claims; those claims then feed succession detection (`runs` is
+/// functional), which is the whole reason the value is worth keeping.
+/// A value object: no letters, at least one digit (`0.19.0`, `1985`, `3.6`).
+/// Admissible as a claim OBJECT, never as a subject or an entity node.
+pub fn is_value_object(name: &str) -> bool {
+    let name = name.trim();
+    !name.is_empty()
+        && !name.chars().any(|c| c.is_alphabetic())
+        && name.chars().any(|c| c.is_ascii_digit())
+}
+
+pub fn extract_value_candidates(text: &str) -> Vec<String> {
+    let stripped = strip_code(text);
+    let mut out: Vec<String> = Vec::new();
+    for word in stripped
+        .split(|c: char| {
+            c.is_whitespace() || matches!(c, ',' | ';' | ':' | '(' | ')' | '[' | ']' | '"' | '\'')
+        })
+        .filter(|s| !s.is_empty())
+    {
+        let w = word.trim_end_matches(|c: char| c == '.' || c == '!' || c == '?');
+        if !is_value_object(w) {
+            continue;
+        }
+        if !out.iter().any(|o| o == w) {
+            out.push(w.to_string());
+        }
+    }
+    out
+}
+
 /// Extract candidate proper-noun entities from free-form text using a
 /// capitalized-chunk heuristic. Groups consecutive capitalized words into
 /// multi-word entities ("Alice Chen", "San Francisco", "Acme Corp") and
@@ -433,6 +553,26 @@ pub fn extract_heuristic_entities(text: &str) -> Vec<String> {
 
 fn extract_heuristic_entities_inner(text: &str) -> Vec<String> {
     let mut entities: Vec<String> = Vec::new();
+    // Clause punctuation ends a name. Without this a heading swallows the
+    // name after its colon (`STRATEGIC POINT: CT128 runs` minted
+    // `STRATEGIC POINT CT128`, or nothing once headings were refused) and
+    // `San Francisco, California` welds into one entity. A period is NOT a
+    // boundary: `St. Louis`, `Dr. Smith` and `Acme Inc.` must stay whole.
+    for segment in text.split(|c: char| {
+        matches!(
+            c,
+            ':' | ';' | ',' | '!' | '?' | '\n' | '(' | ')' | '[' | ']' | '"'
+        )
+    }) {
+        extract_entities_from_segment(segment, &mut entities);
+    }
+    // Deduplicate while preserving first-appearance order.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    entities.retain(|e| seen.insert(e.clone()));
+    entities
+}
+
+fn extract_entities_from_segment(text: &str, entities: &mut Vec<String>) {
     let mut chunk: Vec<String> = Vec::new();
 
     let flush = |chunk: &mut Vec<String>, out: &mut Vec<String>| {
@@ -452,7 +592,10 @@ fn extract_heuristic_entities_inner(text: &str) -> Vec<String> {
         if !chunk.is_empty() && !is_prose_run(chunk) {
             let candidate = chunk.join(" ");
             let alpha_chars = candidate.chars().filter(|c| c.is_alphanumeric()).count();
-            if alpha_chars >= 2 {
+            // Admission is the gate every writer shares: the materializer,
+            // the batch path and the heals all mint through this function,
+            // so a name the table must never hold is refused exactly here.
+            if alpha_chars >= 2 && admit_entity(&candidate) {
                 out.push(candidate);
             }
         }
@@ -474,6 +617,15 @@ fn extract_heuristic_entities_inner(text: &str) -> Vec<String> {
             .or_else(|| word.strip_suffix('\''))
             .filter(|bare| !bare.is_empty());
         let entity_word = possessive.unwrap_or(word);
+        // A token without a letter (`2026`, `0.19.0`, `15`) is a value, not
+        // a name, and it must not glue to its neighbours either: `2026
+        // Alice Moreau` was the production store's most common shape of
+        // junk. Values reach the relation extractor through
+        // `extract_value_candidates`, never through this list.
+        if !entity_word.chars().any(|c| c.is_alphabetic()) {
+            flush(&mut chunk, entities);
+            continue;
+        }
         let first = entity_word.chars().next().unwrap();
         let starts_upper = first.is_uppercase();
         let is_all_caps = entity_word.len() > 1
@@ -493,18 +645,13 @@ fn extract_heuristic_entities_inner(text: &str) -> Vec<String> {
         if joins_chunk {
             chunk.push(entity_word.to_string());
             if possessive.is_some() {
-                flush(&mut chunk, &mut entities);
+                flush(&mut chunk, entities);
             }
         } else {
-            flush(&mut chunk, &mut entities);
+            flush(&mut chunk, entities);
         }
     }
-    flush(&mut chunk, &mut entities);
-
-    // Deduplicate while preserving first-appearance order.
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    entities.retain(|e| seen.insert(e.clone()));
-    entities
+    flush(&mut chunk, entities);
 }
 
 // ── Heuristic relation extraction (RFC 006 Phase 1) ──
@@ -2553,5 +2700,91 @@ mod possessive_entity_tests {
         for bad in ["Let", "It", "What"] {
             assert!(!ents.iter().any(|e| e == bad), "{bad:?} survived: {ents:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod entity_admission_tests {
+    use super::*;
+
+    /// Issue #213: the measured junk classes, one assertion each.
+    #[test]
+    fn measured_junk_classes_are_refused() {
+        for bad in [
+            "2026",                                 // bare year
+            "0.19.0",                               // version
+            "15",                                   // count
+            "STRATEGIC POINT",                      // shouted heading
+            "MASTERING",                            // one shouted word
+            "NOT 1348",                             // function word + number
+            "Recall Return Unrelated Records Root", // five-word run
+            "A Very Long Capitalized Phrase That Is Clearly A Sentence Not A Name",
+        ] {
+            assert!(!admit_entity(bad), "{bad:?} was admitted");
+        }
+    }
+
+    #[test]
+    fn real_names_and_acronyms_are_admitted() {
+        for good in [
+            "Alice Chen",
+            "Fennwick Labs",
+            "San Francisco",
+            "NASA",
+            "HNSW",
+            "FAISS",
+            "CT128",
+            "ONNX",
+            "NASA JPL",
+            "Series A",
+            "Q2",
+            "Indian Institute",
+            "O'Brien",
+            "Yantrikdb",
+        ] {
+            assert!(admit_entity(good), "{good:?} was refused");
+        }
+    }
+
+    #[test]
+    fn possessive_stragglers_are_refused_as_nodes() {
+        assert!(!admit_entity("Pranab\u{2019}s"));
+        assert!(!admit_entity("Pranab's"));
+        assert!(admit_entity("Pranab"));
+    }
+
+    #[test]
+    fn numbers_are_values_not_entities_but_still_relation_objects() {
+        let text = "CT128 runs 0.19.0 in production since 2026.";
+        let ents = extract_heuristic_entities(text);
+        assert!(ents.iter().any(|e| e == "CT128"), "{ents:?}");
+        assert!(
+            !ents.iter().any(|e| e == "0.19.0" || e == "2026"),
+            "value minted as entity: {ents:?}"
+        );
+        let values = extract_value_candidates(text);
+        assert_eq!(values, vec!["0.19.0".to_string(), "2026".to_string()]);
+        let mut cands = ents.clone();
+        cands.extend(values);
+        let rels = extract_heuristic_relations(text, &cands);
+        assert!(
+            rels.iter()
+                .any(|r| r.src == "CT128" && r.rel_type == "runs" && r.dst == "0.19.0"),
+            "runs claim lost its value object: {rels:?}"
+        );
+    }
+
+    #[test]
+    fn shouted_headings_never_reach_the_entity_list() {
+        let ents = extract_heuristic_entities(
+            "STRATEGIC POINT: MASTERING the release. The NASA JPL team shipped it.",
+        );
+        assert!(
+            !ents
+                .iter()
+                .any(|e| e.contains("STRATEGIC") || e == "MASTERING"),
+            "{ents:?}"
+        );
+        assert!(ents.iter().any(|e| e == "NASA JPL"), "{ents:?}");
     }
 }

--- a/crates/yantrikdb-python/src/py_engine/cognition.rs
+++ b/crates/yantrikdb-python/src/py_engine/cognition.rs
@@ -388,6 +388,18 @@ impl PyYantrikDB {
         crate::py_types::json_to_py(py, &val)
     }
 
+    /// Entity-table heal (issue #213): re-apply today's admission predicate to
+    /// every stored entity, drop the refused ones (plus their links and any
+    /// extractor claim on them) unless a manual/stated claim asserts them,
+    /// then rebuild the graph index. Idempotent; `dry_run=True` only reports.
+    #[pyo3(signature = (dry_run=false))]
+    fn reextract_entities(&self, py: Python<'_>, dry_run: bool) -> PyResult<PyObject> {
+        let db = self.get_inner()?;
+        let out = db.reextract_entities(dry_run).map_err(map_err)?;
+        let val = serde_json::to_value(&out).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        crate::py_types::json_to_py(py, &val)
+    }
+
     /// One batch of the v50 source_turn recompute/repair pass — the
     /// maintenance operation `SourceTurnMaintenanceRequiredError` names.
     /// Returns `{"processed", "remaining", "complete"}`; call repeatedly

--- a/tests/test_capability_probes.py
+++ b/tests/test_capability_probes.py
@@ -330,3 +330,44 @@ def test_reextract_claims_replaces_legacy_junk_and_keeps_assertions(db):
     edges = {(e["src"], e["rel_type"], e["dst"]) for e in db.get_edges("Alice Moreau")}
     assert ("Alice Moreau", "works_at", "Fennwick Labs") in edges and ("Alice Moreau", "mentors", "Fennwick Labs") in edges
     assert ("Pranab", "works_at", "Acme") in {(e["src"], e["rel_type"], e["dst"]) for e in db.get_edges("Pranab")}
+
+
+# ── entity admission (issue #213) ────────────────────────────────────────
+
+
+def test_values_and_headings_are_never_entities_but_values_still_serve_claims(db):
+    """The measured junk classes at write time: a bare version, a year and a
+    shouted heading must not become graph nodes, while `runs 0.19.0` still
+    mints its claim with the value as the object."""
+    rid = db.record("STRATEGIC POINT: CT128 runs 0.19.0 since 2026. Alice Moreau was born in 1985.")
+    db.think()
+    names = {e["name"] for e in db.list_entities(limit=100)} if hasattr(db, "list_entities") else None
+    if names is not None:
+        for bad in ("STRATEGIC POINT", "0.19.0", "2026", "1985"):
+            assert bad not in names, names
+        assert "CT128" in names, names
+    edges = {(e["src"], e["rel_type"], e["dst"]) for e in db.get_edges("CT128")}
+    assert ("CT128", "runs", "0.19.0") in edges, edges
+    edges = {(e["src"], e["rel_type"], e["dst"]) for e in db.get_edges("Alice Moreau")}
+    assert ("Alice Moreau", "born_in", "1985") in edges, edges
+    rep = db.attach_claims(rid, [{"subject": "CT128", "relation": "runs", "object": "0.19.0"}])
+    assert len(rep["accepted"]) == 1, rep
+
+
+def test_reextract_entities_drops_legacy_junk_nodes_and_keeps_asserted_ones(db):
+    """A store written by an older extractor keeps its headings and numbers as
+    nodes; the heal removes them (links and heuristic claims included) and
+    keeps any node a writer asserted a claim on."""
+    a = db.record("Alice Moreau works at Fennwick Labs in Berlin.")
+    db.think()
+    db.relate("Alice Moreau", "ACME HOLDINGS INTERNATIONAL", "works_at")
+    dry = db.reextract_entities(dry_run=True)
+    assert dry["dry_run"] is True and dry["entities_removed"] == 0
+    assert dry["kept_by_claims"] >= 1, dry
+    report = db.reextract_entities()
+    assert report["entities_removed"] == report["inadmissible"] - report["kept_by_claims"], report
+    edges = {(e["src"], e["rel_type"], e["dst"]) for e in db.get_edges("Alice Moreau")}
+    assert ("Alice Moreau", "works_at", "Fennwick Labs") in edges, edges
+    assert ("Alice Moreau", "works_at", "ACME HOLDINGS INTERNATIONAL") in edges, edges
+    again = db.reextract_entities()
+    assert again["entities_removed"] == 0 and again["claims_removed"] == 0


### PR DESCRIPTION
## Summary

Entity admission (#213): values and headings never become graph nodes, and `reextract_entities()` heals the stores that already hold them.

Every admitted entity is a hop the claims lane, chain traversal, entity threads and `expand_entities` can follow. On the production store the table had grown to 43,617 nodes of which 48% were ALL-CAPS, 37% carried digits and 11% were bare numbers or versions; 55 of the 99 heuristic claims that survived the 0.19 heal had an all-caps endpoint. The relation extractor was precise after #210; what was left was admission.

## What changed

- **`graph::admit_entity`** is the one predicate every writer shares (chunker, claim path, heal). Refused: no letters; function words / prose runs (as before); more than 4 words or 40 chars; one shouted word over 6 chars (`MASTERING`); a shouted multi-word heading (`STRATEGIC POINT` — `NASA JPL` stays); possessive stragglers. Stopword ends are stripped before judging so `NOT 1348` cannot borrow letters.
- **Two chunker defects fixed at the source.** A digit-only token counted as all-caps, so it opened chunks and glued onto the next name (`2026 Alice Moreau` was the store's most common junk shape). Clause punctuation did not end a chunk, so a heading swallowed the name after its colon. A period is deliberately not a boundary (`St. Louis`, `Acme Inc.`).
- **Values are claim objects, not nodes.** `extract_value_candidates` feeds numbers, versions and years to the relation extractor, so `CT128 -runs-> 0.19.0` and `Alice -born_in-> 1985` still mint (`runs` is functional; the value is what succession keys on). `ingest_claim` no longer upserts a node for an inadmissible endpoint; stated claims accept a value object and refuse a value subject.
- **`reextract_entities(dry_run=False)`**: the entity-table twin of `reextract_claims`. Re-applies admission to every stored name, drops the refused ones with their `memory_entities` links and any extractor claim on them, keeps a name a manual or writer-stated claim asserts, rebuilds the graph index. Idempotent, store-wide (the table has no namespace). Python binding + probe.

## Measured

Rehearsal on a **copy of the live production store** (43,647 entities, schema v51), live untouched:

| | before | after |
|---|---:|---:|
| entities | 43,647 | 22,764 |
| ALL-CAPS | 20,979 | 8,033 (short acronyms: `LLM`, `API`, `PR`) |
| no letters | 4,641 | 6 (each asserted by a manual claim) |
| four-plus words | 8,254 | 1,464 (exactly four) |
| ≥ 40 chars | 1,986 | 0 |
| `memory_entities` links removed | | 371,922 |
| heuristic claims removed | | 36 |
| manual claims | 633 | 633 |
| wall time | | 35.7 s; second pass removes 0 |

Fresh re-ingest of the same 6,448 production texts, published 0.19.0 vs this build (`benchmarks/prod_extraction_census.py`, now reporting the #213 classes):

Fresh re-ingest of the same 6,448 production texts, published 0.19.0 wheel vs this build (`benchmarks/prod_extraction_census.py`, now reporting the #213 classes and every claim so the two runs can be diffed):

| | 0.19.0 | this build |
|---|---:|---:|
| entities | 25,359 | 14,291 |
| no letters | 2,609 | 0 |
| ALL-CAPS | 10,001 | 3,962 |
| four-plus words | 2,261 | 256 (exactly four) |
| ≥ 40 chars | 151 | 0 |
| entities failing the census junk rule | 2,611 | 2 |
| top-8 entities | `10`, `30`, `12`, YantrikDB, LLM, API, PR, `15` | UTC, PR, YantrikDB, LLM, API, Pranab, CI, Users |
| heuristic claims | 47 | 39 |
| claims with an all-caps endpoint | 29 | 24 |
| `runs` claims | 18 | 13 |

Claim by claim: 14 lost, 6 new. Every lost claim had a number or a shouted heading as its **subject** (`14 -works_at-> TCS`, `24 -runs-> 10`, `2GB -runs-> 17`, `CAPABILITY -runs-> DUE`, `DISCOVERY -lives_in-> SEPARATE`, `Pranab -runs-> PARALLEL`); one of the new ones is the same fact minted right (`Pranab -works_at-> TCS`), and `Pranab -born_in-> 2018` shows a value object serving as an object.

**What this does not fix, stated plainly.** Claim precision on this corpus (technical chat logs) is still low by eye even though the census's mechanical rule says 1 junk claim in 39: `Trying -runs-> 5`, `WEAKER -runs-> PrivateNetwork`, `LIMA -founded-> Aug` survive. The dominant remaining cause is a **sentence-initial common word admitted as a subject** (`Critically`, `Failed`, `Idempotent`, `Builder`) — a capitalized token the chunker cannot tell from a name without a lexicon or a part-of-speech signal. That is the next lever, and a different mechanism; this PR is the entity table. Note also that `mention_count` is drain-order dependent (Loop A increments only when its own link is first), so the same corpus gives different counts run to run; the entity *set* is stable.

## Verification

- `cargo test -p yantrikdb --lib`: 2135 passed; fmt clean; clippy findings are all in pre-existing files.
- Value objects are digits joined by `.` or `-` only: the first cut admitted anything digit-bearing and the census promptly minted `Bell -founded-> 67%` and `Idempotent -runs-> */5`; narrowed and re-measured (the table above is the narrowed build).
- Engine tests: measured junk classes refused / real names and acronyms admitted; values still serve as relation objects and stated-claim objects; heal removes inadmissible nodes + links + claims, keeps asserted nodes, is idempotent.
- Probe suite: 22 passed on the rebuilt wheel; graph/claims Python subset 137 passed.

## Deploy note

Back up, deploy, then `reextract_entities()` once (35 s on the production store). Pair with `reextract_claims()` if the store predates 0.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
