### PR TITLE
feat(claims): the temporal tag — stated claims carry valid_from/valid_to and inherit the record's event time

### DIFF
--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -1169,6 +1169,31 @@ pub struct StatedClaim {
     /// `1` asserted (default), `-1` denied.
     #[serde(default = "default_polarity")]
     pub polarity: i32,
+    /// World-validity start (unix seconds): when the stated fact became
+    /// true, not when it was written. Absent, the memory's own event time
+    /// (`event_time_min`, the temporal tag on the record) is used; absent
+    /// that too, the claim carries no window and only write order remains.
+    /// The conflict scanner treats non-overlapping windows as succession,
+    /// not contradiction (RFC 006), so this is what aligns a stated
+    /// relation with the time it held.
+    #[serde(default)]
+    pub valid_from: Option<f64>,
+    /// World-validity end; `None` means still true.
+    #[serde(default)]
+    pub valid_to: Option<f64>,
+}
+
+impl Default for StatedClaim {
+    fn default() -> Self {
+        Self {
+            src: String::new(),
+            rel_type: String::new(),
+            dst: String::new(),
+            polarity: 1,
+            valid_from: None,
+            valid_to: None,
+        }
+    }
 }
 
 fn default_polarity() -> i32 {
@@ -1232,6 +1257,19 @@ impl super::YantrikDB {
     /// See the module note above. Errors only on an unknown or inactive
     /// memory or an oversized batch; per-claim problems are REPORTED in
     /// `rejected`, never raised.
+    /// The record's temporal tag (`event_time_min`, set from metadata
+    /// `event_time_min`/`event_time_max` at write time), if any.
+    pub(crate) fn memory_event_time_min(&self, rid: &str) -> Option<f64> {
+        let conn = self.conn();
+        conn.query_row(
+            "SELECT event_time_min FROM memories WHERE rid = ?1",
+            params![rid],
+            |r| r.get::<_, Option<f64>>(0),
+        )
+        .ok()
+        .flatten()
+    }
+
     pub fn attach_claims(
         &self,
         memory_rid: &str,
@@ -1254,6 +1292,10 @@ impl super::YantrikDB {
             )));
         }
         let text_tokens = crate::graph::tokenize(&memory.text);
+        // The record's temporal tag: a claim stated without its own window
+        // inherits the time the memory is ABOUT, so relation and time stay
+        // aligned without the writer repeating the date per claim.
+        let event_min = self.memory_event_time_min(memory_rid);
         let mut report = AttachClaimsReport {
             memory_rid: memory_rid.to_string(),
             accepted: Vec::new(),
@@ -1351,8 +1393,8 @@ impl super::YantrikDB {
                 &memory.namespace,
                 claim.polarity,
                 "asserted",
-                None,
-                None,
+                claim.valid_from.or(event_min),
+                claim.valid_to,
                 STATED_CLAIM_EXTRACTOR,
                 Some("1.0"),
                 "high",

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -1494,6 +1494,9 @@ impl YantrikDB {
         heuristic_vec: &[String],
     ) -> usize {
         let mut written = 0usize;
+        // Extracted claims inherit the record's temporal tag too: a memory
+        // about 2024 yields claims valid from 2024, not from today.
+        let event_min = self.memory_event_time_min(rid);
         // Value objects (`0.19.0`, `1985`) are never entities but must stay
         // available as relation OBJECTS, or `runs`/`born_in` claims vanish
         // with the entity junk they used to ride on (issue #213).
@@ -1532,7 +1535,7 @@ impl YantrikDB {
                     namespace,
                     rel.polarity,
                     &rel.modality,
-                    None,
+                    event_min,
                     None,
                     "heuristic_v1",
                     Some("1.0"),
@@ -1582,7 +1585,7 @@ impl YantrikDB {
                         namespace,
                         rel.polarity,
                         &rel.modality,
-                        None,
+                        event_min,
                         None,
                         crate::engine::graph_ops::LEARNED_CLAIM_EXTRACTOR,
                         Some("1.0"),

--- a/crates/yantrikdb-core/src/engine/tests/learned_templates.rs
+++ b/crates/yantrikdb-core/src/engine/tests/learned_templates.rs
@@ -28,6 +28,8 @@ fn state(db: &YantrikDB, rid: &str, src: &str, rel: &str, dst: &str) {
                 rel_type: rel.into(),
                 dst: dst.into(),
                 polarity: 1,
+                valid_from: None,
+                valid_to: None,
             }],
         )
         .unwrap();

--- a/crates/yantrikdb-core/src/engine/tests/reextract_claims.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reextract_claims.rs
@@ -68,6 +68,8 @@ fn heal_replaces_extractor_claims_and_preserves_assertions() {
             rel_type: "mentors".into(),
             dst: "Fennwick Labs".into(),
             polarity: 1,
+            valid_from: None,
+            valid_to: None,
         }],
     )
     .unwrap();

--- a/crates/yantrikdb-core/src/engine/tests/reextract_entities.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reextract_entities.rs
@@ -190,6 +190,8 @@ fn new_writes_never_mint_values_or_headings_but_values_still_serve_as_objects() 
                 rel_type: "runs".into(),
                 dst: "0.19.0".into(),
                 polarity: 1,
+                valid_from: None,
+                valid_to: None,
             }],
         )
         .unwrap();

--- a/crates/yantrikdb-core/src/engine/tests/stated_claims.rs
+++ b/crates/yantrikdb-core/src/engine/tests/stated_claims.rs
@@ -28,6 +28,8 @@ fn claim(src: &str, rel: &str, dst: &str) -> StatedClaim {
         rel_type: rel.into(),
         dst: dst.into(),
         polarity: 1,
+        valid_from: None,
+        valid_to: None,
     }
 }
 
@@ -155,4 +157,99 @@ fn oversized_batch_is_refused_whole() {
         .map(|_| claim("Pranab", "prefers", "Vim"))
         .collect();
     assert!(db.attach_claims(&rid, &batch).is_err());
+}
+
+/// The temporal tag: a record's event time flows into the claims it
+/// states and the claims the extractor mints, and an explicit window on
+/// a stated claim wins over it.
+#[test]
+fn claims_inherit_the_records_event_time_unless_the_writer_gives_a_window() {
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let t_2024 = 1_704_067_200.0_f64; // 2024-01-01T00:00:00Z
+    let rid = db
+        .record_text(
+            "Alice Moreau works at Fennwick Labs, and Alice Moreau lives in Berlin.",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({"event_time_min": t_2024, "event_time_max": t_2024}),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    db.apply_pending_ops_once(100).unwrap();
+    let window = |src: &str, rel: &str, dst: &str| -> (Option<f64>, Option<f64>) {
+        db.conn()
+            .query_row(
+                "SELECT valid_from, valid_to FROM claims WHERE src = ?1 AND rel_type = ?2                  AND dst = ?3 AND tombstoned = 0",
+                rusqlite::params![src, rel, dst],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+    };
+    // Extracted claim inherits the record's event time.
+    assert_eq!(
+        window("Alice Moreau", "works_at", "Fennwick Labs"),
+        (Some(t_2024), None)
+    );
+    // Stated claim without a window inherits it too.
+    let rep = db
+        .attach_claims(
+            &rid,
+            &[StatedClaim {
+                src: "Alice Moreau".into(),
+                rel_type: "based_in".into(),
+                dst: "Berlin".into(),
+                ..StatedClaim::default()
+            }],
+        )
+        .unwrap();
+    assert_eq!(rep.accepted.len(), 1, "{rep:?}");
+    assert_eq!(
+        window("Alice Moreau", "based_in", "Berlin"),
+        (Some(t_2024), None)
+    );
+    // An explicit window wins.
+    let t_2025 = 1_735_689_600.0_f64;
+    let rep = db
+        .attach_claims(
+            &rid,
+            &[StatedClaim {
+                src: "Alice Moreau".into(),
+                rel_type: "visited".into(),
+                dst: "Berlin".into(),
+                valid_from: Some(t_2025),
+                valid_to: Some(t_2025 + 86_400.0),
+                ..StatedClaim::default()
+            }],
+        )
+        .unwrap();
+    assert_eq!(rep.accepted.len(), 1, "{rep:?}");
+    assert_eq!(
+        window("Alice Moreau", "visited", "Berlin"),
+        (Some(t_2025), Some(t_2025 + 86_400.0))
+    );
+    // A record without a tag yields claims without a window.
+    let rid2 = db
+        .record_text(
+            "Bob Lin works at Globex.",
+            "semantic",
+            0.5,
+            0.0,
+            604800.0,
+            &serde_json::json!({}),
+            "default",
+            0.8,
+            "general",
+            "user",
+            None,
+        )
+        .unwrap();
+    db.apply_pending_ops_once(100).unwrap();
+    let _ = rid2;
+    assert_eq!(window("Bob Lin", "works_at", "Globex"), (None, None));
 }

--- a/crates/yantrikdb-python/src/py_engine/graph.rs
+++ b/crates/yantrikdb-python/src/py_engine/graph.rs
@@ -44,11 +44,19 @@ impl PyYantrikDB {
                 .map(|v| v.extract::<i32>())
                 .transpose()?
                 .unwrap_or(1);
+            let window = |k: &str| -> PyResult<Option<f64>> {
+                d.get_item(k)?
+                    .filter(|v| !v.is_none())
+                    .map(|v| v.extract::<f64>())
+                    .transpose()
+            };
             stated.push(yantrikdb_core::StatedClaim {
                 src,
                 rel_type,
                 dst,
                 polarity,
+                valid_from: window("valid_from")?,
+                valid_to: window("valid_to")?,
             });
         }
         let report = db.attach_claims(memory_rid, &stated).map_err(map_err)?;

--- a/crates/yantrikdb-python/src/py_engine/graph.rs
+++ b/crates/yantrikdb-python/src/py_engine/graph.rs
@@ -97,6 +97,22 @@ impl PyYantrikDB {
         edges.iter().map(|e| edge_to_dict(py, e)).collect()
     }
 
+    /// Every claim touching an entity with its qualifiers: polarity,
+    /// modality, `valid_from`/`valid_to` (the temporal tag), extractor,
+    /// confidence band, provenance and a derived status. `get_edges` is
+    /// the bare graph view; this is the claims-table view.
+    #[pyo3(signature = (entity, namespace=None))]
+    fn get_claims(
+        &self,
+        py: Python<'_>,
+        entity: &str,
+        namespace: Option<&str>,
+    ) -> PyResult<PyObject> {
+        let db = self.get_inner()?;
+        let rows = db.get_claims(entity, namespace).map_err(map_err)?;
+        json_to_py(py, &serde_json::Value::Array(rows))
+    }
+
     #[pyo3(signature = (pattern=None, entity_type=None, limit=20))]
     fn search_entities(
         &self,

--- a/tests/test_capability_probes.py
+++ b/tests/test_capability_probes.py
@@ -380,22 +380,24 @@ def test_claims_inherit_the_records_event_time_and_a_stated_window_wins(db):
     """A record tagged with the time it is ABOUT (metadata event_time_min/max)
     passes that time to the claims it states and the claims the extractor
     mints, so relation and time stay aligned; an explicit valid_from on a
-    stated claim wins over it."""
+    stated claim wins over it. get_claims is the claims-table view that
+    shows the window (get_edges is the bare graph)."""
     t_2024 = 1_704_067_200.0
     rid = db.record("Alice Moreau works at Fennwick Labs, and Alice Moreau lives in Berlin.",
                     metadata={"event_time_min": t_2024, "event_time_max": t_2024})
     db.think()
-    edges = {(e["src"], e["rel_type"], e["dst"]): e for e in db.get_edges("Alice Moreau")}
-    assert edges[("Alice Moreau", "works_at", "Fennwick Labs")]["valid_from"] == t_2024, edges
+    claims = {(c["src"], c["rel_type"], c["dst"]): c for c in db.get_claims("Alice Moreau")}
+    assert claims[("Alice Moreau", "works_at", "Fennwick Labs")]["valid_from"] == t_2024, claims
     db.attach_claims(rid, [{"subject": "Alice Moreau", "relation": "based_in", "object": "Berlin"}])
     t_2025 = 1_735_689_600.0
     db.attach_claims(rid, [{"subject": "Alice Moreau", "relation": "visited", "object": "Berlin",
                             "valid_from": t_2025, "valid_to": t_2025 + 86_400}])
-    edges = {(e["src"], e["rel_type"], e["dst"]): e for e in db.get_edges("Alice Moreau")}
-    assert edges[("Alice Moreau", "based_in", "Berlin")]["valid_from"] == t_2024, edges
-    e = edges[("Alice Moreau", "visited", "Berlin")]
-    assert (e["valid_from"], e["valid_to"]) == (t_2025, t_2025 + 86_400), e
-    untagged = db.record("Bob Lin works at Globex.")
+    claims = {(c["src"], c["rel_type"], c["dst"]): c for c in db.get_claims("Alice Moreau")}
+    assert claims[("Alice Moreau", "based_in", "Berlin")]["valid_from"] == t_2024, claims
+    c = claims[("Alice Moreau", "visited", "Berlin")]
+    assert (c["valid_from"], c["valid_to"]) == (t_2025, t_2025 + 86_400), c
+    assert c["status_suggestion"] == "historical", c
+    db.record("Bob Lin works at Globex.")
     db.think()
-    e = {(x["src"], x["rel_type"], x["dst"]): x for x in db.get_edges("Bob Lin")}[("Bob Lin", "works_at", "Globex")]
-    assert e["valid_from"] is None and untagged
+    c = {(x["src"], x["rel_type"], x["dst"]): x for x in db.get_claims("Bob Lin")}[("Bob Lin", "works_at", "Globex")]
+    assert c["valid_from"] is None, c

--- a/tests/test_capability_probes.py
+++ b/tests/test_capability_probes.py
@@ -371,3 +371,31 @@ def test_reextract_entities_drops_legacy_junk_nodes_and_keeps_asserted_ones(db):
     assert ("Alice Moreau", "works_at", "ACME HOLDINGS INTERNATIONAL") in edges, edges
     again = db.reextract_entities()
     assert again["entities_removed"] == 0 and again["claims_removed"] == 0
+
+
+# ── temporal tag: claims carry the time they held ────────────────────────
+
+
+def test_claims_inherit_the_records_event_time_and_a_stated_window_wins(db):
+    """A record tagged with the time it is ABOUT (metadata event_time_min/max)
+    passes that time to the claims it states and the claims the extractor
+    mints, so relation and time stay aligned; an explicit valid_from on a
+    stated claim wins over it."""
+    t_2024 = 1_704_067_200.0
+    rid = db.record("Alice Moreau works at Fennwick Labs, and Alice Moreau lives in Berlin.",
+                    metadata={"event_time_min": t_2024, "event_time_max": t_2024})
+    db.think()
+    edges = {(e["src"], e["rel_type"], e["dst"]): e for e in db.get_edges("Alice Moreau")}
+    assert edges[("Alice Moreau", "works_at", "Fennwick Labs")]["valid_from"] == t_2024, edges
+    db.attach_claims(rid, [{"subject": "Alice Moreau", "relation": "based_in", "object": "Berlin"}])
+    t_2025 = 1_735_689_600.0
+    db.attach_claims(rid, [{"subject": "Alice Moreau", "relation": "visited", "object": "Berlin",
+                            "valid_from": t_2025, "valid_to": t_2025 + 86_400}])
+    edges = {(e["src"], e["rel_type"], e["dst"]): e for e in db.get_edges("Alice Moreau")}
+    assert edges[("Alice Moreau", "based_in", "Berlin")]["valid_from"] == t_2024, edges
+    e = edges[("Alice Moreau", "visited", "Berlin")]
+    assert (e["valid_from"], e["valid_to"]) == (t_2025, t_2025 + 86_400), e
+    untagged = db.record("Bob Lin works at Globex.")
+    db.think()
+    e = {(x["src"], x["rel_type"], x["dst"]): x for x in db.get_edges("Bob Lin")}[("Bob Lin", "works_at", "Globex")]
+    assert e["valid_from"] is None and untagged


### PR DESCRIPTION
## Summary

Stacked on #214. The temporal tag at ingestion: a record already says when it is ABOUT (`metadata.event_time_min/max`, persisted as columns since v48) and the claims table has carried world-validity windows since RFC 006, but nothing connected them. Now:

- `StatedClaim` gains `valid_from` / `valid_to` (optional unix seconds). `attach_claims` stores an explicit window as given, otherwise the record's `event_time_min`.
- Extracted claims (`heuristic_v1`, `learned_v1`) inherit `event_time_min` the same way, so a memory about 2024 yields claims valid from 2024, not from today.
- A record without a tag yields claims without a window, exactly as before.
- Python `attach_claims` reads `valid_from` / `valid_to` from the claim dicts. Probe added.

Why it matters: the conflict scanner already treats non-overlapping windows as succession rather than contradiction (RFC 006), so with the tag a 2024 fact recorded after the same 2026 fact reads as its predecessor. Before, only write order existed.

The MCP side (`remember(event_time=...)`, claim `valid_from`/`valid_to` strings) is a separate PR on yantrikdb-mcp.

## Verification

- `cargo test -p yantrikdb --lib`: 2136 passed. New engine test: extracted claim inherits the tag; stated claim without a window inherits it; explicit window wins; untagged record yields no window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
