### PR TITLE
engine: refuse to write while a second SQLite library holds the store open in this process (#225)

### DIFF
--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -257,9 +257,21 @@ unlinks the `-shm` file under the engine (its own lock table says it was
 the last user), so "resume when it closes" would be unsafe. Reads
 continue. `warn`
 counts (`stats().foreign_sqlite_detected_since_boot`) and keeps writing;
-`off` never scans. macOS has no `/proc` (detector reports
-`foreign_sqlite_supported = false`); Windows locks are per handle and is
-not affected.
+`off` never scans. macOS reads the same rule through libproc region
+enumeration (rescanned every second instead of every 200 ms); Windows
+locks are per handle and is not affected (`foreign_sqlite_supported =
+false`).
+
+The cross-process half: SQLite's `PRAGMA data_version` on the writer
+connection changes only when another connection commits, and every
+engine write goes through that one connection, so a change is exactly
+"someone else committed" (another engine process, the `sqlite3` CLI, a
+backup tool — legitimate, but the only way the store changes under the
+engine). Each is counted (`stats().foreign_commits_detected_since_boot`)
+and queues one `PRAGMA quick_check`, run off the writer by the
+materializer or by `integrity_check()` on demand; a failed check taints
+the store the same way, because writing onto a corrupt file only spreads
+the damage.
 
 ---
 

--- a/CONCURRENCY.md
+++ b/CONCURRENCY.md
@@ -243,6 +243,24 @@ Rules:
 - Separate processes (dashboard, census scripts, backups via `.backup`)
   are safe: the kernel serialises them.
 
+**The engine now guards this itself (issue #225, 0.22).** On Linux every
+SQLite instance maps the store's `-shm` file region by region; the same
+`<store>-shm` path mapped at the same offset twice in `/proc/self/maps`
+means a second library has the store open in this process. The engine
+scans at open and from the writer connection's commit hook (cached 200
+ms). `foreign_sqlite_mode`, durable in `meta`, defaults to `refuse` on
+every install: engine writes fail with `ForeignSqliteInstance` — and the
+commit hook aborts anything that slipped past the pre-check, the
+materializer's commits included — from the first detection until the
+engine is reopened: measured 2026-09-07, the foreign library's close
+unlinks the `-shm` file under the engine (its own lock table says it was
+the last user), so "resume when it closes" would be unsafe. Reads
+continue. `warn`
+counts (`stats().foreign_sqlite_detected_since_boot`) and keeps writing;
+`off` never scans. macOS has no `/proc` (detector reports
+`foreign_sqlite_supported = false`); Windows locks are per handle and is
+not affected.
+
 ---
 
 ## Cross-stack rule — engine pressure suppresses enrichment, NEVER decay

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ pip install yantrikdb
 > separate process; sequential use after `close()` is fine. On Linux the
 > engine detects the second instance and refuses to write from then
 > until it is reopened (`ForeignSqliteInstance`,
-> `stats()["foreign_sqlite_*"]`), see CONCURRENCY.md Rule 9.
+> `stats()["foreign_sqlite_*"]`), and on every platform a commit that
+> did not come through the engine queues an integrity check; see
+> CONCURRENCY.md Rule 9.
 
 A new file-backed store opens on `potion-base-8M` (256-dim), fetched
 once (~28 MB, SHA-256 pinned, cached under your user cache dir) and

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ pip install yantrikdb
 `sentence-transformers` install, no ONNX runtime.** Just one
 `pip install`.
 
+> **Never open the store with a second SQLite library in the same
+> process.** The engine bundles its own SQLite; `sqlite3.connect()` on
+> the same file from the same process (for a helper `UPDATE`, a raw
+> `INSERT` into `claims`, your own scan) corrupts the store silently:
+> POSIX locks are per process, so that connection's unlock releases the
+> engine's and the two writers interleave WAL commits. Use the engine API
+> (`correct()`, `ingest_claim()`, `attach_claims()`, `think()`) or a
+> separate process; sequential use after `close()` is fine. On Linux the
+> engine detects the second instance and refuses to write from then
+> until it is reopened (`ForeignSqliteInstance`,
+> `stats()["foreign_sqlite_*"]`), see CONCURRENCY.md Rule 9.
+
 A new file-backed store opens on `potion-base-8M` (256-dim), fetched
 once (~28 MB, SHA-256 pinned, cached under your user cache dir) and
 self-hosted from `yantrikos/yantrikdb-models` — no HuggingFace

--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["ai", "memory", "cognitive", "database", "embeddings"]
 categories = ["database", "science"]
 
 [dependencies]
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled", "hooks"] }
 uuid7 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -88,7 +88,7 @@ tempfile = "3"
 # Pack tests hash the host file to prove unmount mutates nothing, and
 # tamper with a sealed pack to prove the content digest catches it.
 blake3 = "1"
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled", "hooks"] }
 
 [[bench]]
 name = "engine_bench"

--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -81,6 +81,11 @@ profiling = []
 # trace tests.
 testing = []
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Issue #225: the second-SQLite-library detector walks the process's
+# memory regions through libproc on macOS.
+libc = "0.2"
+
 [dev-dependencies]
 criterion = "0.5"
 toml = "0.8"

--- a/crates/yantrikdb-core/src/base/error.rs
+++ b/crates/yantrikdb-core/src/base/error.rs
@@ -455,6 +455,22 @@ pub enum YantrikDbError {
     #[error("provenance rejected at {path}: {reason}")]
     ProvenanceInconsistent { path: &'static str, reason: String },
 
+    /// **Issue #225.** Another SQLite library has this store open in this
+    /// process (Python's stdlib `sqlite3`, a system `libsqlite3`). POSIX
+    /// advisory locks are per process, so its unlock releases the engine's
+    /// and two writers would interleave WAL commits — silent page aliasing.
+    /// The engine refuses to write while the condition holds; writes resume
+    /// once the foreign connection closes. Use the engine API or a separate
+    /// process for raw SQL. See CONCURRENCY.md Rule 9.
+    #[error(
+        "refusing to write: another SQLite library has {path} open in this process \
+         (issue #225 — POSIX locks are per process, so its unlock releases the engine's \
+         and the two writers would interleave WAL commits). Close that connection, check \
+         integrity and reopen the engine (its close may have unlinked the shared-memory \
+         file); use the engine API / a separate process for raw SQL."
+    )]
+    ForeignSqliteInstance { path: String },
+
     /// **v0.10 Item 4a.6c — durable idempotency (T07).** The caller reused an
     /// idempotency key whose committed claim does not match this write —
     /// normally a DIFFERENT payload digest under the same key ("repetition is

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -655,6 +655,28 @@ pub struct Stats {
     /// under `enforce` they were dropped. Empty under `off`.
     #[serde(default)]
     pub claim_chain_gate_suppressed_since_boot: HashMap<String, u64>,
+    /// **Issue #225** — second-SQLite-library guard mode (`off` | `warn` |
+    /// `refuse`); every install defaults to `refuse`.
+    #[serde(default)]
+    pub foreign_sqlite_mode: String,
+    /// Whether this platform/store can be scanned (Linux, file-backed).
+    #[serde(default)]
+    pub foreign_sqlite_supported: bool,
+    /// The last scan found another SQLite library holding the store open in
+    /// this process. Under `refuse`, writes are failing right now.
+    #[serde(default)]
+    pub foreign_sqlite_active: bool,
+    /// A foreign instance was seen at some point since this engine opened.
+    /// Latched: its close may have unlinked the shm/WAL under the engine,
+    /// so writes stay refused (under `refuse`) until the engine is reopened.
+    #[serde(default)]
+    pub foreign_sqlite_tainted: bool,
+    /// Scans since boot that found a foreign instance.
+    #[serde(default)]
+    pub foreign_sqlite_detected_since_boot: u64,
+    /// Engine writes refused (pre-checks and aborted commits) since boot.
+    #[serde(default)]
+    pub foreign_sqlite_refused_since_boot: u64,
     /// Non-tombstoned records carrying an explicit, caller-supplied
     /// `metadata.provenance_verified = true` marker. This is an audit signal,
     /// not an engine assertion: the engine cannot reconstruct authorship.

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -677,6 +677,19 @@ pub struct Stats {
     /// Engine writes refused (pre-checks and aborted commits) since boot.
     #[serde(default)]
     pub foreign_sqlite_refused_since_boot: u64,
+    /// Commits that reached the store without going through this engine
+    /// (another process, most likely) since boot; each queues an integrity
+    /// check.
+    #[serde(default)]
+    pub foreign_commits_detected_since_boot: u64,
+    /// A queued integrity check has not run yet.
+    #[serde(default)]
+    pub integrity_check_pending: bool,
+    #[serde(default)]
+    pub integrity_checks_since_boot: u64,
+    /// The last `PRAGMA quick_check` result, empty until one has run.
+    #[serde(default)]
+    pub last_integrity_check: String,
     /// Non-tombstoned records carrying an explicit, caller-supplied
     /// `metadata.provenance_verified = true` marker. This is an audit signal,
     /// not an engine assertion: the engine cannot reconstruct authorship.

--- a/crates/yantrikdb-core/src/engine/foreign_sqlite.rs
+++ b/crates/yantrikdb-core/src/engine/foreign_sqlite.rs
@@ -1,0 +1,418 @@
+//! Issue #225 — a second SQLite library with the store open in THIS process.
+//!
+//! The engine links its own SQLite (`rusqlite` `bundled`). When another
+//! SQLite library in the same process — Python's stdlib `sqlite3`, a
+//! system `libsqlite3` pulled in by some extension — opens the same store,
+//! the result is silent page aliasing, not a locking error: both
+//! libraries serialise writers with POSIX advisory (`fcntl`) locks, and
+//! the kernel scopes those locks per PROCESS, so the foreign library's
+//! unlock releases the engine's locks and the two writers interleave
+//! their WAL commits (sqlite.org/howtocorrupt.html, "multiple copies of
+//! SQLite linked into the same application"). "Sequential per record"
+//! does not save anyone: the materializer keeps writing after `record()`
+//! returns. Measured on our own CI on 2026-09-06 (an `entities` page
+//! written where a `memories` page belongs) and reported from the field
+//! on 2026-09-07 after a day of blaming hooks and concurrency.
+//!
+//! The engine cannot make a foreign library respect its locks. It CAN
+//! notice that a second SQLite instance has the store open in this
+//! process, and stop committing while that is true — which is enough,
+//! because a single writer at a time is exactly what the locks were
+//! meant to guarantee.
+//!
+//! **Detector (Linux).** Every SQLite instance maps the store's `-shm`
+//! file itself, region by region, with `mmap(offset = i × region)`. One
+//! library shares one shm node across all of its connections, so each
+//! offset appears at most once per library in `/proc/self/maps`. The same
+//! `<store>-shm` path mapped at the same offset TWICE means two libraries
+//! have the store open in this process. That is the hazard exactly, read
+//! in a few hundred microseconds, with no way for it to fire on the
+//! engine's own connections. macOS has no `/proc`; Windows locks are per
+//! handle and does not have the problem. Elsewhere the detector reports
+//! `supported = false` and the mode is inert.
+//!
+//! **Modes**, durable in `meta.foreign_sqlite_mode`, default `refuse`:
+//! `off` never scans; `warn` scans, logs the transition and counts
+//! (`stats().foreign_sqlite_detected_since_boot`); `refuse` additionally
+//! makes every engine write fail with `ForeignSqliteInstance` while the
+//! condition holds — a pre-check at the public write entry points for a
+//! typed error, and a commit hook on the writer connection as the hard
+//! guarantee that no engine commit, the materializer's included, lands
+//! in an interleaved WAL. Reads continue.
+//!
+//! **Why a detection latches until the engine is reopened.** Measured on
+//! WSL 2026-09-07: when the foreign connection closed, its library —
+//! believing itself the last user, because its lock table is its own —
+//! UNLINKED the `-shm` file (and, as SQLite does on last close, is free to
+//! checkpoint and delete the WAL). The engine was left mapping a deleted
+//! shm: consistent with itself, but any other process would now create a
+//! fresh one and diverge. So after a detection the store is tainted for
+//! this engine instance, writes stay refused, and the operator reopens
+//! the engine (which recovers the WAL/shm cleanly) after checking
+//! integrity. `stats().foreign_sqlite_tainted` says so.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::error::{Result, YantrikDbError};
+
+/// How often the commit hook re-reads `/proc/self/maps`. A commit inside
+/// this window reuses the last verdict; the first commit after it pays the
+/// scan.
+const RESCAN_AFTER: Duration = Duration::from_millis(200);
+
+/// `SQLITE_CONSTRAINT_COMMITHOOK`: the extended result code SQLite returns
+/// when a commit hook aborts the commit. `SQLITE_CONSTRAINT | (2 << 8)` =
+/// 531 (pinned by a test below; the docs' table is easy to misread).
+pub const SQLITE_CONSTRAINT_COMMITHOOK: i32 = 531;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForeignSqliteMode {
+    Off,
+    Warn,
+    Refuse,
+}
+
+impl ForeignSqliteMode {
+    /// A malformed persisted or caller-supplied mode is a typed error,
+    /// never a silent `Off`.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "off" => Ok(Self::Off),
+            "warn" => Ok(Self::Warn),
+            "refuse" => Ok(Self::Refuse),
+            other => Err(YantrikDbError::InvalidInput(format!(
+                "foreign_sqlite_mode: expected off|warn|refuse, got {other:?}"
+            ))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Warn => "warn",
+            Self::Refuse => "refuse",
+        }
+    }
+
+    pub fn as_u8(self) -> u8 {
+        match self {
+            Self::Off => 0,
+            Self::Warn => 1,
+            Self::Refuse => 2,
+        }
+    }
+
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            2 => Self::Refuse,
+            1 => Self::Warn,
+            _ => Self::Off,
+        }
+    }
+}
+
+/// Shared between the engine and the writer connection's commit hook.
+pub(crate) struct ForeignSqliteGuard {
+    /// The store's `-shm` path as `/proc/self/maps` prints it (canonical).
+    /// `None` for `:memory:` or an unsupported platform: the guard is inert.
+    shm_path: Option<PathBuf>,
+    /// The store path for messages.
+    store: String,
+    mode: AtomicU8,
+    /// The last scan found a foreign instance.
+    active: AtomicBool,
+    /// A scan found one at some point since this engine opened. Latched:
+    /// the foreign library's close may have unlinked the shm/WAL under us.
+    tainted: AtomicBool,
+    detected_since_boot: AtomicU64,
+    refused_since_boot: AtomicU64,
+    last_scan: parking_lot::Mutex<Option<Instant>>,
+}
+
+impl ForeignSqliteGuard {
+    pub(crate) fn new(db_path: &str, mode: ForeignSqliteMode) -> Self {
+        let shm_path = if db_path == ":memory:" || !cfg!(target_os = "linux") {
+            None
+        } else {
+            std::fs::canonicalize(db_path).ok().map(|p| {
+                let mut s = p.into_os_string();
+                s.push("-shm");
+                PathBuf::from(s)
+            })
+        };
+        Self {
+            shm_path,
+            store: db_path.to_string(),
+            mode: AtomicU8::new(mode.as_u8()),
+            active: AtomicBool::new(false),
+            tainted: AtomicBool::new(false),
+            detected_since_boot: AtomicU64::new(0),
+            refused_since_boot: AtomicU64::new(0),
+            last_scan: parking_lot::Mutex::new(None),
+        }
+    }
+
+    pub(crate) fn mode(&self) -> ForeignSqliteMode {
+        ForeignSqliteMode::from_u8(self.mode.load(Ordering::Relaxed))
+    }
+
+    pub(crate) fn set_mode(&self, mode: ForeignSqliteMode) {
+        self.mode.store(mode.as_u8(), Ordering::Relaxed);
+    }
+
+    /// Whether this platform and store can be scanned at all.
+    pub(crate) fn supported(&self) -> bool {
+        self.shm_path.is_some()
+    }
+
+    pub(crate) fn active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn tainted(&self) -> bool {
+        self.tainted.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn detected_since_boot(&self) -> u64 {
+        self.detected_since_boot.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn refused_since_boot(&self) -> u64 {
+        self.refused_since_boot.load(Ordering::Relaxed)
+    }
+
+    /// Scan now. Returns whether a foreign instance has the store open.
+    /// Logs on the transition into the condition, once, at error level.
+    pub(crate) fn scan(&self) -> bool {
+        let Some(shm) = &self.shm_path else {
+            return false;
+        };
+        if self.mode() == ForeignSqliteMode::Off {
+            return false;
+        }
+        let found = foreign_shm_mapped(shm);
+        *self.last_scan.lock() = Some(Instant::now());
+        let was = self.active.swap(found, Ordering::Relaxed);
+        if found {
+            self.detected_since_boot.fetch_add(1, Ordering::Relaxed);
+            self.tainted.store(true, Ordering::Relaxed);
+            if !was {
+                tracing::error!(
+                    store = %self.store,
+                    mode = self.mode().as_str(),
+                    "another SQLite library has this store open in this process \
+                     (issue #225): POSIX locks are per process, so its unlock releases \
+                     the engine's and the two writers would interleave WAL commits. \
+                     Writes are refused until this engine is reopened: close the foreign \
+                     connection, check integrity, reopen."
+                );
+            }
+        } else if was {
+            tracing::warn!(
+                store = %self.store,
+                "foreign SQLite instance gone, but its close may have unlinked the shm/WAL \
+                 under this engine: writes stay refused until the engine is reopened"
+            );
+        }
+        found
+    }
+
+    /// The commit-hook cadence: rescan at most every `RESCAN_AFTER`.
+    pub(crate) fn scan_cached(&self) -> bool {
+        let due = self
+            .last_scan
+            .lock()
+            .is_none_or(|t| t.elapsed() >= RESCAN_AFTER);
+        if due {
+            self.scan()
+        } else {
+            self.active()
+        }
+    }
+
+    /// Commit-hook body: `true` aborts the commit.
+    pub(crate) fn commit_should_abort(&self) -> bool {
+        self.scan_cached();
+        let abort = decide(self.mode(), self.tainted());
+        if abort {
+            self.refused_since_boot.fetch_add(1, Ordering::Relaxed);
+        }
+        abort
+    }
+
+    /// The typed pre-check at a public write entry point.
+    pub(crate) fn check_write(&self) -> Result<()> {
+        self.scan_cached();
+        if decide(self.mode(), self.tainted()) {
+            self.refused_since_boot.fetch_add(1, Ordering::Relaxed);
+            return Err(YantrikDbError::ForeignSqliteInstance {
+                path: self.store.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Is this SQLite error the writer connection's commit hook refusing a
+/// commit? Used by the error conversion so the abort reaches callers as
+/// the typed `ForeignSqliteInstance`, in Rust and across pyo3 alike.
+pub(crate) fn is_commit_hook_abort(err: &rusqlite::Error) -> bool {
+    matches!(err, rusqlite::Error::SqliteFailure(e, _) if e.extended_code == SQLITE_CONSTRAINT_COMMITHOOK)
+}
+
+/// The one rule: only `refuse` turns a detection into an abort.
+fn decide(mode: ForeignSqliteMode, found: bool) -> bool {
+    matches!(mode, ForeignSqliteMode::Refuse) && found
+}
+
+#[cfg(target_os = "linux")]
+fn foreign_shm_mapped(shm: &Path) -> bool {
+    match std::fs::read_to_string("/proc/self/maps") {
+        Ok(maps) => duplicate_shm_offsets(&maps, shm) > 0,
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn foreign_shm_mapped(_shm: &Path) -> bool {
+    false
+}
+
+/// Count the file offsets at which `shm_path` is mapped more than once in
+/// a `/proc/self/maps` listing. One SQLite library maps each shm region
+/// once; a second library maps the same offsets again.
+///
+/// Line shape: `start-end perms offset dev inode      pathname`, the
+/// pathname possibly containing spaces and possibly suffixed
+/// ` (deleted)` (an unlinked shm is not the live one — ignored).
+pub(crate) fn duplicate_shm_offsets(maps: &str, shm_path: &Path) -> usize {
+    let target = shm_path.to_string_lossy();
+    let mut seen: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for line in maps.lines() {
+        let Some((offset, path)) = maps_fields(line) else {
+            continue;
+        };
+        if path != &*target {
+            continue; // a different file, a longer path, or ` (deleted)`
+        }
+        *seen.entry(offset).or_insert(0) += 1;
+    }
+    seen.values().filter(|&&n| n > 1).count()
+}
+
+/// `(offset, pathname)` of one `/proc/self/maps` line: the third
+/// whitespace-separated field, and everything after the fifth (the
+/// pathname keeps its internal spaces).
+fn maps_fields(line: &str) -> Option<(&str, &str)> {
+    let mut rest = line;
+    let mut offset = None;
+    for i in 0..5 {
+        let trimmed = rest.trim_start();
+        let end = trimmed.find(char::is_whitespace).unwrap_or(trimmed.len());
+        if end == 0 {
+            return None;
+        }
+        if i == 2 {
+            offset = Some(&trimmed[..end]);
+        }
+        rest = &trimmed[end..];
+    }
+    let path = rest.trim_start().trim_end();
+    if path.is_empty() {
+        return None;
+    }
+    offset.map(|o| (o, path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ONE_LIBRARY: &str = "\
+7f0000000000-7f0000008000 rw-s 00000000 08:01 42   /var/lib/y/memory.db-shm
+7f0000008000-7f0000010000 rw-s 00008000 08:01 42   /var/lib/y/memory.db-shm
+7f0000010000-7f0000018000 rw-s 00010000 08:01 42   /var/lib/y/memory.db-shm
+7f0000020000-7f0000028000 rw-s 00000000 08:01 43   /var/lib/y/other.db-shm
+7f0000030000-7f0000038000 rw-s 00000000 08:01 44   /var/lib/y/memory.db-shm (deleted)
+7f0000040000-7f0000048000 r-xp 00000000 08:01 45   /usr/lib/libsqlite3.so.0
+";
+
+    #[test]
+    fn one_library_maps_each_region_once() {
+        assert_eq!(
+            duplicate_shm_offsets(ONE_LIBRARY, Path::new("/var/lib/y/memory.db-shm")),
+            0
+        );
+    }
+
+    #[test]
+    fn a_second_library_maps_the_same_offset_again() {
+        let two = format!(
+            "{ONE_LIBRARY}7f0000050000-7f0000058000 rw-s 00000000 08:01 42   /var/lib/y/memory.db-shm\n"
+        );
+        assert_eq!(
+            duplicate_shm_offsets(&two, Path::new("/var/lib/y/memory.db-shm")),
+            1
+        );
+        // A path with spaces still resolves exactly.
+        let spaced = "7f0-7f1 rw-s 00000000 08:01 9   /home/a b/m.db-shm\n\
+                      7f2-7f3 rw-s 00000000 08:01 9   /home/a b/m.db-shm\n\
+                      7f4-7f5 rw-s 00000000 08:01 9   /home/xa b/m.db-shm\n";
+        assert_eq!(
+            duplicate_shm_offsets(spaced, Path::new("/home/a b/m.db-shm")),
+            1
+        );
+        assert_eq!(duplicate_shm_offsets(spaced, Path::new("b/m.db-shm")), 0);
+    }
+
+    #[test]
+    fn only_refuse_aborts_and_a_bad_mode_is_loud() {
+        assert!(!decide(ForeignSqliteMode::Off, true));
+        assert!(!decide(ForeignSqliteMode::Warn, true));
+        assert!(decide(ForeignSqliteMode::Refuse, true));
+        assert!(!decide(ForeignSqliteMode::Refuse, false));
+        for (s, m) in [
+            ("off", ForeignSqliteMode::Off),
+            ("warn", ForeignSqliteMode::Warn),
+            ("refuse", ForeignSqliteMode::Refuse),
+        ] {
+            assert_eq!(ForeignSqliteMode::parse(s).unwrap(), m);
+            assert_eq!(m.as_str(), s);
+            assert_eq!(ForeignSqliteMode::from_u8(m.as_u8()), m);
+        }
+        assert!(ForeignSqliteMode::parse("enforce").is_err());
+    }
+
+    /// Pins the assumption the error mapping rests on: an aborting commit
+    /// hook surfaces as SQLITE_CONSTRAINT_COMMITHOOK (531).
+    #[test]
+    fn an_aborting_commit_hook_surfaces_as_the_commithook_code() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (x INTEGER)").unwrap();
+        conn.commit_hook(Some(|| true));
+        let err = conn.execute("INSERT INTO t VALUES (1)", []).unwrap_err();
+        match err {
+            rusqlite::Error::SqliteFailure(e, msg) => {
+                assert_eq!(
+                    e.extended_code, SQLITE_CONSTRAINT_COMMITHOOK,
+                    "{e:?} {msg:?}"
+                );
+            }
+            other => panic!("unexpected error shape: {other:?}"),
+        }
+        assert!(is_commit_hook_abort(
+            &conn.execute("INSERT INTO t VALUES (2)", []).unwrap_err()
+        ));
+    }
+
+    #[test]
+    fn a_memory_store_is_never_scanned() {
+        let g = ForeignSqliteGuard::new(":memory:", ForeignSqliteMode::Refuse);
+        assert!(!g.supported());
+        assert!(!g.scan());
+        assert!(g.check_write().is_ok());
+        assert!(!g.commit_should_abort());
+    }
+}

--- a/crates/yantrikdb-core/src/engine/foreign_sqlite.rs
+++ b/crates/yantrikdb-core/src/engine/foreign_sqlite.rs
@@ -27,9 +27,24 @@
 //! `<store>-shm` path mapped at the same offset TWICE means two libraries
 //! have the store open in this process. That is the hazard exactly, read
 //! in a few hundred microseconds, with no way for it to fire on the
-//! engine's own connections. macOS has no `/proc`; Windows locks are per
-//! handle and does not have the problem. Elsewhere the detector reports
+//! engine's own connections. macOS has no `/proc`: the same rule is read
+//! through libproc (`proc_pidinfo(PROC_PIDREGIONPATHINFO)`, one call per
+//! region, so it is rescanned less often). Windows locks are per handle
+//! and does not have the problem; there the detector reports
 //! `supported = false` and the mode is inert.
+//!
+//! **Commits from outside this engine (all platforms).** A second engine
+//! process, the `sqlite3` CLI, a backup tool: legitimate, serialised by
+//! the kernel — and still the only way a store changes under this engine
+//! without going through it. SQLite's `PRAGMA data_version` on the writer
+//! connection changes only when ANOTHER connection commits, and every
+//! engine write goes through that one connection, so a change is exactly
+//! "someone else committed". Each is counted
+//! (`stats().foreign_commits_detected_since_boot`) and asks for one
+//! `PRAGMA quick_check`, run off the writer by the materializer (or
+//! `integrity_check()` on demand); a failed check taints the store the
+//! same way a foreign instance does, because writing onto a corrupt file
+//! only spreads the damage.
 //!
 //! **Modes**, durable in `meta.foreign_sqlite_mode`, default `refuse`:
 //! `off` never scans; `warn` scans, logs the transition and counts
@@ -52,14 +67,18 @@
 //! integrity. `stats().foreign_sqlite_tainted` says so.
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::error::{Result, YantrikDbError};
 
-/// How often the commit hook re-reads `/proc/self/maps`. A commit inside
-/// this window reuses the last verdict; the first commit after it pays the
-/// scan.
+/// How often the commit hook rescans. A commit inside this window reuses
+/// the last verdict; the first commit after it pays the scan. Linux reads
+/// one file; macOS makes one libproc call per region, hence the longer
+/// window there.
+#[cfg(target_os = "macos")]
+const RESCAN_AFTER: Duration = Duration::from_millis(1000);
+#[cfg(not(target_os = "macos"))]
 const RESCAN_AFTER: Duration = Duration::from_millis(200);
 
 /// `SQLITE_CONSTRAINT_COMMITHOOK`: the extended result code SQLite returns
@@ -129,19 +148,29 @@ pub(crate) struct ForeignSqliteGuard {
     detected_since_boot: AtomicU64,
     refused_since_boot: AtomicU64,
     last_scan: parking_lot::Mutex<Option<Instant>>,
+    /// `PRAGMA data_version` of the writer connection at the last check;
+    /// -1 until the first read.
+    last_data_version: AtomicI64,
+    foreign_commits_detected_since_boot: AtomicU64,
+    /// A foreign commit was seen and no integrity check has run since.
+    integrity_check_pending: AtomicBool,
+    integrity_checks_since_boot: AtomicU64,
+    /// The last `PRAGMA quick_check` result (`ok`, or the first problem).
+    last_integrity: parking_lot::Mutex<Option<String>>,
 }
 
 impl ForeignSqliteGuard {
     pub(crate) fn new(db_path: &str, mode: ForeignSqliteMode) -> Self {
-        let shm_path = if db_path == ":memory:" || !cfg!(target_os = "linux") {
-            None
-        } else {
-            std::fs::canonicalize(db_path).ok().map(|p| {
-                let mut s = p.into_os_string();
-                s.push("-shm");
-                PathBuf::from(s)
-            })
-        };
+        let shm_path =
+            if db_path == ":memory:" || !cfg!(any(target_os = "linux", target_os = "macos")) {
+                None
+            } else {
+                std::fs::canonicalize(db_path).ok().map(|p| {
+                    let mut s = p.into_os_string();
+                    s.push("-shm");
+                    PathBuf::from(s)
+                })
+            };
         Self {
             shm_path,
             store: db_path.to_string(),
@@ -151,6 +180,68 @@ impl ForeignSqliteGuard {
             detected_since_boot: AtomicU64::new(0),
             refused_since_boot: AtomicU64::new(0),
             last_scan: parking_lot::Mutex::new(None),
+            last_data_version: AtomicI64::new(-1),
+            foreign_commits_detected_since_boot: AtomicU64::new(0),
+            integrity_check_pending: AtomicBool::new(false),
+            integrity_checks_since_boot: AtomicU64::new(0),
+            last_integrity: parking_lot::Mutex::new(None),
+        }
+    }
+
+    pub(crate) fn foreign_commits_detected_since_boot(&self) -> u64 {
+        self.foreign_commits_detected_since_boot
+            .load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn integrity_check_pending(&self) -> bool {
+        self.integrity_check_pending.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn integrity_checks_since_boot(&self) -> u64 {
+        self.integrity_checks_since_boot.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn last_integrity(&self) -> Option<String> {
+        self.last_integrity.lock().clone()
+    }
+
+    /// Read the writer connection's `PRAGMA data_version` and compare it
+    /// with the last reading. A change means a commit that did not go
+    /// through this engine. Returns whether one was seen.
+    pub(crate) fn note_data_version(&self, conn: &rusqlite::Connection) -> bool {
+        let Ok(v) = conn.query_row("PRAGMA data_version", [], |r| r.get::<_, i64>(0)) else {
+            return false;
+        };
+        let prev = self.last_data_version.swap(v, Ordering::Relaxed);
+        if prev >= 0 && prev != v {
+            self.foreign_commits_detected_since_boot
+                .fetch_add(1, Ordering::Relaxed);
+            self.integrity_check_pending.store(true, Ordering::Relaxed);
+            tracing::info!(
+                store = %self.store,
+                "a commit reached this store without going through this engine \
+                 (another process, most likely); an integrity check is queued"
+            );
+            return true;
+        }
+        false
+    }
+
+    /// Record a `PRAGMA quick_check` result. Anything but `ok` taints the
+    /// store: writing onto a corrupt file only spreads the damage.
+    pub(crate) fn note_integrity(&self, result: &str) {
+        self.integrity_check_pending.store(false, Ordering::Relaxed);
+        self.integrity_checks_since_boot
+            .fetch_add(1, Ordering::Relaxed);
+        *self.last_integrity.lock() = Some(result.to_string());
+        if result != "ok" {
+            self.tainted.store(true, Ordering::Relaxed);
+            tracing::error!(
+                store = %self.store,
+                result = %result,
+                "integrity check failed after a commit from outside this engine; \
+                 writes are refused until the store is repaired and the engine reopened"
+            );
         }
     }
 
@@ -275,9 +366,100 @@ fn foreign_shm_mapped(shm: &Path) -> bool {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
+fn foreign_shm_mapped(shm: &Path) -> bool {
+    duplicate_shm_offsets_macos(shm) > 0
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn foreign_shm_mapped(_shm: &Path) -> bool {
     false
+}
+
+/// macOS: walk this process's regions with libproc and count the file
+/// offsets at which `shm_path` is mapped more than once — the same rule as
+/// the Linux reader. Layouts follow XNU's `sys/proc_info.h`
+/// (`proc_regioninfo`, `proc_regionwithpathinfo`, flavor 8). A walk that
+/// stops advancing ends the scan, so a misbehaving kernel call can only
+/// under-report, never invent a duplicate.
+#[cfg(target_os = "macos")]
+fn duplicate_shm_offsets_macos(shm_path: &Path) -> usize {
+    use std::collections::HashMap;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct ProcRegionInfo {
+        pri_protection: u32,
+        pri_max_protection: u32,
+        pri_inheritance: u32,
+        pri_flags: u32,
+        pri_offset: u64,
+        pri_behavior: u32,
+        pri_user_wired_count: u32,
+        pri_user_tag: u32,
+        pri_pages_resident: u32,
+        pri_pages_shared_now_private: u32,
+        pri_pages_swapped_out: u32,
+        pri_pages_dirtied: u32,
+        pri_ref_count: u32,
+        pri_shadow_depth: u32,
+        pri_share_mode: u32,
+        pri_private_pages_resident: u32,
+        pri_shared_pages_resident: u32,
+        pri_obj_id: u32,
+        pri_depth: u32,
+        pri_address: u64,
+        pri_size: u64,
+    }
+    #[repr(C)]
+    struct ProcRegionWithPathInfo {
+        prp_prinfo: ProcRegionInfo,
+        prp_vip: libc::vnode_info_path,
+    }
+    const PROC_PIDREGIONPATHINFO: libc::c_int = 8;
+    const MAX_REGIONS: usize = 50_000;
+
+    let target = shm_path.to_string_lossy();
+    let pid = std::process::id() as libc::c_int;
+    let mut seen: HashMap<u64, usize> = HashMap::new();
+    let mut address: u64 = 0;
+    for _ in 0..MAX_REGIONS {
+        let mut info = std::mem::MaybeUninit::<ProcRegionWithPathInfo>::zeroed();
+        let size = std::mem::size_of::<ProcRegionWithPathInfo>() as libc::c_int;
+        // SAFETY: libproc fills at most `size` bytes of a properly sized,
+        // zeroed buffer; a non-positive return means no more regions.
+        let got = unsafe {
+            libc::proc_pidinfo(
+                pid,
+                PROC_PIDREGIONPATHINFO,
+                address,
+                info.as_mut_ptr() as *mut libc::c_void,
+                size,
+            )
+        };
+        if got <= 0 {
+            break;
+        }
+        // SAFETY: the call succeeded and wrote the struct.
+        let info = unsafe { info.assume_init() };
+        let next = info
+            .prp_prinfo
+            .pri_address
+            .saturating_add(info.prp_prinfo.pri_size);
+        if next <= address {
+            break; // not advancing: stop rather than loop
+        }
+        address = next;
+        // SAFETY: vip_path is a NUL-terminated C string inside the struct.
+        let path = unsafe {
+            std::ffi::CStr::from_ptr(info.prp_vip.vip_path.as_ptr() as *const libc::c_char)
+        }
+        .to_string_lossy();
+        if path == target {
+            *seen.entry(info.prp_prinfo.pri_offset).or_insert(0) += 1;
+        }
+    }
+    seen.values().filter(|&&n| n > 1).count()
 }
 
 /// Count the file offsets at which `shm_path` is mapped more than once in

--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -149,6 +149,7 @@ impl YantrikDB {
     /// Create or update a relationship between entities.
     #[tracing::instrument(skip(self))]
     pub fn relate(&self, src: &str, dst: &str, rel_type: &str, weight: f64) -> Result<String> {
+        self.foreign_sqlite_precheck()?;
         let edge_id = crate::id::new_id();
         let ts = now();
         // #148: the edge's causal timestamp, minted once and carried VERBATIM
@@ -902,6 +903,7 @@ impl YantrikDB {
         weight: f64,
         grounding: i64,
     ) -> Result<String> {
+        self.foreign_sqlite_precheck()?;
         let claim_id = crate::id::new_id();
         let ts = now();
 

--- a/crates/yantrikdb-core/src/engine/graph_ops.rs
+++ b/crates/yantrikdb-core/src/engine/graph_ops.rs
@@ -149,7 +149,7 @@ impl YantrikDB {
     /// Create or update a relationship between entities.
     #[tracing::instrument(skip(self))]
     pub fn relate(&self, src: &str, dst: &str, rel_type: &str, weight: f64) -> Result<String> {
-        self.foreign_sqlite_precheck()?;
+        self.foreign_commit_precheck()?;
         let edge_id = crate::id::new_id();
         let ts = now();
         // #148: the edge's causal timestamp, minted once and carried VERBATIM

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -816,6 +816,7 @@ impl YantrikDB {
     /// behavioral difference vs the cluster primitive.
     #[tracing::instrument(skip(self))]
     pub fn forget(&self, rid: &str) -> Result<bool> {
+        self.foreign_sqlite_precheck()?;
         let ts_micros = (now() * 1_000_000.0) as i64;
         self.tombstone_inner(rid, None, None, ts_micros, None)
     }
@@ -874,6 +875,7 @@ impl YantrikDB {
         new_valence: Option<f64>,
         reason: &str,
     ) -> Result<CorrectionResult> {
+        self.foreign_sqlite_precheck()?;
         self.correct_impl(
             rid,
             new_text,

--- a/crates/yantrikdb-core/src/engine/lifecycle.rs
+++ b/crates/yantrikdb-core/src/engine/lifecycle.rs
@@ -816,7 +816,7 @@ impl YantrikDB {
     /// behavioral difference vs the cluster primitive.
     #[tracing::instrument(skip(self))]
     pub fn forget(&self, rid: &str) -> Result<bool> {
-        self.foreign_sqlite_precheck()?;
+        self.foreign_commit_precheck()?;
         let ts_micros = (now() * 1_000_000.0) as i64;
         self.tombstone_inner(rid, None, None, ts_micros, None)
     }
@@ -875,7 +875,7 @@ impl YantrikDB {
         new_valence: Option<f64>,
         reason: &str,
     ) -> Result<CorrectionResult> {
-        self.foreign_sqlite_precheck()?;
+        self.foreign_commit_precheck()?;
         self.correct_impl(
             rid,
             new_text,

--- a/crates/yantrikdb-core/src/engine/materializer.rs
+++ b/crates/yantrikdb-core/src/engine/materializer.rs
@@ -103,6 +103,10 @@ fn worker_loop(weak: Weak<YantrikDB>, shutdown: Arc<AtomicBool>, worker_id: usiz
             break;
         };
 
+        // Issue #225: a commit from outside this engine queued an integrity
+        // check; run it here, off the writer, before draining.
+        db.run_pending_integrity_check();
+
         match db.apply_pending_ops_once(DRAIN_BATCH_SIZE) {
             Ok(0) => {
                 // No work — release the strong ref before sleeping so the

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -12,6 +12,8 @@ mod causal;
 mod chunking;
 mod claims_lane;
 pub use claims_lane::ChainGateMode;
+pub(crate) mod foreign_sqlite;
+pub use foreign_sqlite::{ForeignSqliteMode, SQLITE_CONSTRAINT_COMMITHOOK};
 mod cognition;
 mod coherence;
 pub mod conflict;
@@ -267,6 +269,9 @@ pub struct YantrikDB {
     /// before turning the gate on. In-memory by design.
     pub(crate) claim_chain_gate_suppressed_since_boot:
         parking_lot::Mutex<std::collections::BTreeMap<String, u64>>,
+    /// **Issue #225** — the second-SQLite-library guard, shared with the
+    /// writer connection's commit hook. See `engine::foreign_sqlite`.
+    pub(crate) foreign_sqlite: std::sync::Arc<foreign_sqlite::ForeignSqliteGuard>,
     /// **v0.10 Item 3 — correction seqlock (sol r4).** A DB-wide epoch that
     /// makes a text-changing correction's (SQL commit + vector publish +
     /// scoring-cache update) atomic FROM A READER'S PERSPECTIVE, without
@@ -1176,6 +1181,16 @@ impl YantrikDB {
                 [],
             ),
         )?;
+        // Issue #225: refuse to write while a second SQLite library has the
+        // store open in this process — on every install, because the
+        // alternative is silent corruption. `set_foreign_sqlite_mode` opts out.
+        at(
+            "fresh_defaults",
+            conn.execute(
+                "INSERT OR IGNORE INTO meta (key, value) VALUES ('foreign_sqlite_mode', 'refuse')",
+                [],
+            ),
+        )?;
 
         // **v28 (issue #41 brainstorm-4 §6).** Seed meta.active_generation
         // on first install. INSERT OR IGNORE preserves the durable
@@ -1605,6 +1620,32 @@ impl YantrikDB {
             .unwrap_or("shadow"),
         )?
         .as_u8();
+        let foreign_sqlite_mode = foreign_sqlite::ForeignSqliteMode::parse(
+            rewrap(
+                "final_meta_reads",
+                Self::get_meta(&conn, "foreign_sqlite_mode"),
+            )?
+            .as_deref()
+            .unwrap_or("refuse"),
+        )?;
+        // Issue #225: the guard, and the commit hook that makes it a hard
+        // guarantee on the writer connection — every engine commit, the
+        // materializer's included, goes through this one connection.
+        let foreign_sqlite = std::sync::Arc::new(foreign_sqlite::ForeignSqliteGuard::new(
+            db_path,
+            foreign_sqlite_mode,
+        ));
+        {
+            let hook_guard = std::sync::Arc::clone(&foreign_sqlite);
+            conn.commit_hook(Some(move || hook_guard.commit_should_abort()));
+        }
+        if foreign_sqlite.scan() {
+            tracing::warn!(
+                db_path = %db_path,
+                mode = foreign_sqlite_mode.as_str(),
+                "opened with another SQLite library already holding this store in this process"
+            );
+        }
 
         // Missing is the v42-upgrade-compatible default. A malformed or zero
         // persisted value fails open() loudly: silently disabling a write-
@@ -1668,6 +1709,7 @@ impl YantrikDB {
             claim_chain_gate_suppressed_since_boot: parking_lot::Mutex::new(
                 std::collections::BTreeMap::new(),
             ),
+            foreign_sqlite,
             correction_epoch: std::sync::atomic::AtomicU64::new(0),
             visible_seq: dashmap::DashMap::new(),
             visible_seq_cv: parking_lot::Condvar::new(),
@@ -2072,6 +2114,39 @@ impl YantrikDB {
             .store(mode.as_u8(), std::sync::atomic::Ordering::Relaxed);
         drop(conn);
         Ok(())
+    }
+
+    /// **Issue #225.** The second-SQLite-library guard mode
+    /// (`off` | `warn` | `refuse`); every install defaults to `refuse`.
+    pub fn foreign_sqlite_mode(&self) -> foreign_sqlite::ForeignSqliteMode {
+        self.foreign_sqlite.mode()
+    }
+
+    /// Durably set the guard mode. `warn` keeps writing and counts
+    /// detections; `off` never scans. Both are opt-outs from a corruption
+    /// guard — say why in the operator log.
+    pub fn set_foreign_sqlite_mode(&self, mode: foreign_sqlite::ForeignSqliteMode) -> Result<()> {
+        let conn = self.conn();
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('foreign_sqlite_mode', ?1)",
+            params![mode.as_str()],
+        )?;
+        self.foreign_sqlite.set_mode(mode);
+        drop(conn);
+        Ok(())
+    }
+
+    /// Scan now (not the cached verdict): is a second SQLite library holding
+    /// this store open in this process? Always `false` where the detector is
+    /// unsupported (`stats().foreign_sqlite_supported`).
+    pub fn foreign_sqlite_detected(&self) -> bool {
+        self.foreign_sqlite.scan()
+    }
+
+    /// The typed pre-check every public write entry point runs first.
+    #[inline]
+    pub(crate) fn foreign_sqlite_precheck(&self) -> Result<()> {
+        self.foreign_sqlite.check_write()
     }
 
     /// Tick the since-boot suppression counters (one recall's worth).
@@ -2879,6 +2954,7 @@ impl YantrikDB {
         allow_queued_route: bool,
         synthesis: Option<&SynthesisAdmission>,
     ) -> Result<String> {
+        self.foreign_sqlite_precheck()?;
         // v0.9.3 contract gate: scalars validated BEFORE calibration mutates
         // the namespace's running distribution. (The embedding is engine-
         // generated below and validated inside the embed step.)

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -1646,6 +1646,7 @@ impl YantrikDB {
                 "opened with another SQLite library already holding this store in this process"
             );
         }
+        foreign_sqlite.note_data_version(&conn);
 
         // Missing is the v42-upgrade-compatible default. A malformed or zero
         // persisted value fails open() loudly: silently disabling a write-
@@ -2147,6 +2148,41 @@ impl YantrikDB {
     #[inline]
     pub(crate) fn foreign_sqlite_precheck(&self) -> Result<()> {
         self.foreign_sqlite.check_write()
+    }
+
+    /// The cross-process half of the guard, at the user-facing write entry
+    /// points (never from a path that already holds the writer connection):
+    /// notice a commit that did not come through this engine, queue an
+    /// integrity check, and refuse if a check already failed.
+    pub(crate) fn foreign_commit_precheck(&self) -> Result<()> {
+        {
+            let conn = self.conn();
+            self.foreign_sqlite.note_data_version(&conn);
+        }
+        self.foreign_sqlite.check_write()
+    }
+
+    /// `PRAGMA quick_check` on a read connection, recorded in the guard:
+    /// anything but `ok` taints the store (writes refused until it is
+    /// repaired and the engine reopened). Runs on demand here and from the
+    /// materializer whenever a commit from outside this engine was seen.
+    pub fn integrity_check(&self) -> Result<String> {
+        let result: String = {
+            let conn = self.read_conn();
+            conn.query_row("PRAGMA quick_check(1)", [], |r| r.get(0))?
+        };
+        self.foreign_sqlite.note_integrity(&result);
+        Ok(result)
+    }
+
+    /// Run the queued integrity check, if any. Called by the materializer
+    /// between drains so the check never blocks a user write.
+    pub(crate) fn run_pending_integrity_check(&self) {
+        if self.foreign_sqlite.integrity_check_pending() {
+            if let Err(e) = self.integrity_check() {
+                tracing::warn!(error = %e, "queued integrity check failed to run");
+            }
+        }
     }
 
     /// Tick the since-boot suppression counters (one recall's worth).
@@ -2954,7 +2990,7 @@ impl YantrikDB {
         allow_queued_route: bool,
         synthesis: Option<&SynthesisAdmission>,
     ) -> Result<String> {
-        self.foreign_sqlite_precheck()?;
+        self.foreign_commit_precheck()?;
         // v0.9.3 contract gate: scalars validated BEFORE calibration mutates
         // the namespace's running distribution. (The embedding is engine-
         // generated below and validated inside the embed step.)

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -100,6 +100,7 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
     ) -> Result<String> {
+        self.foreign_sqlite_precheck()?;
         self.record_with_idempotency(
             text,
             memory_type,
@@ -170,6 +171,7 @@ impl YantrikDB {
         idempotency_key: Option<&str>,
         created_at: Option<f64>,
     ) -> Result<String> {
+        self.foreign_sqlite_precheck()?;
         self.record_with_idempotency_routed(
             text,
             memory_type,
@@ -1138,6 +1140,7 @@ impl YantrikDB {
     /// Uses SAVEPOINT for atomicity while keeping `&self` (no `&mut self`).
     #[tracing::instrument(skip(self, inputs), fields(batch_size = inputs.len()))]
     pub fn record_batch(&self, inputs: &[RecordInput]) -> Result<Vec<String>> {
+        self.foreign_sqlite_precheck()?;
         if inputs.is_empty() {
             return Ok(vec![]);
         }
@@ -2096,6 +2099,7 @@ impl YantrikDB {
         seq: Option<u64>,
         admission: crate::provenance::WriteAdmission,
     ) -> Result<()> {
+        self.foreign_sqlite_precheck()?;
         // 4a.6b (sol r2 finding 2): the anti-laundering gate. ORIGIN callers are
         // gated exactly like record(); ADMITTED callers (the materializer drain,
         // replication apply) are NOT re-gated — the op was gated at the leader's

--- a/crates/yantrikdb-core/src/engine/record.rs
+++ b/crates/yantrikdb-core/src/engine/record.rs
@@ -100,7 +100,7 @@ impl YantrikDB {
         source: &str,
         emotional_state: Option<&str>,
     ) -> Result<String> {
-        self.foreign_sqlite_precheck()?;
+        self.foreign_commit_precheck()?;
         self.record_with_idempotency(
             text,
             memory_type,
@@ -171,7 +171,7 @@ impl YantrikDB {
         idempotency_key: Option<&str>,
         created_at: Option<f64>,
     ) -> Result<String> {
-        self.foreign_sqlite_precheck()?;
+        self.foreign_commit_precheck()?;
         self.record_with_idempotency_routed(
             text,
             memory_type,
@@ -1140,7 +1140,7 @@ impl YantrikDB {
     /// Uses SAVEPOINT for atomicity while keeping `&self` (no `&mut self`).
     #[tracing::instrument(skip(self, inputs), fields(batch_size = inputs.len()))]
     pub fn record_batch(&self, inputs: &[RecordInput]) -> Result<Vec<String>> {
-        self.foreign_sqlite_precheck()?;
+        self.foreign_commit_precheck()?;
         if inputs.is_empty() {
             return Ok(vec![]);
         }
@@ -2099,7 +2099,7 @@ impl YantrikDB {
         seq: Option<u64>,
         admission: crate::provenance::WriteAdmission,
     ) -> Result<()> {
-        self.foreign_sqlite_precheck()?;
+        self.foreign_commit_precheck()?;
         // 4a.6b (sol r2 finding 2): the anti-laundering gate. ORIGIN callers are
         // gated exactly like record(); ADMITTED callers (the materializer drain,
         // replication apply) are NOT re-gated — the op was gated at the leader's

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -299,6 +299,12 @@ impl YantrikDB {
                 .iter()
                 .map(|(k, v)| (k.clone(), *v))
                 .collect(),
+            foreign_sqlite_mode: self.foreign_sqlite.mode().as_str().to_string(),
+            foreign_sqlite_supported: self.foreign_sqlite.supported(),
+            foreign_sqlite_active: self.foreign_sqlite.active(),
+            foreign_sqlite_tainted: self.foreign_sqlite.tainted(),
+            foreign_sqlite_detected_since_boot: self.foreign_sqlite.detected_since_boot(),
+            foreign_sqlite_refused_since_boot: self.foreign_sqlite.refused_since_boot(),
             provenance_verified_records,
             unverified_user_source_records,
             provenance_source_counts,

--- a/crates/yantrikdb-core/src/engine/stats.rs
+++ b/crates/yantrikdb-core/src/engine/stats.rs
@@ -305,6 +305,12 @@ impl YantrikDB {
             foreign_sqlite_tainted: self.foreign_sqlite.tainted(),
             foreign_sqlite_detected_since_boot: self.foreign_sqlite.detected_since_boot(),
             foreign_sqlite_refused_since_boot: self.foreign_sqlite.refused_since_boot(),
+            foreign_commits_detected_since_boot: self
+                .foreign_sqlite
+                .foreign_commits_detected_since_boot(),
+            integrity_check_pending: self.foreign_sqlite.integrity_check_pending(),
+            integrity_checks_since_boot: self.foreign_sqlite.integrity_checks_since_boot(),
+            last_integrity_check: self.foreign_sqlite.last_integrity().unwrap_or_default(),
             provenance_verified_records,
             unverified_user_source_records,
             provenance_source_counts,

--- a/crates/yantrikdb-core/src/lib.rs
+++ b/crates/yantrikdb-core/src/lib.rs
@@ -63,6 +63,7 @@ pub use engine::thread::{
     MaintenanceProgress, ThreadItem, ThreadItemV2, ThreadQuery, ThreadRecall, ThreadRecallV2,
 };
 pub use engine::ChainGateMode;
+pub use engine::ForeignSqliteMode;
 pub use engine::YantrikDB;
 pub use error::YantrikDbError;
 pub use patterns::mine_patterns;

--- a/crates/yantrikdb-python/src/lib.rs
+++ b/crates/yantrikdb-python/src/lib.rs
@@ -42,6 +42,10 @@ fn _yantrikdb_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.py().get_type::<py_errors::RecallContended>(),
     )?;
     m.add(
+        "ForeignSqliteInstance",
+        m.py().get_type::<py_errors::ForeignSqliteInstance>(),
+    )?;
+    m.add(
         "PackEmbedderMismatch",
         m.py().get_type::<py_errors::PackEmbedderMismatch>(),
     )?;

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -380,6 +380,19 @@ pub(crate) fn map_err(e: yantrikdb_core::YantrikDbError) -> PyErr {
             py_errors::ProvenanceInconsistent::new_err(e.to_string())
         }
         E::RecallContended { .. } => py_errors::RecallContended::new_err(e.to_string()),
+        E::ForeignSqliteInstance { .. } => py_errors::ForeignSqliteInstance::new_err(e.to_string()),
+        // The commit hook's abort surfaces from SQLite as
+        // SQLITE_CONSTRAINT_COMMITHOOK; it means the same thing.
+        E::Database(rusqlite::Error::SqliteFailure(ref err, _))
+            if err.extended_code == yantrikdb_core::engine::SQLITE_CONSTRAINT_COMMITHOOK =>
+        {
+            py_errors::ForeignSqliteInstance::new_err(
+                "refusing to write: another SQLite library has this store open in this \
+                 process (issue #225); the commit was aborted. Close that connection, check \
+                 integrity and reopen the engine (its close may have unlinked the \
+                 shared-memory file); use the engine API / a separate process for raw SQL.",
+            )
+        }
         E::PackEmbedderMismatch { .. } => py_errors::PackEmbedderMismatch::new_err(e.to_string()),
         E::PackAlreadyMounted { .. } => py_errors::PackAlreadyMounted::new_err(e.to_string()),
         E::PackSignatureInvalid { .. } => py_errors::PackSignatureInvalid::new_err(e.to_string()),
@@ -790,6 +803,32 @@ impl PyYantrikDB {
         self.get_inner()?
             .set_claim_chain_gate_mode(parsed)
             .map_err(map_err)
+    }
+
+    /// `"off"` | `"warn"` | `"refuse"`: what the engine does when another
+    /// SQLite library (the stdlib `sqlite3` module, a system libsqlite3)
+    /// has this store open in this process — the silent-corruption hazard
+    /// of issue #225. Every database defaults to `refuse`: writes fail with
+    /// `ForeignSqliteInstance` from the first detection until the engine is
+    /// reopened (the foreign library's close may unlink the shm/WAL under it). Detection needs Linux and a
+    /// file-backed store (`stats()["foreign_sqlite_supported"]`).
+    fn foreign_sqlite_mode(&self) -> PyResult<String> {
+        Ok(self.get_inner()?.foreign_sqlite_mode().as_str().to_string())
+    }
+
+    /// Durably set the guard mode. `warn` keeps writing and counts; `off`
+    /// never scans. Both opt out of a corruption guard.
+    fn set_foreign_sqlite_mode(&self, mode: &str) -> PyResult<()> {
+        let parsed = yantrikdb_core::ForeignSqliteMode::parse(mode).map_err(map_err)?;
+        self.get_inner()?
+            .set_foreign_sqlite_mode(parsed)
+            .map_err(map_err)
+    }
+
+    /// Scan now: is a second SQLite library holding this store open in this
+    /// process? Always False where detection is unsupported.
+    fn foreign_sqlite_detected(&self) -> PyResult<bool> {
+        Ok(self.get_inner()?.foreign_sqlite_detected())
     }
 
     /// Exposed for Python consolidate.py compatibility.

--- a/crates/yantrikdb-python/src/py_engine/mod.rs
+++ b/crates/yantrikdb-python/src/py_engine/mod.rs
@@ -831,6 +831,14 @@ impl PyYantrikDB {
         Ok(self.get_inner()?.foreign_sqlite_detected())
     }
 
+    /// `PRAGMA quick_check` on a read connection, recorded in
+    /// `stats()["last_integrity_check"]`. Anything but "ok" makes the engine
+    /// refuse writes until the store is repaired and reopened. Queued
+    /// automatically whenever a commit from outside this engine is seen.
+    fn integrity_check(&self) -> PyResult<String> {
+        self.get_inner()?.integrity_check().map_err(map_err)
+    }
+
     /// Exposed for Python consolidate.py compatibility.
     #[pyo3(signature = (op_type, target_rid, payload))]
     fn _log_op(

--- a/crates/yantrikdb-python/src/py_errors.rs
+++ b/crates/yantrikdb-python/src/py_errors.rs
@@ -69,6 +69,20 @@ create_exception!(
 
 create_exception!(
     yantrikdb,
+    ForeignSqliteInstance,
+    PyRuntimeError,
+    "Another SQLite library (the stdlib `sqlite3` module, a system libsqlite3) \
+     has this store open in this process, and the engine refused to write: \
+     POSIX locks are per process, so that connection's unlock releases the \
+     engine's and the two writers would interleave WAL commits (silent page \
+     aliasing; issue #225). Close that connection, check integrity and reopen \
+     the engine — its close may have unlinked the shared-memory file under the \
+     engine, so writes stay refused until then — and use the engine API or a \
+     separate process for raw SQL."
+);
+
+create_exception!(
+    yantrikdb,
     RecallContended,
     PyRuntimeError,
     "A recall lost a bounded read-contention race (writer-priority lock \

--- a/crates/yantrikdb-python/src/py_types.rs
+++ b/crates/yantrikdb-python/src/py_types.rs
@@ -303,6 +303,19 @@ pub fn stats_to_dict(py: Python<'_>, s: &yantrikdb_core::Stats) -> PyResult<PyOb
         "claim_chain_gate_suppressed_since_boot",
         &s.claim_chain_gate_suppressed_since_boot,
     )?;
+    // Issue #225: the second-SQLite-library guard.
+    dict.set_item("foreign_sqlite_mode", &s.foreign_sqlite_mode)?;
+    dict.set_item("foreign_sqlite_supported", s.foreign_sqlite_supported)?;
+    dict.set_item("foreign_sqlite_active", s.foreign_sqlite_active)?;
+    dict.set_item("foreign_sqlite_tainted", s.foreign_sqlite_tainted)?;
+    dict.set_item(
+        "foreign_sqlite_detected_since_boot",
+        s.foreign_sqlite_detected_since_boot,
+    )?;
+    dict.set_item(
+        "foreign_sqlite_refused_since_boot",
+        s.foreign_sqlite_refused_since_boot,
+    )?;
     dict.set_item("provenance_verified_records", s.provenance_verified_records)?;
     dict.set_item(
         "unverified_user_source_records",

--- a/crates/yantrikdb-python/src/py_types.rs
+++ b/crates/yantrikdb-python/src/py_types.rs
@@ -316,6 +316,13 @@ pub fn stats_to_dict(py: Python<'_>, s: &yantrikdb_core::Stats) -> PyResult<PyOb
         "foreign_sqlite_refused_since_boot",
         s.foreign_sqlite_refused_since_boot,
     )?;
+    dict.set_item(
+        "foreign_commits_detected_since_boot",
+        s.foreign_commits_detected_since_boot,
+    )?;
+    dict.set_item("integrity_check_pending", s.integrity_check_pending)?;
+    dict.set_item("integrity_checks_since_boot", s.integrity_checks_since_boot)?;
+    dict.set_item("last_integrity_check", &s.last_integrity_check)?;
     dict.set_item("provenance_verified_records", s.provenance_verified_records)?;
     dict.set_item(
         "unverified_user_source_records",

--- a/src/yantrikdb/__init__.py
+++ b/src/yantrikdb/__init__.py
@@ -14,6 +14,7 @@ from yantrikdb._yantrikdb_rust import (
     PhraseRouteUnavailableError,
     ProvenanceInconsistent,
     RecallContended,
+    ForeignSqliteInstance,
     SourceTurnMaintenanceRequiredError,
     TenantManager,
     YantrikDB,
@@ -98,5 +99,6 @@ __all__ = [
     "PhraseRouteUnavailableError",
     "ProvenanceInconsistent",
     "RecallContended",
+    "ForeignSqliteInstance",
     "SourceTurnMaintenanceRequiredError",
 ]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -303,6 +303,10 @@ class TestStats:
             "provenance_gate_mode", "provenance_flagged_since_boot",
             # 0.22: claim-chain gate adoption surface (shadow counters).
             "claim_chain_gate_mode", "claim_chain_gate_suppressed_since_boot",
+            # Issue #225: the second-SQLite-library guard.
+            "foreign_sqlite_mode", "foreign_sqlite_supported", "foreign_sqlite_active",
+            "foreign_sqlite_tainted",
+            "foreign_sqlite_detected_since_boot", "foreign_sqlite_refused_since_boot",
             # Provenance-origin census: explicitly verified records and
             # legacy/user-source rows without an explicit verification marker.
             "provenance_verified_records", "unverified_user_source_records",

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -306,6 +306,8 @@ class TestStats:
             # Issue #225: the second-SQLite-library guard.
             "foreign_sqlite_mode", "foreign_sqlite_supported", "foreign_sqlite_active",
             "foreign_sqlite_tainted",
+            "foreign_commits_detected_since_boot", "integrity_check_pending",
+            "integrity_checks_since_boot", "last_integrity_check",
             "foreign_sqlite_detected_since_boot", "foreign_sqlite_refused_since_boot",
             # Provenance-origin census: explicitly verified records and
             # legacy/user-source rows without an explicit verification marker.

--- a/tests/test_foreign_sqlite.py
+++ b/tests/test_foreign_sqlite.py
@@ -28,7 +28,10 @@ import pytest
 import yantrikdb
 from yantrikdb import YantrikDB
 
-linux_only = pytest.mark.skipif(sys.platform != "linux", reason="the detector reads /proc/self/maps")
+linux_only = pytest.mark.skipif(
+    sys.platform not in ("linux", "darwin"),
+    reason="the instance detector reads /proc/self/maps (Linux) or libproc regions (macOS)",
+)
 
 
 @pytest.fixture
@@ -44,7 +47,7 @@ def test_mode_defaults_to_refuse_and_persists(store):
     assert db.foreign_sqlite_mode() == "refuse"
     s = db.stats()
     assert s["foreign_sqlite_mode"] == "refuse"
-    assert s["foreign_sqlite_supported"] == (sys.platform == "linux")
+    assert s["foreign_sqlite_supported"] == (sys.platform in ("linux", "darwin"))
     assert s["foreign_sqlite_active"] is False
     db.set_foreign_sqlite_mode("warn")
     db.close()
@@ -145,3 +148,40 @@ def test_a_separate_process_is_not_a_foreign_instance(store):
     assert int(out.stdout.strip()) >= 1
     assert db.foreign_sqlite_detected() is False
     assert db.record("still writing")
+
+
+def test_a_commit_from_another_process_is_counted_and_checked(store):
+    """The cross-process half: a commit that did not come through this
+    engine (another engine process here) is noticed on the next write,
+    queues an integrity check, and a clean check leaves writes alone."""
+    db, path = store
+    db.record("first, from this engine")
+    db.record("second, still this engine")
+    db.think()
+    before = db.stats()
+    assert before["foreign_commits_detected_since_boot"] == 0, before
+    code = textwrap.dedent(
+        f"""
+        from yantrikdb import YantrikDB
+        other = YantrikDB.with_default({path!r})
+        other.record("from another process, through the engine")
+        other.think()
+        other.close()
+        print("done")
+        """
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=120)
+    assert out.returncode == 0, out.stderr
+    assert db.record("third, after the other process") , "a foreign commit is not a refusal"
+    s = db.stats()
+    assert s["foreign_commits_detected_since_boot"] >= 1, s
+    assert s["foreign_sqlite_tainted"] is False
+    assert db.integrity_check() == "ok"
+    s = db.stats()
+    assert s["integrity_check_pending"] is False and s["last_integrity_check"] == "ok"
+    assert s["integrity_checks_since_boot"] >= 1
+    # The engine's own writes never count as foreign.
+    n = s["foreign_commits_detected_since_boot"]
+    db.record("fourth")
+    db.record("fifth")
+    assert db.stats()["foreign_commits_detected_since_boot"] == n

--- a/tests/test_foreign_sqlite.py
+++ b/tests/test_foreign_sqlite.py
@@ -1,0 +1,147 @@
+"""Issue #225 — a second SQLite library with the store open in this process.
+
+The engine bundles its own SQLite; Python's stdlib ``sqlite3`` is a second
+one. Both rely on POSIX advisory locks, which the kernel scopes per
+process, so the stdlib connection's unlock releases the engine's locks
+and two writers interleave WAL commits: silent page aliasing (seen on
+our CI 2026-09-06, reported from the field 2026-09-07). The engine cannot
+make the other library respect its locks; it can notice the second
+instance (Linux: the ``-shm`` file mapped twice at the same offset in
+``/proc/self/maps``) and refuse to write while it is there.
+
+These tests deliberately do the hazardous thing on a throwaway store,
+with the engine idle between steps, so the corruption window never opens.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+
+import pytest
+
+import yantrikdb
+from yantrikdb import YantrikDB
+
+linux_only = pytest.mark.skipif(sys.platform != "linux", reason="the detector reads /proc/self/maps")
+
+
+@pytest.fixture
+def store():
+    path = os.path.join(tempfile.mkdtemp(), "guard.db")
+    db = YantrikDB.with_default(path)
+    yield db, path
+    db.close()
+
+
+def test_mode_defaults_to_refuse_and_persists(store):
+    db, path = store
+    assert db.foreign_sqlite_mode() == "refuse"
+    s = db.stats()
+    assert s["foreign_sqlite_mode"] == "refuse"
+    assert s["foreign_sqlite_supported"] == (sys.platform == "linux")
+    assert s["foreign_sqlite_active"] is False
+    db.set_foreign_sqlite_mode("warn")
+    db.close()
+    again = YantrikDB.with_default(path)
+    try:
+        assert again.foreign_sqlite_mode() == "warn"
+        with pytest.raises(Exception):
+            again.set_foreign_sqlite_mode("enforce")
+        again.set_foreign_sqlite_mode("refuse")
+    finally:
+        again.close()
+    # The fixture closes the (already closed) handle; reopen so it can.
+    store_db = YantrikDB.with_default(path)
+    store_db.close()
+
+
+@linux_only
+def test_refuse_latches_until_the_engine_is_reopened(store):
+    db, path = store
+    rid = db.record("Alice Moreau works at Fennwick Labs.")
+    db.think()  # let the materializer finish before the hazardous step
+    assert not db.foreign_sqlite_detected()
+
+    foreign = sqlite3.connect(path)
+    try:
+        # A WAL reader maps the -shm; that alone makes the process unsafe.
+        foreign.execute("SELECT COUNT(*) FROM memories").fetchone()
+        assert db.foreign_sqlite_detected() is True
+        with pytest.raises(yantrikdb.ForeignSqliteInstance):
+            db.record("this must not be committed")
+        with pytest.raises(yantrikdb.ForeignSqliteInstance):
+            db.correct(rid, "nor this")
+        s = db.stats()
+        assert s["foreign_sqlite_active"] is True
+        assert s["foreign_sqlite_tainted"] is True
+        assert s["foreign_sqlite_detected_since_boot"] >= 1
+        assert s["foreign_sqlite_refused_since_boot"] >= 2
+        # Reads keep working.
+        assert db.recall(query="Alice Moreau", top_k=3, skip_reinforce=True)
+    finally:
+        foreign.close()
+
+    # The foreign library's close unlinked the shm under the engine
+    # (measured 2026-09-07): the store stays tainted for this instance.
+    time.sleep(0.3)  # past the rescan window
+    assert db.foreign_sqlite_detected() is False
+    with pytest.raises(yantrikdb.ForeignSqliteInstance):
+        db.record("still refused: reopen first")
+    s = db.stats()
+    assert s["foreign_sqlite_active"] is False and s["foreign_sqlite_tainted"] is True
+
+    # A reopen recovers the WAL/shm cleanly and starts untainted.
+    db.close()
+    again = YantrikDB.with_default(path)
+    try:
+        assert again.stats()["foreign_sqlite_tainted"] is False
+        assert again.record("Writes resume after a reopen.")
+        assert again.recall(query="Alice Moreau", top_k=3, skip_reinforce=True)
+    finally:
+        again.close()
+    store_db = YantrikDB.with_default(path)  # the fixture closes this one
+    store_db.close()
+
+
+@linux_only
+def test_warn_counts_but_keeps_writing(store):
+    db, path = store
+    db.set_foreign_sqlite_mode("warn")
+    db.record("seed")
+    db.think()
+    foreign = sqlite3.connect(path)
+    try:
+        foreign.execute("SELECT COUNT(*) FROM memories").fetchone()  # maps the -shm
+        assert db.foreign_sqlite_detected() is True
+        assert db.record("warn mode keeps writing")  # counted, not refused
+        s = db.stats()
+        assert s["foreign_sqlite_detected_since_boot"] >= 1
+        assert s["foreign_sqlite_refused_since_boot"] == 0
+    finally:
+        foreign.close()
+
+
+@linux_only
+def test_a_separate_process_is_not_a_foreign_instance(store):
+    db, path = store
+    db.record("Separate processes are serialised by the kernel.")
+    db.think()
+    code = textwrap.dedent(
+        f"""
+        import sqlite3
+        c = sqlite3.connect({path!r})
+        print(c.execute("SELECT COUNT(*) FROM memories").fetchone()[0])
+        c.close()
+        """
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=60)
+    assert out.returncode == 0, out.stderr
+    assert int(out.stdout.strip()) >= 1
+    assert db.foreign_sqlite_detected() is False
+    assert db.record("still writing")


### PR DESCRIPTION
Closes #225.

**Why.** The engine bundles its own SQLite. A second SQLite library in the same process (Python's stdlib `sqlite3`, a system `libsqlite3`) opening the same store corrupts it silently: both rely on POSIX advisory locks, the kernel scopes those per process, so the foreign library's unlock releases the engine's locks and the two writers interleave WAL commits. Seen on our CI on 2026-09-06, reported from the field on 2026-09-07 after a day of blaming hooks and concurrency. Rule 9 in CONCURRENCY.md was the only place that said so.

**What the engine does now.**
- **Detector (Linux).** Every SQLite instance maps the store's `-shm` file region by region; one library shares one shm node across its connections. The same `<store>-shm` path mapped twice at the same offset in `/proc/self/maps` means a second library has the store open in this process. Scanned at open and from the writer connection's commit hook (cached 200 ms). Windows locks are per handle and is not affected (`foreign_sqlite_supported = false`).
- **Modes**, durable in `meta.foreign_sqlite_mode`, **`refuse` on every install**: `off` never scans; `warn` logs the transition and counts; `refuse` makes every engine write fail with the typed `ForeignSqliteInstance` (pre-check at `record*`, `correct`, `forget`, `relate`, `ingest_claim*`) and the commit hook aborts anything that slipped past, the materializer's commits included. Reads continue.
- **macOS** reads the same rule through libproc region enumeration (`proc_pidinfo(PROC_PIDREGIONPATHINFO)`, one call per region, rescanned every second); a walk that stops advancing ends the scan, so a misbehaving call can only under-report. Verified by the macos-14 CI job running the detector tests.
- **Cross-process half (all platforms).** `PRAGMA data_version` on the writer connection changes only when another connection commits, and every engine write goes through that connection, so a change is exactly "someone else committed". Each is counted (`stats().foreign_commits_detected_since_boot`) and queues one `PRAGMA quick_check`, run off the writer by the materializer or by `integrity_check()` on demand; a failed check taints the store the same way.
- **A detection latches until the engine is reopened.** Measured on WSL while building this: when the foreign connection closed, its library believed itself the last user and unlinked the `-shm` and WAL under the engine. "Resume when it closes" would therefore be unsafe; the store is tainted for this engine instance (`stats().foreign_sqlite_tainted`), and a reopen recovers cleanly.
- `stats()`: `foreign_sqlite_mode`, `_supported`, `_active`, `_tainted`, `_detected_since_boot`, `_refused_since_boot`. Python: `foreign_sqlite_mode()`, `set_foreign_sqlite_mode()`, `foreign_sqlite_detected()`, exception `yantrikdb.ForeignSqliteInstance`.
- Docs: README callout at the Python surface, CONCURRENCY.md Rule 9 addendum. `rusqlite` gains the `hooks` feature. No schema change (a meta key).

**Verified.**
- Rust: the maps parser on one library (three regions, a deleted mapping, another file), on a second library, and on paths with spaces; the mode rule; a `:memory:` store never scanned; the commit-hook abort pinned to `SQLITE_CONSTRAINT_COMMITHOOK` = 531 (the docs' table is easy to misread).
- Linux (WSL, manylinux wheel, stdlib SQLite 3.45 vs bundled 3.50): with a stdlib connection holding a read transaction, `foreign_sqlite_detected()` flips, `record` and `correct` raise `ForeignSqliteInstance` (with the store path), reads keep working, the counters tick; after the foreign close the engine's shm mapping shows `(deleted)` and the WAL and shm files are gone, writes stay refused, and a reopen writes again; `warn` counts and keeps writing; a separate process is not flagged.
- Core suite green on Windows (2169 + guard tests), slim build green, Python suites on the Linux wheel green.

**Consumer follow-up done:** yantrikos/yantrikdb-mcp#42 moves the MCP server's store probe into a child process so it never touches the store with `sqlite3` in-process.

**Not done here:** an in-engine SQL surface so nobody needs a second library — an API decision, follow-up in #225's thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
