### PR TITLE
extract: a sentence-final period ends a name

### DIFF
--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -838,7 +838,7 @@ pub enum TokenCase {
 /// says nothing about whether it is a name, which is the whole reason the
 /// class exists.
 pub fn token_case_observations(text: &str) -> Vec<(String, TokenCase)> {
-    let stripped = strip_code(text);
+    let stripped: String = mark_sentence_ends(strip_code(text).as_ref());
     let mut seen: std::collections::HashSet<(String, TokenCase)> = std::collections::HashSet::new();
     let mut out = Vec::new();
     for segment in stripped.split(|c: char| {
@@ -1127,10 +1127,62 @@ where
     extract_heuristic_entities_inner(stripped.as_ref(), &lookup)
 }
 
+/// Titles after which a period is an abbreviation, not a sentence end:
+/// `St. Louis`, `Dr. Smith`, `Gen. Patton` must not split inside the name.
+/// Company suffixes (`Inc.`, `Ltd.`) are deliberately NOT here: they end
+/// sentences far more often than they precede a capitalized continuation,
+/// and `Acme Inc. Then Bob left` welded into `Acme Inc Then Bob`.
+const ABBREVIATIONS_BEFORE_PERIOD: &[&str] = &[
+    "mr", "mrs", "ms", "dr", "prof", "st", "mt", "ft", "gen", "sen", "rep", "gov", "capt", "lt",
+    "sgt", "col",
+];
+
+/// Mark sentence ends so a name at the end of one sentence is never welded
+/// to the capitalized word that opens the next. Measured 2026-09-06: the
+/// chunker read `moved to Munich. Assistant: ok` as the entity `Munich
+/// Assistant`, so no `lives_in` claim could fire; every BEAM turn ends
+/// that way (`... . User:` / `... . Assistant:`) and ordinary prose does
+/// too (`works at Fennwick Labs. Alice Moreau lives in Berlin`). A period
+/// followed by whitespace becomes a hard boundary unless the token before
+/// it is a single letter (an initial: `J. K. Rowling`) or a known
+/// abbreviation; decimals (`0.19.0`) have no whitespace after the period
+/// and are untouched.
+fn mark_sentence_ends(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 8);
+    let chars: Vec<char> = text.chars().collect();
+    let mut word = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '.' {
+            let next_ws = i + 1 >= chars.len() || chars[i + 1].is_whitespace();
+            let prev = word.to_lowercase();
+            let is_abbrev = prev.chars().count() == 1 && prev.chars().all(|ch| ch.is_alphabetic())
+                || ABBREVIATIONS_BEFORE_PERIOD.contains(&prev.as_str());
+            out.push('.');
+            if next_ws && !prev.is_empty() && !is_abbrev {
+                out.push('\n');
+            }
+            word.clear();
+        } else {
+            if c.is_alphanumeric() || c == '\'' {
+                word.push(c);
+            } else {
+                word.clear();
+            }
+            out.push(c);
+        }
+        i += 1;
+    }
+    out
+}
+
 fn extract_heuristic_entities_inner(
     text: &str,
     lookup: &dyn Fn(&str) -> Option<CaseStats>,
 ) -> Vec<String> {
+    let text_owned = mark_sentence_ends(text);
+    let text = text_owned.as_str();
     let mut entities: Vec<String> = Vec::new();
     // Clause punctuation ends a name. Without this a heading swallows the
     // name after its colon (`STRATEGIC POINT: CT128 runs` minted
@@ -3586,5 +3638,72 @@ mod common_word_tests {
             assert_eq!(*w, w.to_lowercase(), "{w}");
             assert!(seen.insert(*w), "duplicate {w}");
         }
+    }
+}
+
+#[cfg(test)]
+mod sentence_boundary_tests {
+    use super::*;
+
+    #[test]
+    fn a_name_at_a_sentence_end_is_not_welded_to_the_next_sentence() {
+        for (text, must_have, must_not) in [
+            (
+                "[June-02-2024 | Turn 0] User: Alice Moreau moved to Munich. Assistant: ok.",
+                vec!["Alice Moreau", "Munich"],
+                vec!["Munich Assistant"],
+            ),
+            (
+                "Alice Moreau works at Fennwick Labs. Alice Moreau lives in Berlin.",
+                vec!["Fennwick Labs", "Berlin"],
+                vec!["Fennwick Labs Alice Moreau"],
+            ),
+            (
+                "We met in St. Louis with Dr. Smith of Acme Inc. Then Bob left.",
+                vec!["St Louis", "Dr Smith", "Acme Inc"],
+                vec!["Acme Inc Then", "Louis"],
+            ),
+            (
+                "J. K. Rowling signed. Carol Vance read it.",
+                vec!["J K Rowling", "Carol Vance"],
+                vec!["Rowling Carol Vance"],
+            ),
+        ] {
+            let ents = extract_heuristic_entities(text);
+            for e in &must_have {
+                assert!(
+                    ents.iter().any(|x| x == e),
+                    "{e:?} missing from {ents:?} for {text:?}"
+                );
+            }
+            for e in &must_not {
+                assert!(
+                    !ents.iter().any(|x| x == e),
+                    "{e:?} welded in {ents:?} for {text:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn beam_turn_format_now_mints_the_relation() {
+        let t = "[June-02-2024 | Turn 0] User: Alice Moreau moved to Munich. Assistant: ok.";
+        let ents = extract_heuristic_entities(t);
+        let rels = extract_heuristic_relations(t, &ents);
+        assert!(
+            rels.iter()
+                .any(|r| r.src == "Alice Moreau" && r.rel_type == "lives_in" && r.dst == "Munich"),
+            "{rels:?}"
+        );
+    }
+
+    #[test]
+    fn decimals_and_initials_keep_their_periods() {
+        let ents = extract_heuristic_entities("CT128 runs 0.19.0 now. Mt. Fuji is tall.");
+        assert!(ents.iter().any(|e| e == "Mt Fuji"), "{ents:?}");
+        assert_eq!(
+            extract_value_candidates("CT128 runs 0.19.0 now."),
+            vec!["0.19.0".to_string()]
+        );
     }
 }

--- a/crates/yantrikdb-core/src/knowledge/graph.rs
+++ b/crates/yantrikdb-core/src/knowledge/graph.rs
@@ -271,6 +271,22 @@ const MAX_ENTITY_TOKENS: usize = 6;
 /// Genuine all-caps names are short: `NASA`, `IBM`, `HNSW`, `IBM WATSON`.
 const MAX_ALLCAPS_TOKENS: usize = 2;
 
+/// `I'm`, `I'd`, `I'll`, `I've`, `We're`, `Don't`, `Can't`: an apostrophe
+/// followed by a clitic. `O'Brien` and `D'Arcy` have a capital after the
+/// apostrophe and a longer tail, and stay names.
+fn is_contraction(tok: &str) -> bool {
+    let lower = tok.to_lowercase();
+    if let Some(pos) = lower.find('\'') {
+        let tail = &lower[pos + 1..];
+        let next_upper = tok[pos + 1..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_uppercase());
+        return matches!(tail, "m" | "d" | "ll" | "ve" | "re" | "s" | "t") && !next_upper;
+    }
+    false
+}
+
 fn is_all_caps_token(tok: &str) -> bool {
     tok.chars().any(|c| c.is_alphabetic())
         && tok.chars().all(|c| !c.is_alphabetic() || c.is_uppercase())
@@ -991,6 +1007,9 @@ pub fn admit_entity(name: &str) -> bool {
     if name.ends_with("'s") || name.ends_with("\u{2019}s") || name.ends_with('\'') {
         return false;
     }
+    if name.split_whitespace().any(is_contraction) {
+        return false;
+    }
     if is_rejected_entity_name(name) {
         return false;
     }
@@ -1252,6 +1271,14 @@ fn extract_entities_from_segment(
             .or_else(|| word.strip_suffix('\''))
             .filter(|bare| !bare.is_empty());
         let entity_word = possessive.unwrap_or(word);
+        // A contraction (`I'm`, `I'd`, `We'll`, `Don't`) is grammar, not a
+        // name, and it must not open or extend a chunk: on BEAM every
+        // facts block the first cut rendered was `I'm -headquartered_in->
+        // East Janethaven`, the subject being the pronoun's contraction.
+        if is_contraction(entity_word) {
+            flush(&mut chunk, entities);
+            continue;
+        }
         // A token without a letter (`2026`, `0.19.0`, `15`) is a value, not
         // a name, and it must not glue to its neighbours either: `2026
         // Alice Moreau` was the production store's most common shape of
@@ -3705,5 +3732,36 @@ mod sentence_boundary_tests {
             extract_value_candidates("CT128 runs 0.19.0 now."),
             vec!["0.19.0".to_string()]
         );
+    }
+}
+
+#[cfg(test)]
+mod contraction_tests {
+    use super::*;
+
+    #[test]
+    fn contractions_are_never_names_but_irish_names_are() {
+        for bad in ["I'm", "I'd", "I'll", "We're", "Don't", "It's"] {
+            assert!(is_contraction(bad), "{bad}");
+            assert!(!admit_entity(bad), "{bad} admitted");
+        }
+        for good in ["O'Brien", "D'Arcy", "Alice", "Fennwick Labs"] {
+            assert!(!is_contraction(good), "{good}");
+            assert!(admit_entity(good), "{good} refused");
+        }
+        let ents = extract_heuristic_entities(
+            "I'm headquartered in East Janethaven. We'll meet Alice Moreau there.",
+        );
+        assert!(
+            !ents
+                .iter()
+                .any(|e| e.starts_with("I'm") || e.starts_with("We'll")),
+            "{ents:?}"
+        );
+        assert!(
+            ents.iter().any(|e| e == "East Janethaven") && ents.iter().any(|e| e == "Alice Moreau"),
+            "{ents:?}"
+        );
+        assert!(!admit_entity("I'm Alice"), "a contraction inside a name");
     }
 }


### PR DESCRIPTION
## Summary

Two extractor defects found while wiring the BEAM facts arm, both general:

1. **A sentence-final name welded to the next sentence's capital.** The chunker joined consecutive capitalized tokens across a period, so `moved to Munich. Assistant: ok` minted the entity `Munich Assistant` and no `lives_in` claim could fire; `works at Fennwick Labs. Alice Moreau lives in Berlin` minted `Fennwick Labs Alice Moreau`. Every BEAM turn ends `... . User:` / `... . Assistant:`, so the extractor was blind on most BEAM sentences, and ordinary prose has the same shape. A period followed by whitespace now ends a name for the chunker and the case observations, unless the token before it is an initial (`J. K. Rowling`) or a title (`St. Louis`, `Dr. Smith`, `Gen.`). Company suffixes deliberately split (`Acme Inc. Then Bob left`). Decimals have no whitespace after the period and are untouched.
2. **A contraction admitted as a subject.** The first BEAM facts arm rendered the same one-line block on 46 of 400 contexts: `I'm -headquartered_in-> East Janethaven`. Contractions (`I'm`, `I'd`, `We'll`, `Don't`, `It's`) now end a chunk instead of opening or extending one, and the admission predicate refuses stored names containing one; `O'Brien` and `D'Arcy` stay names.

## Measured

Production census (6,458 texts, both arms drained to a fixed point), published 0.21.1 vs this branch:

| | 0.21.1 | sentence boundary | + contractions |
|---|---:|---:|---:|
| entities | 14,614 | 13,758 | 13,733 |
| four-plus-word names | 346 | 326 | 326 |
| heuristic claims | 46 | 49 | 49 |
| claims lost / gained vs 0.21.1 | | 1 lost (`Dallas -lives_in-> Bentonville`, a weld), 4 gained (`Walmart Global Tech -headquartered_in-> Ramsey NJ`, `Walmart -headquartered_in-> Ramsey NJ`, `Pranab -lives_in-> Bentonville`, `Pranab -acquired-> MiniMax Plus`) | same set as the boundary arm (the contraction rule touches no claim on this corpus; it removed 25 more welded entities) |

BEAM 100K (judge-free context diff, provider unchanged): the boundary fix alone changes the retrieved set on 21 of 400 contexts (Jaccard 0.985, coverage −0.002); on the same wheel the engine now mints `Alice Moreau -lives_in-> Munich` from `[June-02-2024 | Turn 0] User: Alice Moreau moved to Munich. Assistant: ok.`, which it could not before.

## Verification

- `cargo test -p yantrikdb --lib`: 2146 passed (boundary), 2147 passed (with contractions). Unit: sentence-final names are not welded (BEAM turn format, two-sentence prose, titles, initials); the BEAM turn format mints the relation; decimals keep their periods; contractions refused, Irish names kept.
- Probes 24 passed on the rebuilt wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
