### PR TITLE
release: v0.20.0

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -1510,7 +1510,10 @@ impl YantrikDB {
         for rel in &relations {
             // A value can be an object, never a subject: `2026 -leads-> X`
             // anchors nothing at read time and is refused there anyway.
-            if crate::graph::is_rejected_entity_name(&rel.src) {
+            // And only a few relations can take a value as an object.
+            if crate::graph::is_rejected_entity_name(&rel.src)
+                || !crate::graph::relation_admits_value_object(&rel.rel_type, &rel.dst)
+            {
                 continue;
             }
             let already_exists = {
@@ -1560,7 +1563,9 @@ impl YantrikDB {
         if !templates.is_empty() {
             let learned = crate::graph::extract_learned_relations(text, &candidates, &templates);
             for rel in &learned {
-                if crate::graph::is_rejected_entity_name(&rel.src) {
+                if crate::graph::is_rejected_entity_name(&rel.src)
+                    || !crate::graph::relation_admits_value_object(&rel.rel_type, &rel.dst)
+                {
                     continue;
                 }
                 let already_exists = {

--- a/crates/yantrikdb-core/src/engine/tests/reextract_entities.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reextract_entities.rs
@@ -181,6 +181,19 @@ fn new_writes_never_mint_values_or_headings_but_values_still_serve_as_objects() 
         edges.contains(&("Alice Moreau".into(), "born_in".into(), "1985".into())),
         "{edges:?}"
     );
+    // A value never rides a relation that cannot take one.
+    let rid3 = rec(&db, "Carol Vance leads 2 teams and Dana Ito works at 2026.");
+    db.apply_pending_ops_once(100).unwrap();
+    let junk: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM claims WHERE tombstoned = 0 AND source_memory_rid = ?1 \
+             AND rel_type IN ('leads', 'works_at')",
+            rusqlite::params![rid3],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(junk, 0, "a value object rode a generic relation");
     // A stated claim on a value object is still grounded and stored.
     let rep = db
         .attach_claims(

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -503,6 +503,20 @@ pub fn admit_entity(name: &str) -> bool {
 /// extractor needs them as OBJECTS so `born_in 1985` and `runs 0.19.0` keep
 /// minting claims; those claims then feed succession detection (`runs` is
 /// functional), which is the whole reason the value is worth keeping.
+/// Relations whose OBJECT may be a value object. A version, year or count
+/// is a sensible object of `runs` (`CT128 runs 0.19.0`) or `born_in`
+/// (`Alice born_in 1985`) — the functional shapes succession keys on — and
+/// of nothing else the extractor knows: the first cut let every pattern
+/// take a value and a production re-extraction minted `Make -leads-> 2`,
+/// `Qwen -leads-> 2`, `Make -leads-> 2026-08-11`.
+pub const VALUE_OBJECT_RELS: &[&str] = &["runs", "born_in", "founded_in", "released"];
+
+/// May this extracted relation carry a value object? A value is never a
+/// subject; as an object it is admitted only for [`VALUE_OBJECT_RELS`].
+pub fn relation_admits_value_object(rel_type: &str, dst: &str) -> bool {
+    !is_value_object(dst) || VALUE_OBJECT_RELS.contains(&rel_type)
+}
+
 /// A value object: a number, version, year or ISO date — digit groups
 /// joined by `.` or `-` only (`0.19.0`, `1985`, `3.6`, `2026-08-01`).
 /// Admissible as a claim OBJECT, never as a subject or an entity node.
@@ -2798,6 +2812,16 @@ mod entity_admission_tests {
                 .any(|r| r.src == "CT128" && r.rel_type == "runs" && r.dst == "0.19.0"),
             "runs claim lost its value object: {rels:?}"
         );
+    }
+
+    #[test]
+    fn values_are_objects_only_for_relations_that_can_take_one() {
+        assert!(relation_admits_value_object("runs", "0.19.0"));
+        assert!(relation_admits_value_object("born_in", "1985"));
+        assert!(relation_admits_value_object("leads", "Acme")); // not a value: unaffected
+        assert!(!relation_admits_value_object("leads", "2"));
+        assert!(!relation_admits_value_object("works_at", "2026-08-11"));
+        assert!(!relation_admits_value_object("ceo_of", "42"));
     }
 
     #[test]

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.19.0"
+version = "0.20.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.19.0"
+version = "0.20.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.20.0 — the entity table admits names, and claims carry the time they held

Schema unchanged (v51). Two mechanisms, both measured on a production store.

### Entity admission (#214, issue #213)
- `graph::admit_entity` is the one predicate every writer shares: the chunker, the claim path and the heal. Refused: names without a letter, function-word runs, more than 4 words or 40 chars, one shouted word over 6 chars, shouted multi-word headings (`STRATEGIC POINT`; `NASA JPL` stays), possessive stragglers.
- Two chunker defects fixed at the source: a digit-only token counted as all-caps and glued onto the next name (`2026 Alice Moreau`), and clause punctuation did not end a chunk (a heading swallowed the name after its colon). A period is deliberately not a boundary.
- Values are claim objects, not nodes: numbers, versions, years and ISO dates reach the relation extractor so `CT128 -runs-> 0.19.0` and `Alice -born_in-> 1985` still mint, and stated claims accept a value object (never a value subject). No node is upserted for an inadmissible claim endpoint.
- `reextract_entities(dry_run=False)`: re-applies admission to every stored entity, drops the refused ones with their links and any extractor claim on them, keeps names a manual or writer-stated claim asserts, rebuilds the graph index. Idempotent, store-wide.
- Measured on a copy of a 6,976-row production store with the release wheel: 43,675 → 22,776 entities, 372,109 junk links and 36 heuristic claims removed, 633 manual claims untouched, ~36 s; the claims heal on the same copy then re-extracts 84 claims (`runs` 30, `leads` 12, `works_at` 11, `lives_in` 10) with value objects confined to `runs`/`born_in` — the first candidate let every relation take a value and minted `Make -leads-> 2`, which is why VALUE_OBJECT_RELS exists. Fresh re-ingest of the same 6,448 texts: 25,359 → 14,291 entities, zero no-letter nodes, all-caps 10,001 → 3,962, four-plus-word 2,261 → 256; the most-mentioned "entities" go from `10`, `30`, `12` to UTC, PR, YantrikDB.
- Stated limit: a sentence-initial common word (`Critically`, `Failed`, `Lets`) is still admitted as a subject, and clause splitting exposes a few more such pairs to the generic `leads` pattern on chat-log corpora; that needs a lexicon or a part-of-speech signal and is the next lever.

### The temporal tag (#215)
- `StatedClaim` carries `valid_from` / `valid_to`. `attach_claims` stores an explicit window as given and otherwise the record's own event time (`metadata.event_time_min`, persisted since v48). Extracted claims inherit it the same way; an untagged record yields claims without a window, exactly as before.
- Why: the conflict scanner already treats non-overlapping windows as succession rather than contradiction (RFC 006). With the tag, a 2024 fact recorded after the same 2026 fact reads as its predecessor. Before, only write order existed.
- Python: `get_claims(entity, namespace=None)` is the claims-table view (windows, extractor, provenance, status suggestion); `get_edges` stays the bare graph. `attach_claims` reads `valid_from` / `valid_to` from the claim dicts.

### Deploying to an existing store
Back up, install, then run `reextract_entities()` once (~36 s on the store above) and, if the store predates 0.19, `reextract_claims()` once. Both are idempotent.
