### PR TITLE
claims lane: an eligibility gate, shadow by default (schema v53)

### DIFF
--- a/crates/yantrikdb-core/src/base/schema.rs
+++ b/crates/yantrikdb-core/src/base/schema.rs
@@ -24,7 +24,7 @@
 // v51 adds the self-mined relation template tables (learned_relation_patterns +
 // support), fed by cooperative claims and applied by the materializer.
 // v52 adds token_case_stats, the store's own lexicon for entity admission.
-pub const SCHEMA_VERSION: i32 = 52;
+pub const SCHEMA_VERSION: i32 = 53;
 
 pub const SCHEMA_SQL: &str = "
 -- Memory records: the source of truth
@@ -734,6 +734,13 @@ CREATE TABLE IF NOT EXISTS claims (
     extractor TEXT NOT NULL DEFAULT 'manual',       -- manual|structured_ingest|heuristic_v1|agent_llm
     extractor_version TEXT,
     confidence_band TEXT NOT NULL DEFAULT 'medium', -- low|medium|high
+    -- v53: versioned grounding status. 0 = the argument binding was never
+    -- validated (every extractor row so far); 1 = cooperative: a writer
+    -- stated the claim and the engine grounded both endpoints in the source
+    -- text (attach_claims). The claim-chain gate reads this column; see
+    -- engine::claims_lane. Higher values are reserved for validated
+    -- extractor bindings.
+    grounding INTEGER NOT NULL DEFAULT 0,
     source_memory_rid TEXT,                         -- provenance: which memory spawned this claim
     span_start INTEGER,                             -- byte offset in source memory text
     span_end INTEGER,
@@ -3316,4 +3323,17 @@ CREATE TABLE IF NOT EXISTS token_case_stats (
     cap_mid_n INTEGER NOT NULL DEFAULT 0,
     cap_start_n INTEGER NOT NULL DEFAULT 0
 );
+";
+
+pub const MIGRATE_V52_TO_V53: &str = "
+-- v53: claims.grounding — a versioned grounding status the claim-chain gate
+-- reads (engine::claims_lane). 0 = binding never validated: every extractor
+-- row written before the gate existed, and every heuristic row since, until
+-- an extractor that validates its bindings sets a higher value. 1 =
+-- cooperative: the writer stated it and the engine grounded both endpoints
+-- in the text (attach_claims, extractor 'agent_stated'), so the backfill
+-- marks exactly those rows. The gate mode itself lives in meta
+-- ('claim_chain_gate_mode', seeded 'shadow' on open).
+ALTER TABLE claims ADD COLUMN grounding INTEGER NOT NULL DEFAULT 0;
+UPDATE claims SET grounding = 1 WHERE extractor = 'agent_stated';
 ";

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -644,6 +644,17 @@ pub struct Stats {
     /// consider `set_provenance_gate_mode(Enforce)` once callers are fixed.
     #[serde(default)]
     pub provenance_flagged_since_boot: u64,
+    /// Claim-chain gate mode (`off` | `shadow` | `enforce`); see
+    /// `engine::claims_lane`. Every install defaults to `shadow`.
+    #[serde(default)]
+    pub claim_chain_gate_mode: String,
+    /// Since boot: claims-lane admissions and traversals the gate would
+    /// refuse under `enforce`, keyed `hop1:<reason>` / `seed:<reason>` /
+    /// `hop2:<reason>` (reasons: ungrounded, not_yet_valid, superseded,
+    /// negated, non_asserted). Under `shadow` they were still admitted;
+    /// under `enforce` they were dropped. Empty under `off`.
+    #[serde(default)]
+    pub claim_chain_gate_suppressed_since_boot: HashMap<String, u64>,
     /// Non-tombstoned records carrying an explicit, caller-supplied
     /// `metadata.provenance_verified = true` marker. This is an audit signal,
     /// not an engine assertion: the engine cannot reconstruct authorship.

--- a/crates/yantrikdb-core/src/engine/claims_lane.rs
+++ b/crates/yantrikdb-core/src/engine/claims_lane.rs
@@ -107,41 +107,249 @@ pub(crate) fn claims_lex_strength(why: &[String]) -> Option<f64> {
     })
 }
 
-/// `(src, rel_type, dst, source_memory_rid, polarity)` rows of the
-/// claims touching `entity`, most recent first, with phantom endpoints
-/// already suppressed (see the note inside). Empty on a missing table.
-fn claims_touching(
-    conn: &Connection,
-    entity: &str,
-    namespace: Option<&str>,
-) -> Vec<(String, String, String, String, i64)> {
-    let sql = format!(
-        "SELECT src, rel_type, dst, source_memory_rid, polarity, extractor FROM claims \
-         WHERE (src = ?1 OR dst = ?1) AND tombstoned = 0 \
-         AND source_memory_rid IS NOT NULL {} \
-         ORDER BY created_at DESC LIMIT {}",
-        if namespace.is_some() {
-            "AND namespace = ?2"
-        } else {
-            ""
-        },
-        MAX_CLAIMS_PER_ENTITY,
-    );
-    let Ok(mut stmt) = conn.prepare_cached(&sql) else {
-        return Vec::new(); // no claims table — empty lane, never an error
+// ── Claim-chain eligibility gate (2026-09-07) ───────────────────────
+//
+// Measured on the production store after the 0.21.2 deploy: the heal
+// wrote `PyPI -works_at-> Google` (the subject search walked back past a
+// sentence boundary and a colon to the previous capitalized entity) and
+// `PyPI -runs-> CT128` (the true subject, lowercase `core`, was skipped),
+// and this lane then surfaced both with confident path provenance on a
+// query about CT128. Extraction will be fixed; the gate is what stops a
+// wrong claim from PROPAGATING in the meantime, and what keeps future
+// wrong claims from doing so.
+//
+// A claim is eligible for the lane when its `grounding` status says its
+// argument binding was validated (today: only cooperative claims, whose
+// endpoints the engine grounded in the text) AND it is valid as of the
+// query's time. A claim may additionally be TRAVERSED (used as a seed or
+// admitted as the second hop of a path) only when it is a positive,
+// asserted proposition — a denial or a reported rumour is exact evidence
+// about its anchor, never a link to chain through.
+//
+// Three modes, durable in `meta.claim_chain_gate_mode`, default `shadow`
+// on every install: `off` evaluates nothing; `shadow` admits exactly what
+// the lane admitted before and COUNTS what `enforce` would refuse
+// (`stats().claim_chain_gate_suppressed_since_boot`, keyed
+// `hop1:<reason>` / `seed:<reason>` / `hop2:<reason>`); `enforce` refuses
+// it. Under `enforce`, every edge of a path must be eligible — a path is
+// never built through a claim that could not stand on its own.
+
+/// `claims.grounding`: the binding was never validated (every extractor
+/// row so far).
+pub(crate) const GROUNDING_NONE: i64 = 0;
+/// `claims.grounding`: cooperative — the writer stated it, the engine
+/// grounded both endpoints in the source text (`attach_claims`).
+pub(crate) const GROUNDING_COOPERATIVE: i64 = 1;
+
+/// The claim-chain gate mode. See the module note above.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainGateMode {
+    Off,
+    Shadow,
+    Enforce,
+}
+
+impl ChainGateMode {
+    /// Parse a persisted or caller-supplied mode. A malformed value is a
+    /// typed error, never a silent `Off`.
+    pub fn parse(s: &str) -> crate::error::Result<Self> {
+        match s {
+            "off" => Ok(Self::Off),
+            "shadow" => Ok(Self::Shadow),
+            "enforce" => Ok(Self::Enforce),
+            other => Err(crate::error::YantrikDbError::InvalidInput(format!(
+                "claim_chain_gate_mode: expected off|shadow|enforce, got {other:?}"
+            ))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Shadow => "shadow",
+            Self::Enforce => "enforce",
+        }
+    }
+
+    pub fn as_u8(self) -> u8 {
+        match self {
+            Self::Off => 0,
+            Self::Shadow => 1,
+            Self::Enforce => 2,
+        }
+    }
+
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            2 => Self::Enforce,
+            1 => Self::Shadow,
+            _ => Self::Off,
+        }
+    }
+}
+
+/// Why a claim was (or under `enforce`, would be) refused by the gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Ineligible {
+    /// `grounding` says the binding was never validated.
+    Ungrounded,
+    /// `valid_from` is after the query's as-of time.
+    NotYetValid,
+    /// `valid_to` is before the query's as-of time.
+    Superseded,
+    /// Polarity is not positive — a denial is evidence, not a link.
+    Negated,
+    /// Modality is not `asserted` — reported, hypothetical, quoted.
+    NonAsserted,
+}
+
+impl Ineligible {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ungrounded => "ungrounded",
+            Self::NotYetValid => "not_yet_valid",
+            Self::Superseded => "superseded",
+            Self::Negated => "negated",
+            Self::NonAsserted => "non_asserted",
+        }
+    }
+}
+
+/// One refusal (real under `enforce`, hypothetical under `shadow`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Suppression {
+    /// `hop1` (a direct admission), `seed` (a hop-1 claim the path would
+    /// have continued from), `hop2` (a second-hop admission).
+    pub hop: &'static str,
+    pub reason: Ineligible,
+}
+
+impl Suppression {
+    /// The stats counter key, `hop1:ungrounded` and the like.
+    pub(crate) fn key(&self) -> String {
+        format!("{}:{}", self.hop, self.reason.as_str())
+    }
+}
+
+/// The gate as one recall sees it: the mode and the instant claims must
+/// be valid at (the end of the caller's time window, else now).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ChainGate {
+    pub mode: ChainGateMode,
+    pub as_of: f64,
+}
+
+impl ChainGate {
+    pub(crate) fn new(mode: ChainGateMode, as_of: f64) -> Self {
+        Self { mode, as_of }
+    }
+
+    /// No gate at all — the pre-gate lane, for tests of the lane itself.
+    #[cfg(test)]
+    pub(crate) fn off() -> Self {
+        Self {
+            mode: ChainGateMode::Off,
+            as_of: f64::MAX,
+        }
+    }
+}
+
+/// One claim row as the lane reads it.
+#[derive(Debug, Clone)]
+pub(crate) struct ClaimRow {
+    pub src: String,
+    pub rel: String,
+    pub dst: String,
+    /// The claim's source record — what the lane admits.
+    pub rid: String,
+    pub polarity: i64,
+    pub modality: String,
+    pub valid_from: Option<f64>,
+    pub valid_to: Option<f64>,
+    pub grounding: i64,
+}
+
+fn valid_as_of(row: &ClaimRow, as_of: f64) -> Option<Ineligible> {
+    if row.valid_from.is_some_and(|from| from > as_of) {
+        return Some(Ineligible::NotYetValid);
+    }
+    if row.valid_to.is_some_and(|to| to < as_of) {
+        return Some(Ineligible::Superseded);
+    }
+    None
+}
+
+/// May this claim be admitted as direct evidence about a query entity?
+pub(crate) fn direct_ineligibility(row: &ClaimRow, as_of: f64) -> Option<Ineligible> {
+    if row.grounding < GROUNDING_COOPERATIVE {
+        return Some(Ineligible::Ungrounded);
+    }
+    valid_as_of(row, as_of)
+}
+
+/// May this claim be chained through — used as a seed, or admitted as the
+/// second hop of a path? Stricter than direct admission: only a positive,
+/// asserted proposition links two entities.
+pub(crate) fn traversal_ineligibility(row: &ClaimRow, as_of: f64) -> Option<Ineligible> {
+    if let Some(reason) = direct_ineligibility(row, as_of) {
+        return Some(reason);
+    }
+    if row.polarity < 1 {
+        return Some(Ineligible::Negated);
+    }
+    if row.modality != "asserted" {
+        return Some(Ineligible::NonAsserted);
+    }
+    None
+}
+
+/// The claims touching `entity`, most recent first, with phantom
+/// endpoints already suppressed (see the note inside). Empty on a
+/// missing table. A `claims` table that predates v53 (a pack sealed
+/// before the column existed) is read through the legacy column set:
+/// its rows carry no grounding and no windows, which the gate reads as
+/// ungrounded — counted under `shadow`, refused under `enforce`.
+fn claims_touching(conn: &Connection, entity: &str, namespace: Option<&str>) -> Vec<ClaimRow> {
+    let ns_clause = if namespace.is_some() {
+        "AND namespace = ?2"
+    } else {
+        ""
     };
-    let mapper =
-        |row: &rusqlite::Row| -> rusqlite::Result<(String, String, String, String, i64, String)> {
-            Ok((
-                row.get(0)?,
-                row.get(1)?,
-                row.get(2)?,
-                row.get(3)?,
-                row.get(4)?,
-                row.get(5)?,
-            ))
-        };
-    let rows: Vec<(String, String, String, String, i64, String)> = if let Some(ns) = namespace {
+    let sql = format!(
+        "SELECT src, rel_type, dst, source_memory_rid, polarity, modality, valid_from, \
+         valid_to, grounding FROM claims \
+         WHERE (src = ?1 OR dst = ?1) AND tombstoned = 0 \
+         AND source_memory_rid IS NOT NULL {ns_clause} \
+         ORDER BY created_at DESC LIMIT {MAX_CLAIMS_PER_ENTITY}",
+    );
+    let legacy_sql = format!(
+        "SELECT src, rel_type, dst, source_memory_rid, polarity, 'asserted', NULL, NULL, \
+         {GROUNDING_NONE} FROM claims \
+         WHERE (src = ?1 OR dst = ?1) AND tombstoned = 0 \
+         AND source_memory_rid IS NOT NULL {ns_clause} \
+         ORDER BY created_at DESC LIMIT {MAX_CLAIMS_PER_ENTITY}",
+    );
+    let mut stmt = match conn.prepare_cached(&sql) {
+        Ok(stmt) => stmt,
+        Err(_) => match conn.prepare_cached(&legacy_sql) {
+            Ok(stmt) => stmt,
+            Err(_) => return Vec::new(), // no claims table — empty lane, never an error
+        },
+    };
+    let mapper = |row: &rusqlite::Row| -> rusqlite::Result<ClaimRow> {
+        Ok(ClaimRow {
+            src: row.get(0)?,
+            rel: row.get(1)?,
+            dst: row.get(2)?,
+            rid: row.get(3)?,
+            polarity: row.get(4)?,
+            modality: row.get(5)?,
+            valid_from: row.get(6)?,
+            valid_to: row.get(7)?,
+            grounding: row.get(8)?,
+        })
+    };
+    let rows: Vec<ClaimRow> = if let Some(ns) = namespace {
         stmt.query_map(params![entity, ns], mapper)
             .map(|r| r.filter_map(|x| x.ok()).collect())
             .unwrap_or_default()
@@ -151,7 +359,7 @@ fn claims_touching(
             .unwrap_or_default()
     };
     rows.into_iter()
-        .filter(|(src, _, dst, _, _, _extractor)| {
+        .filter(|row| {
             // PHANTOM SUPPRESSION — the claims-lane twin of the 0.14.1
             // GraphIndex::build_from_db heal. Claims written by pre-0.14.1
             // extractors keep stopword anchors (observed live 2026-08-16:
@@ -184,30 +392,35 @@ fn claims_touching(
             // Suppressed rows do occupy slots in the per-anchor fetch
             // window above; a phantom-heavy window yields fewer candidates,
             // which is the point — those rows were noise.
-            !(crate::graph::is_rejected_entity_name(src)
-                || crate::graph::is_rejected_entity_name(dst))
+            !(crate::graph::is_rejected_entity_name(&row.src)
+                || crate::graph::is_rejected_entity_name(&row.dst))
         })
-        .map(|(src, rel, dst, rid, polarity, _)| (src, rel, dst, rid, polarity))
         .collect()
 }
 
 /// Resolve `query_tokens` to entities and return the source records of
-/// their claims. Best-effort by design: a missing `claims` table (old
-/// packs) or any read error yields an empty lane, never a failed
-/// recall. Duplicate rids keep their first (best-anchored) why.
-/// Claims with a phantom endpoint (an entity today's extractor would
-/// not mint) are suppressed at read time, with NO extractor exemption —
-/// the V14→V15 backfill made 'manual' untrustworthy on lane rows; see
-/// the inline comment in the row loop.
+/// their claims, plus what the gate refused (or, under `shadow`, would
+/// have). Best-effort by design: a missing `claims` table (old packs) or
+/// any read error yields an empty lane, never a failed recall. Duplicate
+/// rids keep their first (best-anchored) why. Claims with a phantom
+/// endpoint (an entity today's extractor would not mint) are suppressed
+/// at read time, with NO extractor exemption — the V14→V15 backfill made
+/// 'manual' untrustworthy on lane rows; see the inline comment in
+/// `claims_touching`.
 pub(crate) fn claims_candidates(
     conn: &Connection,
     graph_index: &GraphIndex,
     query_tokens: &[String],
     namespace: Option<&str>,
-) -> Vec<ClaimCandidate> {
+    gate: &ChainGate,
+) -> (Vec<ClaimCandidate>, Vec<Suppression>) {
+    let mut suppressed: Vec<Suppression> = Vec::new();
+    let audit = gate.mode != ChainGateMode::Off;
+    let enforce = gate.mode == ChainGateMode::Enforce;
+
     let mut anchors = graph_index.entity_matches_query(query_tokens);
     if anchors.is_empty() {
-        return Vec::new();
+        return (Vec::new(), suppressed);
     }
     // Strongest anchors first (mention count), bounded — with entity
     // name as the TOTAL tiebreak. Fix (f), 2026-08-06: without it,
@@ -229,26 +442,57 @@ pub(crate) fn claims_candidates(
     // discovery order — deterministic because anchors and claim rows are.
     let mut path_seeds: Vec<(String, String, String)> = Vec::new();
     for (entity, _etype, _mentions) in &anchors {
-        for (src, rel, dst, rid, polarity) in claims_touching(conn, entity, namespace) {
-            let neg = if polarity < 0 { "NOT " } else { "" };
-            let far = if src == *entity { &dst } else { &src };
-            if chain_traversable(&rel)
+        for row in claims_touching(conn, entity, namespace) {
+            if audit {
+                if let Some(reason) = direct_ineligibility(&row, gate.as_of) {
+                    suppressed.push(Suppression {
+                        hop: "hop1",
+                        reason,
+                    });
+                    if enforce {
+                        continue; // neither admitted nor a seed
+                    }
+                }
+            }
+            let neg = if row.polarity < 0 { "NOT " } else { "" };
+            let far = if row.src == *entity {
+                &row.dst
+            } else {
+                &row.src
+            };
+            if chain_traversable(&row.rel)
                 && !anchor_names.contains(far.as_str())
                 && path_seeds.len() < MAX_PATH_SEEDS
                 && !path_seeds.iter().any(|(seed, _, _)| seed == far)
             {
-                path_seeds.push((
-                    far.clone(),
-                    entity.clone(),
-                    format!("{src} -{neg}{rel}-> {dst}"),
-                ));
+                let refused = if audit {
+                    traversal_ineligibility(&row, gate.as_of)
+                } else {
+                    None
+                };
+                if let Some(reason) = refused {
+                    suppressed.push(Suppression {
+                        hop: "seed",
+                        reason,
+                    });
+                }
+                if refused.is_none() || !enforce {
+                    path_seeds.push((
+                        far.clone(),
+                        entity.clone(),
+                        format!("{} -{neg}{}-> {}", row.src, row.rel, row.dst),
+                    ));
+                }
             }
-            if !seen.insert(rid.clone()) {
+            if !seen.insert(row.rid.clone()) {
                 continue;
             }
             out.push(ClaimCandidate {
-                why: format!("claims_match: {src} -{neg}{rel}-> {dst} (anchor {entity})"),
-                rid,
+                why: format!(
+                    "claims_match: {} -{neg}{}-> {} (anchor {entity})",
+                    row.src, row.rel, row.dst
+                ),
+                rid: row.rid,
                 hops: 1,
             });
         }
@@ -267,30 +511,43 @@ pub(crate) fn claims_candidates(
             continue;
         }
         let mut per_seed = 0usize;
-        for (src, rel, dst, rid, polarity) in rows {
+        for row in rows {
             if per_seed >= MAX_PATH_PER_SEED || path_admitted >= MAX_PATH_CANDIDATES {
                 break;
             }
-            if !chain_traversable(&rel) {
+            if !chain_traversable(&row.rel) {
                 continue; // generic link: never the second hop of a path
             }
-            if !seen.insert(rid.clone()) {
+            if seen.contains(&row.rid) {
                 continue; // hop-1 provenance, or the hop-1 claim read backwards
             }
-            let neg = if polarity < 0 { "NOT " } else { "" };
+            if audit {
+                if let Some(reason) = traversal_ineligibility(&row, gate.as_of) {
+                    suppressed.push(Suppression {
+                        hop: "hop2",
+                        reason,
+                    });
+                    if enforce {
+                        continue; // not marked seen: another claim may still admit the rid
+                    }
+                }
+            }
+            seen.insert(row.rid.clone());
+            let neg = if row.polarity < 0 { "NOT " } else { "" };
             out.push(ClaimCandidate {
                 why: format!(
-                    "claims_match: {hop1} ; {src} -{neg}{rel}-> {dst} \
-                     {PATH_MARKER}{seed}, anchor {anchor})"
+                    "claims_match: {hop1} ; {} -{neg}{}-> {} \
+                     {PATH_MARKER}{seed}, anchor {anchor})",
+                    row.src, row.rel, row.dst
                 ),
-                rid,
+                rid: row.rid,
                 hops: 2,
             });
             per_seed += 1;
             path_admitted += 1;
         }
     }
-    out
+    (out, suppressed)
 }
 
 impl super::YantrikDB {
@@ -337,12 +594,20 @@ impl super::YantrikDB {
         let Some(qt) = query_text else {
             return Ok(());
         };
-        let cands = {
+        // The gate evaluates claims as of the end of the caller's window,
+        // else now: a superseded claim is still the right answer to a
+        // question about the time it held.
+        let gate = ChainGate::new(
+            self.claim_chain_gate_mode(),
+            time_window.map_or(ts, |(_, hi)| hi),
+        );
+        let (cands, suppressed) = {
             let gi = self.graph_index.read();
             let tokens = crate::graph::tokenize(qt);
             let conn = self.read_conn();
-            claims_candidates(&conn, &gi, &tokens, namespace)
+            claims_candidates(&conn, &gi, &tokens, namespace, &gate)
         };
+        self.note_chain_gate_suppressions(&suppressed);
         if cands.is_empty() {
             return Ok(());
         }
@@ -494,8 +759,10 @@ mod tests {
                  dst TEXT NOT NULL, rel_type TEXT NOT NULL, weight REAL DEFAULT 1.0, \
                  created_at REAL NOT NULL, tombstoned INTEGER NOT NULL DEFAULT 0, \
                  polarity INTEGER NOT NULL DEFAULT 1, \
+                 modality TEXT NOT NULL DEFAULT 'asserted', valid_from REAL, valid_to REAL, \
                  extractor TEXT NOT NULL DEFAULT 'manual', source_memory_rid TEXT, \
-                 namespace TEXT NOT NULL DEFAULT 'default');
+                 namespace TEXT NOT NULL DEFAULT 'default', \
+                 grounding INTEGER NOT NULL DEFAULT 0);
              CREATE VIEW edges AS SELECT src, dst, weight, tombstoned FROM claims;",
         )
         .unwrap();
@@ -540,7 +807,7 @@ mod tests {
         let conn = seeded_store();
         let gi = GraphIndex::build_from_db(&conn).unwrap();
         let tokens = crate::graph::tokenize("what does DB use");
-        let cands = claims_candidates(&conn, &gi, &tokens, None);
+        let cands = claims_candidates(&conn, &gi, &tokens, None, &ChainGate::off()).0;
         let rids: Vec<&str> = cands.iter().map(|c| c.rid.as_str()).collect();
         assert!(
             !rids.contains(&"m1"),
@@ -583,7 +850,7 @@ mod tests {
         .unwrap();
         let gi = GraphIndex::build_from_db(&conn).unwrap();
         let tokens = crate::graph::tokenize("release 15 log architecture");
-        let cands = claims_candidates(&conn, &gi, &tokens, None);
+        let cands = claims_candidates(&conn, &gi, &tokens, None, &ChainGate::off()).0;
         let rids: Vec<&str> = cands.iter().map(|c| c.rid.as_str()).collect();
         assert!(
             !rids.contains(&"m9"),
@@ -606,7 +873,7 @@ mod tests {
             "fixture must reproduce the protected-anchor precondition"
         );
         let tokens = crate::graph::tokenize("the database leads");
-        let cands = claims_candidates(&conn, &gi, &tokens, None);
+        let cands = claims_candidates(&conn, &gi, &tokens, None, &ChainGate::off()).0;
         assert!(
             !cands.iter().any(|c| c.why.contains("DB -leads-> THE")),
             "the exact live phantom why must never be emitted, got {:?}",
@@ -701,7 +968,7 @@ mod tests {
         let conn = chain_store();
         let gi = GraphIndex::build_from_db(&conn).unwrap();
         let tokens = crate::graph::tokenize("which city does Alice Moreau work in");
-        let cands = claims_candidates(&conn, &gi, &tokens, None);
+        let cands = claims_candidates(&conn, &gi, &tokens, None, &ChainGate::off()).0;
         let direct = cands
             .iter()
             .find(|c| c.rid == "mA")
@@ -734,7 +1001,7 @@ mod tests {
         let conn = chain_store();
         let gi = GraphIndex::build_from_db(&conn).unwrap();
         let tokens = crate::graph::tokenize("Alice Moreau");
-        let cands = claims_candidates(&conn, &gi, &tokens, None);
+        let cands = claims_candidates(&conn, &gi, &tokens, None, &ChainGate::off()).0;
         assert_eq!(cands.iter().filter(|c| c.rid == "mA").count(), 1);
     }
 
@@ -760,7 +1027,7 @@ mod tests {
         }
         let gi = GraphIndex::build_from_db(&conn).unwrap();
         let tokens = crate::graph::tokenize("which city does Alice Moreau work in");
-        let cands = claims_candidates(&conn, &gi, &tokens, None);
+        let cands = claims_candidates(&conn, &gi, &tokens, None, &ChainGate::off()).0;
         assert!(
             cands.iter().all(|c| c.hops == 1),
             "hub must not be traversed: {:?}",
@@ -788,7 +1055,7 @@ mod tests {
         .unwrap();
         let gi = GraphIndex::build_from_db(&conn).unwrap();
         let tokens = crate::graph::tokenize("which city does Alice Moreau work in");
-        let cands = claims_candidates(&conn, &gi, &tokens, None);
+        let cands = claims_candidates(&conn, &gi, &tokens, None, &ChainGate::off()).0;
         assert!(
             cands.iter().any(|c| c.rid == "mB"),
             "real hop-2 still admitted"
@@ -813,5 +1080,216 @@ mod tests {
         assert_eq!(claims_lex_strength(&path), Some(PATH_CLAIM_LEX));
         assert!(PATH_CLAIM_LEX < DIRECT_CLAIM_LEX);
         assert_eq!(claims_lex_strength(&["keyword_match".to_string()]), None);
+    }
+
+    // ── Claim-chain eligibility gate ──
+
+    /// The production repro of 2026-09-07, verbatim: the heal minted
+    /// `PyPI -runs-> CT128` (true subject: lowercase `core`) and
+    /// `PyPI -works_at-> Google` (true subject: a quoted 'Sarah), and a
+    /// query about CT128 surfaced both with path provenance.
+    fn pypi_store() -> Connection {
+        let conn = seeded_store();
+        for (name, etype, mc) in [
+            ("CT128", "tech", 9),
+            ("PyPI", "org", 4),
+            ("Google", "org", 2),
+        ] {
+            conn.execute(
+                "INSERT INTO entities (name, entity_type, first_seen, last_seen, mention_count) \
+                 VALUES (?1, ?2, 0.0, 0.0, ?3)",
+                params![name, etype, mc],
+            )
+            .unwrap();
+        }
+        for (cid, src, dst, rel, ts, rid) in [
+            ("cRun", "PyPI", "CT128", "runs", 40.0, "mRun"),
+            ("cWork", "PyPI", "Google", "works_at", 41.0, "mWork"),
+        ] {
+            conn.execute(
+                "INSERT INTO claims (claim_id, src, dst, rel_type, created_at, \
+                 extractor, source_memory_rid) VALUES (?1, ?2, ?3, ?4, ?5, 'heuristic_v1', ?6)",
+                params![cid, src, dst, rel, ts, rid],
+            )
+            .unwrap();
+        }
+        for (rid, name) in [
+            ("mRun", "CT128"),
+            ("mRun", "PyPI"),
+            ("mWork", "PyPI"),
+            ("mWork", "Google"),
+        ] {
+            conn.execute(
+                "INSERT INTO memory_entities (memory_rid, entity_name) VALUES (?1, ?2)",
+                params![rid, name],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    fn run(conn: &Connection, query: &str, gate: ChainGate) -> (Vec<String>, Vec<String>) {
+        let gi = GraphIndex::build_from_db(conn).unwrap();
+        let tokens = crate::graph::tokenize(query);
+        let (cands, sups) = claims_candidates(conn, &gi, &tokens, None, &gate);
+        (
+            cands.iter().map(|c| c.rid.clone()).collect(),
+            sups.iter().map(|s| s.key()).collect(),
+        )
+    }
+
+    #[test]
+    fn shadow_counts_what_enforce_refuses_and_admits_everything() {
+        let conn = pypi_store();
+        let q = "what does CT128 run";
+        let (off_rids, off_sups) = run(&conn, q, ChainGate::off());
+        assert_eq!(
+            off_rids,
+            vec!["mRun", "mWork"],
+            "the pre-gate lane chains the junk"
+        );
+        assert!(off_sups.is_empty(), "off evaluates nothing");
+
+        let (rids, sups) = run(&conn, q, ChainGate::new(ChainGateMode::Shadow, 1000.0));
+        assert_eq!(rids, off_rids, "shadow changes no admission");
+        assert_eq!(
+            sups,
+            vec!["hop1:ungrounded", "seed:ungrounded", "hop2:ungrounded"],
+            "every stage enforce would refuse is counted, in lane order"
+        );
+    }
+
+    #[test]
+    fn enforce_never_builds_a_path_through_an_ungrounded_claim() {
+        let conn = pypi_store();
+        let (rids, sups) = run(
+            &conn,
+            "what does CT128 run",
+            ChainGate::new(ChainGateMode::Enforce, 1000.0),
+        );
+        assert!(rids.is_empty(), "both PyPI edges refused, got {rids:?}");
+        assert_eq!(
+            sups,
+            vec!["hop1:ungrounded"],
+            "a refused hop-1 row is never a seed"
+        );
+    }
+
+    #[test]
+    fn cooperative_claims_pass_and_a_denial_is_evidence_but_never_a_link() {
+        let conn = chain_store();
+        conn.execute(
+            "UPDATE claims SET grounding = 1 WHERE claim_id IN ('cA', 'cB')",
+            [],
+        )
+        .unwrap();
+        let q = "which city does Alice Moreau work in";
+        let (rids, sups) = run(&conn, q, ChainGate::new(ChainGateMode::Enforce, 1000.0));
+        assert_eq!(rids, vec!["mA", "mB"], "grounded chain survives enforce");
+        assert!(
+            sups.is_empty(),
+            "nothing to refuse on a grounded chain: {sups:?}"
+        );
+
+        // Alice does NOT work at Fennwick Labs: still exact evidence about
+        // Alice (admitted, rendered NOT) but no path may run through it.
+        conn.execute("UPDATE claims SET polarity = -1 WHERE claim_id = 'cA'", [])
+            .unwrap();
+        let (rids, sups) = run(&conn, q, ChainGate::new(ChainGateMode::Enforce, 1000.0));
+        assert_eq!(
+            rids,
+            vec!["mA"],
+            "the denial is admitted at hop 1, the path is not built"
+        );
+        assert!(sups.contains(&"seed:negated".to_string()), "{sups:?}");
+
+        // A reported claim is not asserted: same rule.
+        conn.execute(
+            "UPDATE claims SET polarity = 1, modality = 'reported' WHERE claim_id = 'cA'",
+            [],
+        )
+        .unwrap();
+        let (rids, sups) = run(&conn, q, ChainGate::new(ChainGateMode::Enforce, 1000.0));
+        assert_eq!(rids, vec!["mA"]);
+        assert!(sups.contains(&"seed:non_asserted".to_string()), "{sups:?}");
+    }
+
+    #[test]
+    fn validity_is_judged_as_of_the_query_time() {
+        let conn = chain_store();
+        conn.execute(
+            "UPDATE claims SET grounding = 1, valid_from = 100.0, valid_to = 200.0 \
+             WHERE claim_id = 'cA'",
+            [],
+        )
+        .unwrap();
+        conn.execute("UPDATE claims SET grounding = 1 WHERE claim_id = 'cB'", [])
+            .unwrap();
+        let q = "Alice Moreau";
+        for (as_of, expect_rid, expect_sup) in [
+            (150.0, true, None),
+            (300.0, false, Some("hop1:superseded")),
+            (50.0, false, Some("hop1:not_yet_valid")),
+        ] {
+            let (rids, sups) = run(&conn, q, ChainGate::new(ChainGateMode::Enforce, as_of));
+            assert_eq!(
+                rids.contains(&"mA".to_string()),
+                expect_rid,
+                "as_of {as_of}: {rids:?}"
+            );
+            match expect_sup {
+                Some(key) => assert!(sups.contains(&key.to_string()), "as_of {as_of}: {sups:?}"),
+                None => assert!(sups.is_empty(), "as_of {as_of}: {sups:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_pre_v53_claims_table_reads_as_ungrounded_not_as_an_error() {
+        // A pack sealed before the column existed: the legacy column set.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE entities (name TEXT PRIMARY KEY, entity_type TEXT, \
+                 first_seen REAL, last_seen REAL, mention_count INTEGER);
+             CREATE TABLE memory_entities (memory_rid TEXT, entity_name TEXT);
+             CREATE TABLE claims (claim_id TEXT PRIMARY KEY, src TEXT NOT NULL, \
+                 dst TEXT NOT NULL, rel_type TEXT NOT NULL, weight REAL DEFAULT 1.0, \
+                 created_at REAL NOT NULL, tombstoned INTEGER NOT NULL DEFAULT 0, \
+                 polarity INTEGER NOT NULL DEFAULT 1, \
+                 extractor TEXT NOT NULL DEFAULT 'manual', source_memory_rid TEXT, \
+                 namespace TEXT NOT NULL DEFAULT 'default');
+             CREATE VIEW edges AS SELECT src, dst, weight, tombstoned FROM claims;
+             INSERT INTO entities VALUES ('Taylor', 'person', 0.0, 0.0, 3);
+             INSERT INTO claims (claim_id, src, dst, rel_type, created_at, source_memory_rid) \
+                 VALUES ('c', 'Taylor', 'Carol', 'reports_to', 1.0, 'm');
+             INSERT INTO memory_entities VALUES ('m', 'Taylor');",
+        )
+        .unwrap();
+        let (rids, sups) = run(&conn, "Taylor", ChainGate::new(ChainGateMode::Shadow, 10.0));
+        assert_eq!(
+            rids,
+            vec!["m"],
+            "legacy rows still reach the lane under shadow"
+        );
+        assert_eq!(
+            sups,
+            vec!["hop1:ungrounded", "seed:ungrounded"],
+            "read as ungrounded at both stages, never as an error"
+        );
+    }
+
+    #[test]
+    fn gate_mode_round_trips_and_refuses_garbage() {
+        for (text, mode) in [
+            ("off", ChainGateMode::Off),
+            ("shadow", ChainGateMode::Shadow),
+            ("enforce", ChainGateMode::Enforce),
+        ] {
+            let parsed = ChainGateMode::parse(text).unwrap();
+            assert_eq!(parsed, mode);
+            assert_eq!(parsed.as_str(), text);
+            assert_eq!(ChainGateMode::from_u8(parsed.as_u8()), mode);
+        }
+        assert!(ChainGateMode::parse("warn").is_err());
     }
 }

--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -852,6 +852,15 @@ impl YantrikDB {
     ) -> Result<String> {
         let claim_id = crate::id::new_id();
         let ts = now();
+        // v53 grounding status: only a cooperative claim has had its
+        // endpoints grounded in the source text by the engine
+        // (attach_claims). Every other writer, the heuristic extractor
+        // included, gets 0 until it validates its own bindings.
+        let grounding: i64 = if extractor == STATED_CLAIM_EXTRACTOR {
+            1
+        } else {
+            0
+        };
 
         // Resolve aliases before storage
         let src_resolved = self.resolve_alias(src, namespace);
@@ -886,18 +895,18 @@ impl YantrikDB {
                 "INSERT INTO claims (claim_id, src, dst, rel_type, weight, created_at, \
                  polarity, modality, valid_from, valid_to, extractor, extractor_version, \
                  confidence_band, source_memory_rid, span_start, span_end, namespace, \
-                 proposition_id, regime_tag) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19) \
+                 proposition_id, regime_tag, grounding) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20) \
                  ON CONFLICT(src, dst, rel_type, extractor, polarity, namespace) DO UPDATE SET \
                  weight = ?5, created_at = ?6, modality = ?8, \
                  valid_from = ?9, valid_to = ?10, extractor_version = ?12, \
                  confidence_band = ?13, source_memory_rid = ?14, span_start = ?15, span_end = ?16, \
-                 proposition_id = ?18, regime_tag = ?19",
+                 proposition_id = ?18, regime_tag = ?19, grounding = ?20",
                 params![
                     claim_id, src_resolved, dst_resolved, rel_type, weight, ts,
                     polarity, modality, valid_from, valid_to, extractor, extractor_version,
                     confidence_band, source_memory_rid, span_start, span_end, namespace,
-                    proposition_id, regime_tag
+                    proposition_id, regime_tag, grounding
                 ],
             )?;
 
@@ -1016,18 +1025,18 @@ impl YantrikDB {
         let conn = self.conn.lock();
         let sql = if let Some(ns) = namespace {
             format!(
-                "SELECT edge_id, src, dst, rel_type, weight, created_at, \
+                "SELECT claim_id, src, dst, rel_type, weight, created_at, \
                  polarity, modality, valid_from, valid_to, extractor, confidence_band, \
-                 source_memory_rid, namespace \
-                 FROM edges WHERE (src = ?1 OR dst = ?1) AND namespace = '{}' AND tombstoned = 0 \
+                 source_memory_rid, namespace, grounding \
+                 FROM claims WHERE (src = ?1 OR dst = ?1) AND namespace = '{}' AND tombstoned = 0 \
                  ORDER BY created_at DESC",
                 ns.replace('\'', "''")
             )
         } else {
-            "SELECT edge_id, src, dst, rel_type, weight, created_at, \
+            "SELECT claim_id, src, dst, rel_type, weight, created_at, \
              polarity, modality, valid_from, valid_to, extractor, confidence_band, \
-             source_memory_rid, namespace \
-             FROM edges WHERE (src = ?1 OR dst = ?1) AND tombstoned = 0 \
+             source_memory_rid, namespace, grounding \
+             FROM claims WHERE (src = ?1 OR dst = ?1) AND tombstoned = 0 \
              ORDER BY created_at DESC"
                 .to_string()
         };
@@ -1088,6 +1097,7 @@ impl YantrikDB {
                     "confidence_band": row.get::<_, String>(11)?,
                     "source_memory_rid": source_rid,
                     "namespace": row.get::<_, String>(13)?,
+                    "grounding": row.get::<_, i64>(14)?,
                     "status_suggestion": status,
                 }))
             })?

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -11,6 +11,7 @@ mod capture;
 mod causal;
 mod chunking;
 mod claims_lane;
+pub use claims_lane::ChainGateMode;
 mod cognition;
 mod coherence;
 pub mod conflict;
@@ -115,8 +116,9 @@ use crate::schema::{
     MIGRATE_V36_TO_V37, MIGRATE_V37_TO_V38, MIGRATE_V3_TO_V4, MIGRATE_V40_TO_V41,
     MIGRATE_V41_TO_V42, MIGRATE_V42_TO_V43, MIGRATE_V44_TO_V45, MIGRATE_V45_TO_V46,
     MIGRATE_V46_TO_V47, MIGRATE_V47_TO_V48, MIGRATE_V48_TO_V49, MIGRATE_V49_TO_V50,
-    MIGRATE_V4_TO_V5, MIGRATE_V50_TO_V51, MIGRATE_V51_TO_V52, MIGRATE_V5_TO_V6, MIGRATE_V6_TO_V7,
-    MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10, SCHEMA_SQL, SCHEMA_VERSION,
+    MIGRATE_V4_TO_V5, MIGRATE_V50_TO_V51, MIGRATE_V51_TO_V52, MIGRATE_V52_TO_V53, MIGRATE_V5_TO_V6,
+    MIGRATE_V6_TO_V7, MIGRATE_V7_TO_V8, MIGRATE_V8_TO_V9, MIGRATE_V9_TO_V10, SCHEMA_SQL,
+    SCHEMA_VERSION,
 };
 use crate::types::*;
 
@@ -253,6 +255,18 @@ pub struct YantrikDB {
     /// (warn mode). Surfaced in `stats()` so a migrated DB's operator sees what
     /// `enforce` would reject before opting in. In-memory by design.
     pub(crate) provenance_flagged_since_boot: std::sync::atomic::AtomicU64,
+    /// **Claim-chain gate mode** (2026-09-07), cached from
+    /// `meta.claim_chain_gate_mode` (0=off, 1=shadow, 2=enforce). `shadow`
+    /// is the default everywhere: the claims lane admits exactly what it
+    /// admitted before and COUNTS what `enforce` would refuse. See
+    /// `engine::claims_lane::ChainGate`.
+    pub(crate) claim_chain_gate_mode: std::sync::atomic::AtomicU8,
+    /// Since boot: claims-lane admissions and traversals the gate would
+    /// refuse under `enforce`, keyed `hop1:<reason>` / `seed:<reason>` /
+    /// `hop2:<reason>`. The adoption nudge an operator reads in `stats()`
+    /// before turning the gate on. In-memory by design.
+    pub(crate) claim_chain_gate_suppressed_since_boot:
+        parking_lot::Mutex<std::collections::BTreeMap<String, u64>>,
     /// **v0.10 Item 3 — correction seqlock (sol r4).** A DB-wide epoch that
     /// makes a text-changing correction's (SQL commit + vector publish +
     /// scoring-cache update) atomic FROM A READER'S PERSPECTIVE, without
@@ -894,6 +908,7 @@ impl YantrikDB {
             (49, MIGRATE_V49_TO_V50),
             (50, MIGRATE_V50_TO_V51),
             (51, MIGRATE_V51_TO_V52),
+            (52, MIGRATE_V52_TO_V53),
         ];
         if let Some(v) = existing_version {
             for &(from_v, sql) in migrations {
@@ -1148,6 +1163,16 @@ impl YantrikDB {
             conn.execute(
                 "INSERT OR IGNORE INTO meta (key, value) VALUES ('provenance_gate_mode', ?1)",
                 params![default_gate_mode],
+            ),
+        )?;
+        // Claim-chain gate: `shadow` on every install, fresh or migrated —
+        // it changes no result until an operator has read the counters and
+        // opted in. INSERT OR IGNORE keeps an operator-set value.
+        at(
+            "fresh_defaults",
+            conn.execute(
+                "INSERT OR IGNORE INTO meta (key, value) VALUES ('claim_chain_gate_mode', 'shadow')",
+                [],
             ),
         )?;
 
@@ -1568,6 +1593,17 @@ impl YantrikDB {
             .unwrap_or("warn"),
         )?
         .as_u8();
+        // Same contract for the claim-chain gate: a malformed persisted mode
+        // is a typed error, never a silent `Off`.
+        let claim_chain_gate_mode = claims_lane::ChainGateMode::parse(
+            rewrap(
+                "final_meta_reads",
+                Self::get_meta(&conn, "claim_chain_gate_mode"),
+            )?
+            .as_deref()
+            .unwrap_or("shadow"),
+        )?
+        .as_u8();
 
         // Missing is the v42-upgrade-compatible default. A malformed or zero
         // persisted value fails open() loudly: silently disabling a write-
@@ -1627,6 +1663,10 @@ impl YantrikDB {
             embedder_chunked_writes: std::sync::atomic::AtomicU64::new(0),
             provenance_gate_mode: std::sync::atomic::AtomicU8::new(provenance_gate_mode),
             provenance_flagged_since_boot: std::sync::atomic::AtomicU64::new(0),
+            claim_chain_gate_mode: std::sync::atomic::AtomicU8::new(claim_chain_gate_mode),
+            claim_chain_gate_suppressed_since_boot: parking_lot::Mutex::new(
+                std::collections::BTreeMap::new(),
+            ),
             correction_epoch: std::sync::atomic::AtomicU64::new(0),
             visible_seq: dashmap::DashMap::new(),
             visible_seq_cv: parking_lot::Condvar::new(),
@@ -2005,6 +2045,43 @@ impl YantrikDB {
             .store(mode.as_u8(), std::sync::atomic::Ordering::Relaxed);
         drop(conn);
         Ok(())
+    }
+
+    /// The active claim-chain gate mode (`off` | `shadow` | `enforce`).
+    /// Every install defaults to `shadow`; see `engine::claims_lane`.
+    pub fn claim_chain_gate_mode(&self) -> claims_lane::ChainGateMode {
+        claims_lane::ChainGateMode::from_u8(
+            self.claim_chain_gate_mode
+                .load(std::sync::atomic::Ordering::Relaxed),
+        )
+    }
+
+    /// Durable opt-in to a claim-chain gate mode. The adoption path is:
+    /// run in `shadow`, read `stats().claim_chain_gate_suppressed_since_boot`,
+    /// heal or accept what would be refused, then `enforce`. Same
+    /// linearization note as `set_provenance_gate_mode`: a recall already
+    /// past the gate finishes under the old mode.
+    pub fn set_claim_chain_gate_mode(&self, mode: claims_lane::ChainGateMode) -> Result<()> {
+        let conn = self.conn();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('claim_chain_gate_mode', ?1)",
+            params![mode.as_str()],
+        )?;
+        self.claim_chain_gate_mode
+            .store(mode.as_u8(), std::sync::atomic::Ordering::Relaxed);
+        drop(conn);
+        Ok(())
+    }
+
+    /// Tick the since-boot suppression counters (one recall's worth).
+    pub(crate) fn note_chain_gate_suppressions(&self, suppressed: &[claims_lane::Suppression]) {
+        if suppressed.is_empty() {
+            return;
+        }
+        let mut counts = self.claim_chain_gate_suppressed_since_boot.lock();
+        for s in suppressed {
+            *counts.entry(s.key()).or_insert(0) += 1;
+        }
     }
 
     /// **v0.10 Item 4a.4 — the anti-laundering gate.** Parse the record's

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -277,6 +277,13 @@ impl YantrikDB {
             provenance_flagged_since_boot: self
                 .provenance_flagged_since_boot
                 .load(std::sync::atomic::Ordering::Relaxed),
+            claim_chain_gate_mode: self.claim_chain_gate_mode().as_str().to_string(),
+            claim_chain_gate_suppressed_since_boot: self
+                .claim_chain_gate_suppressed_since_boot
+                .lock()
+                .iter()
+                .map(|(k, v)| (k.clone(), *v))
+                .collect(),
             provenance_verified_records,
             unverified_user_source_records,
             provenance_source_counts,

--- a/crates/yantrikdb-core/src/engine/tests/claim_chain_gate.rs
+++ b/crates/yantrikdb-core/src/engine/tests/claim_chain_gate.rs
@@ -1,0 +1,223 @@
+//! The claim-chain eligibility gate, end to end: the v53 grounding
+//! column, the durable mode, the shadow counters and enforcement on a
+//! real recall.
+
+use crate::{ChainGateMode, StatedClaim, YantrikDB};
+use rusqlite::params;
+
+fn rec(db: &YantrikDB, text: &str) -> String {
+    db.record_text(
+        text,
+        "semantic",
+        0.5,
+        0.0,
+        604800.0,
+        &serde_json::json!({}),
+        "default",
+        0.8,
+        "general",
+        "user",
+        None,
+    )
+    .unwrap()
+}
+
+fn whys_for(db: &YantrikDB, query: &str, rid: &str) -> Vec<String> {
+    let resp = db
+        .recall_with_response(
+            &db.embed(query).unwrap(),
+            10,
+            None,
+            None,
+            false,
+            true,
+            Some(query),
+            true,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    resp.results
+        .iter()
+        .find(|r| r.rid == rid)
+        .map(|r| r.why_retrieved.clone())
+        .unwrap_or_default()
+}
+
+fn claim_whys(whys: &[String]) -> Vec<&str> {
+    whys.iter()
+        .filter(|w| w.starts_with("claims_match"))
+        .map(String::as_str)
+        .collect()
+}
+
+#[test]
+fn grounding_marks_cooperative_claims_and_nothing_else() {
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let rid = rec(&db, "Sarah works at Google. Sarah lives in Berlin.");
+    db.attach_claims(
+        &rid,
+        &[StatedClaim {
+            src: "Sarah".into(),
+            rel_type: "works_at".into(),
+            dst: "Google".into(),
+            polarity: 1,
+            valid_from: None,
+            valid_to: None,
+        }],
+    )
+    .unwrap();
+    // The heuristic extractor mints the same facts under its own label.
+    db.reextract_claims(None, false).unwrap();
+    let claims = db.get_claims("Sarah", None).unwrap();
+    let mut by_extractor: Vec<(String, String, i64)> = claims
+        .iter()
+        .map(|c| {
+            (
+                c["extractor"].as_str().unwrap().to_string(),
+                c["rel_type"].as_str().unwrap().to_string(),
+                c["grounding"].as_i64().unwrap(),
+            )
+        })
+        .collect();
+    by_extractor.sort();
+    assert!(
+        by_extractor.contains(&("agent_stated".into(), "works_at".into(), 1)),
+        "{by_extractor:?}"
+    );
+    assert!(
+        by_extractor
+            .iter()
+            .filter(|(e, _, _)| e == "heuristic_v1")
+            .all(|(_, _, g)| *g == 0),
+        "heuristic rows are ungrounded until an extractor validates its bindings: {by_extractor:?}"
+    );
+    assert!(
+        by_extractor.iter().any(|(e, _, _)| e == "heuristic_v1"),
+        "fixture must mint at least one heuristic claim: {by_extractor:?}"
+    );
+}
+
+#[test]
+fn mode_defaults_to_shadow_and_persists_across_opens() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("gate.db");
+    let path = path.to_str().unwrap();
+    {
+        let db = YantrikDB::with_default(path).unwrap();
+        assert_eq!(db.claim_chain_gate_mode(), ChainGateMode::Shadow);
+        assert_eq!(db.stats(None).unwrap().claim_chain_gate_mode, "shadow");
+        db.set_claim_chain_gate_mode(ChainGateMode::Enforce)
+            .unwrap();
+    }
+    let db = YantrikDB::with_default(path).unwrap();
+    assert_eq!(db.claim_chain_gate_mode(), ChainGateMode::Enforce);
+    assert_eq!(db.stats(None).unwrap().claim_chain_gate_mode, "enforce");
+}
+
+/// The production repro on a live engine: two ungrounded claims chain
+/// junk onto a query about CT128. Shadow admits and counts; enforce
+/// refuses; a cooperative claim about the same entity still comes through.
+#[test]
+fn enforce_stops_the_pypi_chain_and_keeps_cooperative_evidence() {
+    let db = YantrikDB::with_default(":memory:").unwrap();
+    let run_rid = rec(
+        &db,
+        "Deploy note: core runs CT128 dogfood after the PyPI publish.",
+    );
+    let work_rid = rec(
+        &db,
+        "PyPI and latest release both 0.15.6. Re-verified: 'Sarah works at Google'.",
+    );
+    // A named object on purpose: the lane's phantom filter still refuses a
+    // value object (`0.21.2`) as an endpoint at read time — a pre-existing
+    // limit, noted for the next step, not this gate's concern.
+    let coop_rid = rec(&db, "CT128 runs Hermes now, verified by content.");
+    {
+        let conn = db.conn.lock();
+        for (name, etype, mc) in [
+            ("CT128", "tech", 9),
+            ("PyPI", "org", 4),
+            ("Google", "org", 2),
+        ] {
+            conn.execute(
+                "INSERT OR REPLACE INTO entities (name, entity_type, mention_count, first_seen, last_seen) \
+                 VALUES (?1, ?2, ?3, 1.0, 1.0)",
+                params![name, etype, mc],
+            )
+            .unwrap();
+        }
+        for (cid, src, dst, rel, rid) in [
+            ("cRun", "PyPI", "CT128", "runs", run_rid.as_str()),
+            ("cWork", "PyPI", "Google", "works_at", work_rid.as_str()),
+        ] {
+            conn.execute(
+                "INSERT INTO claims (claim_id, src, dst, rel_type, weight, created_at, \
+                 extractor, source_memory_rid) VALUES (?1, ?2, ?3, ?4, 1.0, 1.0, 'heuristic_v1', ?5)",
+                params![cid, src, dst, rel, rid],
+            )
+            .unwrap();
+        }
+    }
+    db.rebuild_graph_index().unwrap();
+    let query = "What does CT128 run?";
+
+    // Shadow (the default): the junk path is still built, and counted.
+    let run_whys = whys_for(&db, query, &run_rid);
+    assert!(
+        claim_whys(&run_whys)
+            .iter()
+            .any(|w| w.contains("PyPI -runs-> CT128")),
+        "shadow admits the hop-1 claim: {run_whys:?}"
+    );
+    let work_whys = whys_for(&db, query, &work_rid);
+    assert!(
+        claim_whys(&work_whys)
+            .iter()
+            .any(|w| w.contains("PyPI -works_at-> Google") && w.contains("(path via PyPI")),
+        "shadow builds the junk path: {work_whys:?}"
+    );
+    let stats = db.stats(None).unwrap();
+    for key in ["hop1:ungrounded", "seed:ungrounded", "hop2:ungrounded"] {
+        assert!(
+            stats
+                .claim_chain_gate_suppressed_since_boot
+                .get(key)
+                .copied()
+                .unwrap_or(0)
+                > 0,
+            "shadow counts {key}: {:?}",
+            stats.claim_chain_gate_suppressed_since_boot
+        );
+    }
+
+    // Enforce: neither PyPI edge reaches the reader.
+    db.set_claim_chain_gate_mode(ChainGateMode::Enforce)
+        .unwrap();
+    assert!(claim_whys(&whys_for(&db, query, &run_rid)).is_empty());
+    assert!(claim_whys(&whys_for(&db, query, &work_rid)).is_empty());
+
+    // A cooperative claim about CT128 is grounded and still admitted.
+    let report = db
+        .attach_claims(
+            &coop_rid,
+            &[StatedClaim {
+                src: "CT128".into(),
+                rel_type: "runs".into(),
+                dst: "Hermes".into(),
+                polarity: 1,
+                valid_from: None,
+                valid_to: None,
+            }],
+        )
+        .unwrap();
+    assert_eq!(report.accepted.len(), 1, "{:?}", report.rejected);
+    let coop_whys = whys_for(&db, query, &coop_rid);
+    assert!(
+        claim_whys(&coop_whys)
+            .iter()
+            .any(|w| w.contains("CT128 -runs-> Hermes")),
+        "grounded claim survives enforce: {coop_whys:?}"
+    );
+}

--- a/crates/yantrikdb-core/src/engine/tests/mod.rs
+++ b/crates/yantrikdb-core/src/engine/tests/mod.rs
@@ -13,6 +13,7 @@ mod backpressure_lifecycle;
 mod basics;
 mod bundled_embedder;
 mod chunking;
+mod claim_chain_gate;
 mod cognition_gates;
 mod consolidate_cluster;
 mod corrections;

--- a/crates/yantrikdb-core/src/engine/tests/mod.rs
+++ b/crates/yantrikdb-core/src/engine/tests/mod.rs
@@ -13,6 +13,7 @@ mod backpressure_lifecycle;
 mod basics;
 mod bundled_embedder;
 mod chunking;
+#[cfg(feature = "bundled-embedder")]
 mod claim_chain_gate;
 mod cognition_gates;
 mod consolidate_cluster;

--- a/crates/yantrikdb-core/src/engine/tests/reextract_entities.rs
+++ b/crates/yantrikdb-core/src/engine/tests/reextract_entities.rs
@@ -357,5 +357,5 @@ fn heal_uses_the_lexicon_and_unlinks_kept_value_names() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(v, "52");
+    assert_eq!(v, crate::base::schema::SCHEMA_VERSION.to_string());
 }

--- a/crates/yantrikdb-core/src/lib.rs
+++ b/crates/yantrikdb-core/src/lib.rs
@@ -60,6 +60,7 @@ pub use engine::tenant::{TenantConfig, TenantManager};
 pub use engine::thread::{
     MaintenanceProgress, ThreadItem, ThreadItemV2, ThreadQuery, ThreadRecall, ThreadRecallV2,
 };
+pub use engine::ChainGateMode;
 pub use engine::YantrikDB;
 pub use error::YantrikDbError;
 pub use patterns::mine_patterns;

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -771,6 +771,27 @@ impl PyYantrikDB {
             .map_err(map_err)
     }
 
+    /// `"off"` | `"shadow"` | `"enforce"`: whether the claims lane admits
+    /// only grounded, currently-valid claims. Every database defaults to
+    /// `shadow`, which changes no result and counts what `enforce` would
+    /// refuse into `stats()["claim_chain_gate_suppressed_since_boot"]`.
+    fn claim_chain_gate_mode(&self) -> PyResult<String> {
+        Ok(self
+            .get_inner()?
+            .claim_chain_gate_mode()
+            .as_str()
+            .to_string())
+    }
+
+    /// Durably set the claim-chain gate mode. Read the suppression counters
+    /// under `shadow` first; a malformed value is a loud error.
+    fn set_claim_chain_gate_mode(&self, mode: &str) -> PyResult<()> {
+        let parsed = yantrikdb_core::ChainGateMode::parse(mode).map_err(map_err)?;
+        self.get_inner()?
+            .set_claim_chain_gate_mode(parsed)
+            .map_err(map_err)
+    }
+
     /// Exposed for Python consolidate.py compatibility.
     #[pyo3(signature = (op_type, target_rid, payload))]
     fn _log_op(

--- a/crates/yantrikdb-python/src/py_types.rs
+++ b/crates/yantrikdb-python/src/py_types.rs
@@ -296,6 +296,13 @@ pub fn stats_to_dict(py: Python<'_>, s: &yantrikdb_core::Stats) -> PyResult<PyOb
         "provenance_flagged_since_boot",
         s.provenance_flagged_since_boot,
     )?;
+    // Claim-chain gate adoption surface: `mode` is off|shadow|enforce;
+    // the map counts what `enforce` would refuse, by hop and reason.
+    dict.set_item("claim_chain_gate_mode", &s.claim_chain_gate_mode)?;
+    dict.set_item(
+        "claim_chain_gate_suppressed_since_boot",
+        &s.claim_chain_gate_suppressed_since_boot,
+    )?;
     dict.set_item("provenance_verified_records", s.provenance_verified_records)?;
     dict.set_item(
         "unverified_user_source_records",

--- a/tests/test_capability_probes.py
+++ b/tests/test_capability_probes.py
@@ -422,3 +422,41 @@ def test_common_words_are_not_entities_by_seed_or_by_this_stores_usage(db):
     assert db.search_entities("Gizmo") == [], db.search_entities("Gizmo")
     report = db.reextract_entities(dry_run=True)
     assert report["lexicon_memories"] >= 6, report
+
+
+# ── the claim-chain gate (v53) ───────────────────────────────────────────
+
+
+def test_claim_chain_gate_shadows_by_default_and_enforce_keeps_only_grounded_claims(db):
+    """Every store opens in `shadow`: the claims lane admits what it always
+    did and counts what `enforce` would refuse. A heuristic claim is
+    ungrounded (its binding was never validated); a cooperative claim the
+    engine grounded in the text is not, and survives `enforce`."""
+    assert db.claim_chain_gate_mode() == "shadow"
+    assert db.stats()["claim_chain_gate_mode"] == "shadow"
+    rid = db.record("Alice Moreau works at Fennwick Labs. Fennwick Labs is headquartered in Berlin.")
+    db.think()
+    claims = {(c["src"], c["rel_type"], c["dst"]): c for c in db.get_claims("Alice Moreau")}
+    assert claims[("Alice Moreau", "works_at", "Fennwick Labs")]["grounding"] == 0, claims
+
+    query = "Which city does Alice Moreau work in?"
+    hits = db.recall(query=query, top_k=5, skip_reinforce=True)
+    assert any(w.startswith("claims_match") for h in hits for w in h["why_retrieved"]), hits
+    counted = db.stats()["claim_chain_gate_suppressed_since_boot"]
+    assert counted.get("hop1:ungrounded", 0) > 0, counted
+
+    db.set_claim_chain_gate_mode("enforce")
+    assert db.stats()["claim_chain_gate_mode"] == "enforce"
+    hits = db.recall(query=query, top_k=5, skip_reinforce=True)
+    assert not any(w.startswith("claims_match") for h in hits for w in h["why_retrieved"]), hits
+
+    db.attach_claims(rid, [{"subject": "Alice Moreau", "relation": "works_at", "object": "Fennwick Labs"}])
+    claims = db.get_claims("Alice Moreau")
+    assert any(c["extractor"] == "agent_stated" and c["grounding"] == 1 for c in claims), claims
+    hits = db.recall(query=query, top_k=5, skip_reinforce=True)
+    assert any("Alice Moreau -works_at-> Fennwick Labs" in w for h in hits for w in h["why_retrieved"]), hits
+
+    with pytest.raises(Exception):
+        db.set_claim_chain_gate_mode("warn")
+    db.set_claim_chain_gate_mode("shadow")
+    assert db.claim_chain_gate_mode() == "shadow"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -301,6 +301,8 @@ class TestStats:
             "synthesis_fanout_sources_over_cap",
             # v0.10 Item 4a.4: anti-laundering gate adoption surface.
             "provenance_gate_mode", "provenance_flagged_since_boot",
+            # 0.22: claim-chain gate adoption surface (shadow counters).
+            "claim_chain_gate_mode", "claim_chain_gate_suppressed_since_boot",
             # Provenance-origin census: explicitly verified records and
             # legacy/user-source rows without an explicit verification marker.
             "provenance_verified_records", "unverified_user_source_records",


### PR DESCRIPTION
Step 1 of the engine plan agreed on 2026-09-07 (gpt-6-astra / gpt-5.5 / maintainer debate): contain untrusted claim edges before fixing extraction.

**Why.** After the 0.21.2 deploy the claims heal minted `PyPI -works_at-> Google` (subject search walked back across a sentence boundary and a colon) and `PyPI -runs-> CT128` (true subject, lowercase `core`, skipped). The claims lane then surfaced both with confident path provenance on a query about CT128. The extractor fix is next; this PR stops a wrong claim from propagating in the meantime and keeps the next one from doing so.

**What.**
- `claims.grounding` (schema v53): a versioned grounding status. `0` = binding never validated (every extractor row so far); `1` = cooperative, the writer stated it and the engine grounded both endpoints in the text (`attach_claims`). Migration backfills `agent_stated` rows.
- `ChainGateMode` `off | shadow | enforce`, durable in `meta.claim_chain_gate_mode`, **shadow on every install**: the lane admits exactly what it admitted before and counts what `enforce` would refuse into `stats().claim_chain_gate_suppressed_since_boot`, keyed `hop1:` / `seed:` / `hop2:` `<reason>` (ungrounded, not_yet_valid, superseded, negated, non_asserted).
- Eligibility: direct admission needs grounded + valid as of the query time (end of the caller's window, else now); traversal (seeding a path, admitting its second hop) also needs positive polarity and asserted modality. Under `enforce` every edge of a path must be eligible.
- A claims table that predates v53 (a pack sealed earlier) is read through the legacy column set as ungrounded, never as an error.
- `get_claims` returns `grounding`; Python gains `claim_chain_gate_mode()` / `set_claim_chain_gate_mode()` and the two stats keys.

**Behaviour change for users:** none under the default. Results are byte-identical in `shadow`; only two stats keys appear.

**Verified.**
- Lane fixture of the production repro: shadow counts `hop1:ungrounded`, `seed:ungrounded`, `hop2:ungrounded` and admits both; enforce yields no candidates and a refused hop-1 row is never a seed.
- A denial is admitted as evidence at hop 1 but never seeds a path; a reported claim likewise; validity judged as of the query time (150 in, 300 superseded, 50 not yet valid).
- Live engine: the repro under shadow then enforce, plus a cooperative claim surviving enforce.
- Core suite 2156 passed; Python 111 passed on the Windows wheel; migration rehearsed from a v51 store (v53, backfill, integrity ok).

**Known limit found, deliberately not touched here:** the lane's phantom filter refuses value-object endpoints (`0.21.2`) at read time, so `CT128 runs 0.21.2` claims never surface in the claims lane. Candidate for the mentions/binding step.

Releases as 0.22.0 (schema bump); gate on the co-iteration run before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
