### PR TITLE
perf(lexicon): one transaction per memory for token_case_stats, not one per token

### DIFF
--- a/benchmarks/ingest_write_cost.py
+++ b/benchmarks/ingest_write_cost.py
@@ -1,0 +1,24 @@
+"""Write-path cost probe: record 300 synthetic memories, then drain the materializer.
+
+Run it against two installed engine versions and compare the two lines. It caught
+the 0.21.0 regression where the lexicon wrote one autocommit per token
+(drain 10.5 s -> 17.8 s on this probe; the BEAM capture took twice as long):
+
+    python benchmarks/ingest_write_cost.py
+"""
+import sys, time, math, tempfile, os, random
+import yantrikdb
+from yantrikdb import YantrikDB
+random.seed(7)
+words = ["alpha","beta","gamma","delta","Alice","Moreau","Fennwick","Labs","Berlin","runs","works","the","of","in","Critically","Failed","project","release","version","0.19.0","2026","CT128","API","PR","team","plan","fix","next","done","start"]
+texts = [" ".join(random.choice(words) for _ in range(120)) + "." for _ in range(300)]
+d = tempfile.mkdtemp(); db = YantrikDB(os.path.join(d, "b.db"), 64)
+def unit(s):
+    v=[math.sin(s*(i+1)) for i in range(64)]; n=math.sqrt(sum(x*x for x in v)); return [x/n for x in v]
+t0 = time.perf_counter()
+for i, t in enumerate(texts): db.record(text=t, embedding=unit(i+1))
+t1 = time.perf_counter()
+for _ in range(40): db.think({"run_consolidation": False, "run_pattern_mining": False, "run_conflict_scan": False})
+t2 = time.perf_counter()
+print(f"engine {yantrikdb.__version__}: record 300 = {t1-t0:.1f}s, drain = {t2-t1:.1f}s, entities={db.stats()['entities']}")
+db.close()

--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -1263,17 +1263,18 @@ impl super::YantrikDB {
         conn: &rusqlite::Connection,
         token: &str,
     ) -> Option<crate::graph::CaseStats> {
-        conn.query_row(
-            "SELECT lower_n, cap_mid_n, cap_start_n FROM token_case_stats WHERE token = ?1",
-            params![token],
-            |r| {
-                Ok(crate::graph::CaseStats {
-                    lower_n: r.get(0)?,
-                    cap_mid_n: r.get(1)?,
-                    cap_start_n: r.get(2)?,
-                })
-            },
-        )
+        let mut stmt = conn
+            .prepare_cached(
+                "SELECT lower_n, cap_mid_n, cap_start_n FROM token_case_stats WHERE token = ?1",
+            )
+            .ok()?;
+        stmt.query_row(params![token], |r| {
+            Ok(crate::graph::CaseStats {
+                lower_n: r.get(0)?,
+                cap_mid_n: r.get(1)?,
+                cap_start_n: r.get(2)?,
+            })
+        })
         .ok()
     }
 
@@ -1288,19 +1289,40 @@ impl super::YantrikDB {
         if self.is_encrypted() {
             return Ok(());
         }
-        let mut stmt = conn.prepare_cached(
-            "INSERT INTO token_case_stats (token, lower_n, cap_mid_n, cap_start_n) \
-             VALUES (?1, ?2, ?3, ?4) \
-             ON CONFLICT(token) DO UPDATE SET lower_n = lower_n + ?2, \
-             cap_mid_n = cap_mid_n + ?3, cap_start_n = cap_start_n + ?4",
-        )?;
-        for (token, class) in crate::graph::token_case_observations(text) {
-            let (l, m, st) = match class {
-                crate::graph::TokenCase::Lower => (1, 0, 0),
-                crate::graph::TokenCase::CapMid => (0, 1, 0),
-                crate::graph::TokenCase::CapStart => (0, 0, 1),
-            };
-            stmt.execute(params![token, l, m, st])?;
+        let observations = crate::graph::token_case_observations(text);
+        if observations.is_empty() {
+            return Ok(());
+        }
+        // One transaction per memory, not one per token: a 120-word memory
+        // has ~100 distinct tokens, and 100 autocommits per write made the
+        // materializer drain 70% slower on the 0.21.0 wheel (10.5 s -> 17.8 s
+        // for 300 memories). A savepoint nests safely under any outer
+        // transaction the caller may hold.
+        conn.execute_batch("SAVEPOINT token_case_stats")?;
+        let result = (|| -> Result<()> {
+            let mut stmt = conn.prepare_cached(
+                "INSERT INTO token_case_stats (token, lower_n, cap_mid_n, cap_start_n) \
+                 VALUES (?1, ?2, ?3, ?4) \
+                 ON CONFLICT(token) DO UPDATE SET lower_n = lower_n + ?2, \
+                 cap_mid_n = cap_mid_n + ?3, cap_start_n = cap_start_n + ?4",
+            )?;
+            for (token, class) in &observations {
+                let (l, m, st) = match class {
+                    crate::graph::TokenCase::Lower => (1, 0, 0),
+                    crate::graph::TokenCase::CapMid => (0, 1, 0),
+                    crate::graph::TokenCase::CapStart => (0, 0, 1),
+                };
+                stmt.execute(params![token, l, m, st])?;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => conn.execute_batch("RELEASE token_case_stats")?,
+            Err(e) => {
+                let _ =
+                    conn.execute_batch("ROLLBACK TO token_case_stats; RELEASE token_case_stats");
+                return Err(e);
+            }
         }
         Ok(())
     }
@@ -1321,12 +1343,20 @@ impl super::YantrikDB {
                 .collect::<std::result::Result<_, _>>()?;
             rows
         };
+        // One transaction for the whole rebuild: 6,449 memories of
+        // per-token upserts is the heal's dominant cost otherwise.
+        conn.execute_batch("SAVEPOINT token_case_rebuild")?;
         let mut n = 0usize;
         for stored in &texts {
             let text = self.decrypt_text(stored).unwrap_or_else(|_| stored.clone());
-            self.record_token_case_observations(&conn, &text)?;
+            if let Err(e) = self.record_token_case_observations(&conn, &text) {
+                let _ = conn
+                    .execute_batch("ROLLBACK TO token_case_rebuild; RELEASE token_case_rebuild");
+                return Err(e);
+            }
             n += 1;
         }
+        conn.execute_batch("RELEASE token_case_rebuild")?;
         Ok(n)
     }
 


### PR DESCRIPTION
## Summary

0.21.0 folded each memory's case observations into `token_case_stats` with one autocommitted upsert per token, about 100 commits per 120-word memory.

Measured with the new `benchmarks/ingest_write_cost.py` (300 synthetic memories, then drain):

| | 0.20.0 | 0.21.0 | this build |
|---|---:|---:|---:|
| record 300 | 5.6 s | 7.0 s | 6.1 s (0.20.0 rerun 6.2 s) |
| materializer drain | 10.5 s | 17.8 s | 13.4 s (0.20.0 rerun 12.2 s) |

The BEAM 100K context capture (20 units) took 1,001 s on 0.21.0 against 496 s on the anchor, which is how it was noticed.

## Change

- `record_token_case_observations` runs under a savepoint per memory (a savepoint nests safely under any outer transaction the caller holds) and rolls back on error.
- `rebuild_token_case_stats` runs under one savepoint for the whole rebuild.
- `token_case_stats` lookup uses a cached statement.

No behaviour change; `cargo test -p yantrikdb --lib` 2143 passed. Intended for 0.21.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
