### PR TITLE
release: v0.22.0

### DIFF
--- a/crates/yantrikdb-core/Cargo.toml
+++ b/crates/yantrikdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb"
-version = "0.21.2"
+version = "0.22.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Cognitive memory engine for persistent AI systems"

--- a/crates/yantrikdb-python/Cargo.toml
+++ b/crates/yantrikdb-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yantrikdb-python"
-version = "0.21.2"
+version = "0.22.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Python bindings for YantrikDB cognitive memory engine"

--- a/crates/yantrikdb-python/pyproject.toml
+++ b/crates/yantrikdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.21.2"
+version = "0.22.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "../../README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "yantrikdb"
-version = "0.21.2"
+version = "0.22.0"
 description = "A Cognitive Memory Engine for Persistent AI Systems"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.22.0 — claims earn their authority, and the store refuses a second SQLite library

Schema v52 → v54 (`claims.grounding`, `extraction_refusals`). Migration is automatic on open; both heals are idempotent and safe to re-run. Default behaviour of recall is unchanged (the gate opens in `shadow`). One behaviour change on purpose: on Linux, an engine write now fails while a second SQLite library holds the store open in the same process (#225), because the alternative was silent corruption.

**Why.** After 0.21.2 the production store minted `PyPI -works_at-> Google` and `PyPI -runs-> CT128`: the relation pass took "the nearest capitalized entity before the verb" as the subject, unbounded, and the claims lane then surfaced both with confident path provenance. This release contains the damage first and fixes the cause second, with instruments that show whether it worked.

### The store refuses a second SQLite library in the same process (#225)
The engine bundles its own SQLite. Opening the same store with the stdlib `sqlite3` module (or a system libsqlite3) from the same process corrupted it silently: POSIX locks are per process, so that connection's unlock released the engine's and two writers interleaved WAL commits. Seen on our CI on 2026-09-06, reported from the field on 2026-09-07 after a day of blaming hooks.
- On Linux the engine detects the second instance (`<store>-shm` mapped twice at the same offset in `/proc/self/maps`) at open and from the writer connection's commit hook.
- `foreign_sqlite_mode` `off | warn | refuse`, durable, **`refuse` on every install**: writes fail with `ForeignSqliteInstance` while the condition holds and the commit hook aborts anything that slipped past, the materializer's commits included; reads continue; writes resume once the foreign connection closes. `warn` counts and keeps writing. `stats()["foreign_sqlite_*"]` shows mode, support, active state and counters. Python: `foreign_sqlite_mode()`, `set_foreign_sqlite_mode()`, `foreign_sqlite_detected()`.
- macOS reads the same rule through libproc region enumeration; Windows locks are per handle and is not affected (`foreign_sqlite_supported = false`).
- On every platform, a commit that did not come through the engine (another engine process, the `sqlite3` CLI, a backup tool) is counted (`stats()["foreign_commits_detected_since_boot"]`) and queues one `PRAGMA quick_check`, run off the writer; a failed check taints the store the same way. `integrity_check()` runs it on demand.
- The entity chunker no longer welds a sentence opener onto the name after it (`Tonight CT128`), #227.
- Use the engine API (`correct()`, `ingest_claim()`, `attach_claims()`, `think()`) or a separate process for raw SQL; sequential use after `close()` is fine. CONCURRENCY.md Rule 9.

### Claim-chain eligibility gate (#223)
- `claims.grounding`: a versioned grounding status. `0` = the binding was never validated (every extractor row written before this release); `1` = cooperative, the writer stated it and the engine grounded both endpoints in the text (`attach_claims`); `2` = the extractor bound both arguments inside one segment and recorded the evidence span.
- `claim_chain_gate_mode` `off | shadow | enforce`, durable, **shadow on every install**: the lane admits exactly what it admitted before and counts what `enforce` would refuse into `stats()["claim_chain_gate_suppressed_since_boot"]`, keyed `hop1:` / `seed:` / `hop2:` `<reason>`. Under `enforce` every edge of a path must be eligible: grounded, valid as of the query time, and (to be chained through) positive and asserted. Python: `claim_chain_gate_mode()`, `set_claim_chain_gate_mode()`.
- The lane admits a value object as a claim's object when the relation admits values, so `CT128 -runs-> 0.21.2` finally surfaces.

### Occurrence-local relation binding (#224)
- Text is cut into segments (sentence ends, newlines, semicolons, arrows, label colons); every entity occurrence is a mention with a byte span; each trigger binds the first mention after it and the last mention before it, with only closed-class wrappers allowed between (`which`, `who`, an auxiliary, `now`). A comma right before the trigger closes an appositive; `and` shares a subject only through the previous binding's object. Anything else is a **refusal with a reason**. The extractor never walks back for a convenient name, and a name introduced in a heading now binds where the assertion actually is.
- `extraction_refusals` (v54): the ledger of triggers that did not bind, with reason and the tokens that broke it, rewritten per memory. `extraction_refusal_counts()` and `extraction_refusals()` in Rust and Python. This is how the next rule gets chosen.
- Bound claims carry `grounding = 2`, `extractor_version = "2.0"` and `span_start/span_end`. `reextract_claims()` rewrites a store's extractor claims with the new binding and fills the ledger.
- `extraction_silver_recall()`: every cooperative claim is a labelled example; hide the label, re-run the extractor over its memory, count recovered / missed-by-reason / unsupported relation. Judge-free, and it moves when a precision change costs recall.
- Learned templates go through the same binder; the chunker admits a quoted name (`'Sarah`).

### Measured
- Both production incidents reproduced verbatim as tests: the quoted subject binds, PyPI never does; `core runs CT128` is refused as `lowercase_subject` with its tokens.
- Prefix invariance: prepending unrelated text, a label, an arrow chain or a Unicode prelude never changes a triple.
- Core 2169 tests, Python 105 on the wheel, migration rehearsed from a v51 store through v54 with integrity ok; co-iteration gate on the hermes plugin corpus (see the release PR).

### Upgrade notes
- Run `reextract_claims()` once after upgrading a store with extractor claims: legacy rows keep `grounding = 0` until then and would be refused under `enforce`.
- Read `stats()["claim_chain_gate_suppressed_since_boot"]` under `shadow` before opting into `enforce`.
