### PR TITLE
release: v0.21.0

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.20.0"
+version = "0.21.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.20.0"
+version = "0.21.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.21.0 — the store learns its own lexicon

Schema **v52** (additive: `token_case_stats`; migrates on open).

### Common words are not entity subjects (#217)
- After 0.20.0 the junk that remained in the claims layer had one shape: a sentence-initial common word admitted as a subject (`Critically -reports_to-> Taylor`, `Lets -leads-> Recall`, `Make -leads-> 2`). A capitalized token at a sentence start says nothing about whether it is a name; the store's own history of how it writes that token does.
- The materializer now counts, per token, how often this store writes it lowercase, capitalized mid-sentence (the shape a name has) and capitalized by position only — one observation per token per class per memory, never on encrypted stores. A single-token candidate the store writes lowercase twice as often as mid-sentence-capitalized is a word (`recall` 982:71); a token capitalized mid-sentence more than lowercase and at least as often as at sentence starts is a name (`Pranab`, `API`, and a brand called `Target`); a hand-written seed of ~360 sentence starters covers cold stores. No external word list, so no licence rides along.
- Shouted words are judged by the same statistic, so `CLASS`, `CODE`, `FIX` headings are refused while `API`, `PR`, `UTC` stay.
- `reextract_entities()` rebuilds the lexicon from all active texts first, then applies admission with it; names kept because a real claim asserts them lose their links (a `2026` asserted once stops being a 49-link hub), and a `co_occurs_with` edge no longer counts as an assertion (auto-relate stamps them `manual`; they are derived). The entity-hub trigger skips names admission refuses.
- Measured on a copy of a production store already healed by 0.20.0: 22,814 → 17,983 entities, 899,360 stale links and 505 derived co-occurrence edges on refused names removed, every non-generic manual claim kept; the mention-count leaders go from `Pranab, NOT, 10, LLM, API, YantrikDB, AND, PR, CI, NO` to `Pranab, LLM, API, YantrikDB, PR, CI, MCP, JSON, GitHub, DB`.

### Instruments
- `benchmarks/prod_extraction_census.py` drains the materializer until the store stops changing (three stable reads) rather than a fixed number of `think()` calls; a fixed count under-drained on a loaded host and made two arms incomparable.

### Deploying to an existing store
Back up, install, then run `reextract_entities()` once (it rebuilds the lexicon, ~1 min on a 7k-row store) and `reextract_claims()` once. Both are idempotent.

### Stated limit
A common word used as a real name on a cold store with no history (a person called `Will` in a single memory) is refused until the store has written it capitalized mid-sentence three times more than lowercase; once it exists as a node from any other source, the graph-index backfill links it.
