### PR TITLE
release: v0.21.2

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.21.1"
+version = "0.21.2"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.21.1"
+version = "0.21.2"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.21.2 — a sentence-final name ends at the period; a contraction is never a name

Schema unchanged (v52). Two extractor precision fixes (#221), no API change.

- **Sentence boundary.** The chunker joined consecutive capitalized tokens across a period, so a name that ended a sentence welded to the capitalized word opening the next: `moved to Munich. Assistant: ok` minted the entity `Munich Assistant` and no `lives_in` claim could fire; `works at Fennwick Labs. Alice Moreau lives in Berlin` minted `Fennwick Labs Alice Moreau`. Chat transcripts end nearly every turn that way, and ordinary prose has the same shape. A period followed by whitespace now ends a name unless the token before it is an initial (`J. K. Rowling`) or a title (`St. Louis`, `Dr. Smith`, `Gen.`); company suffixes deliberately split; decimals are untouched.
- **Contractions.** `I'm`, `I'd`, `We'll`, `Don't`, `It's` no longer open or extend a name, and the admission predicate refuses stored names containing one; `O'Brien` and `D'Arcy` stay names.
- Measured on a 6,458-text production export (both arms drained to a fixed point): entities 14,614 → 13,733, four-plus-word names 346 → 326, heuristic claims 46 → 49 with one welded claim lost and four correct facts gained (`Walmart Global Tech -headquartered_in-> Ramsey NJ`, `Pranab -lives_in-> Bentonville`, …). On BEAM 100K the engine now mints `Alice Moreau -lives_in-> Munich` from a turn-formatted line it could not read before; the retrieved set changes on 21 of 400 contexts.

Deploying to an existing store: install, then `reextract_claims()` once so previously welded sentences yield their claims (idempotent). `reextract_entities()` is unchanged and also idempotent.
