### PR TITLE
release: v0.21.1

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.21.0"
+version = "0.21.1"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.21.0"
+version = "0.21.1"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.21.1 — the lexicon writes in one transaction per memory

Schema unchanged (v52). One change, no behaviour change (#219).

- 0.21.0 folded each memory's case observations into `token_case_stats` with one autocommitted upsert per token, about 100 commits per 120-word memory. On the new `benchmarks/ingest_write_cost.py` probe (300 memories, then drain) that cost record 5.6 → 7.0 s and materializer drain 10.5 → 17.8 s against 0.20.0; a 400-query BEAM context capture took twice as long.
- Now one savepoint per memory (nests under any outer transaction, rolls back on error), one savepoint for the whole lexicon rebuild inside `reextract_entities()`, and a cached lookup statement. After: record 6.1 s vs 6.2 s, drain 13.4 s vs 12.2 s.
- `benchmarks/ingest_write_cost.py` joins the repo so the next write-path regression is caught before a release.

Deploying: install; no heal needed beyond what 0.21.0 already ran (both heals stay idempotent).
