### PR TITLE
recall: carry event_time_min/max on recall results (#181)

### DIFF
--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -205,6 +205,26 @@ pub struct RecallResult {
     /// rows. See [`PackProvenance`].
     #[serde(default)]
     pub pack: Option<PackProvenance>,
+    /// v48 (#149) valid time: when the described events happened, as
+    /// stamped on the record — distinct from `created_at`, which is
+    /// transaction time (when the row was written). `None` when the
+    /// record carries no event time, which is also what a record
+    /// excluded by an `event_after`/`event_before` filter would have
+    /// had; a caller who filtered by time can read these to see WHY a
+    /// row was eligible, or to lay the results out on a timeline.
+    ///
+    /// Sourced from the record's metadata JSON during hydration rather
+    /// than the mirrored `memories.event_time_min`/`event_time_max`
+    /// columns: the two agree by construction on a plain store (every
+    /// writer stamps the columns FROM this JSON via
+    /// [`crate::base::datetext::event_time_bounds`], and the census
+    /// invariant enforces it), but on an ENCRYPTED store the columns
+    /// are NULL by design — metadata is ciphertext at rest — while the
+    /// hydrated JSON is plaintext and still carries the values.
+    #[serde(default)]
+    pub event_time_min: Option<f64>,
+    #[serde(default)]
+    pub event_time_max: Option<f64>,
 }
 
 /// v0.13.1 explain surface — per-lane status with the never-ran /

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -205,30 +205,16 @@ pub struct RecallResult {
     /// rows. See [`PackProvenance`].
     #[serde(default)]
     pub pack: Option<PackProvenance>,
-    /// v48 (#149) valid time: when the described events happened, as
-    /// opposed to `created_at`, which is transaction time (when the row
-    /// was written). `None` when the record carries no event time. A
-    /// caller who filtered with `event_after`/`event_before` reads these
-    /// to see WHY a row was eligible, or to lay the results out on a
-    /// timeline.
+    /// v48 (#149) valid time — when the described events happened, as
+    /// opposed to `created_at` (when the row was written). `None` when
+    /// the record carries no event time.
     ///
-    /// Host rows carry the `memories.event_time_min`/`event_time_max`
-    /// columns verbatim — the same values the recall prefilter
-    /// range-scans, so a row's reported bounds and its eligibility never
-    /// disagree. That matters on rows whose columns are still NULL while
-    /// their metadata JSON is not (a pre-v48 row not yet rewritten, a
-    /// follower apply that carried a ciphertext payload): the filter
-    /// excludes those, so re-extracting bounds from their JSON would
-    /// claim an eligibility they do not have.
-    ///
-    /// Three paths have no column to read and fall back to
-    /// [`crate::base::datetext::event_time_bounds`] over the plaintext
-    /// metadata, none of them subject to that filter: mounted pack rows
-    /// (a pack sealed before v48 has no such column and can never be
-    /// migrated), link-surfaced neighbors (built from a `Memory`), and
-    /// `recall_as_of` rollback (the restored revision's own JSON is the
-    /// only record of what the bounds were at that point in time — the
-    /// columns describe the live row).
+    /// Host rows carry the `memories` columns verbatim: those are what
+    /// `event_after`/`event_before` range-scans, so a row's reported
+    /// bounds can never claim an eligibility the filter denies. Pack
+    /// rows, link-surfaced neighbors and `recall_as_of` rollback have no
+    /// column to read and derive from metadata instead; none are subject
+    /// to that filter.
     #[serde(default)]
     pub event_time_min: Option<f64>,
     #[serde(default)]

--- a/crates/yantrikdb-core/src/base/types.rs
+++ b/crates/yantrikdb-core/src/base/types.rs
@@ -206,21 +206,29 @@ pub struct RecallResult {
     #[serde(default)]
     pub pack: Option<PackProvenance>,
     /// v48 (#149) valid time: when the described events happened, as
-    /// stamped on the record — distinct from `created_at`, which is
-    /// transaction time (when the row was written). `None` when the
-    /// record carries no event time, which is also what a record
-    /// excluded by an `event_after`/`event_before` filter would have
-    /// had; a caller who filtered by time can read these to see WHY a
-    /// row was eligible, or to lay the results out on a timeline.
+    /// opposed to `created_at`, which is transaction time (when the row
+    /// was written). `None` when the record carries no event time. A
+    /// caller who filtered with `event_after`/`event_before` reads these
+    /// to see WHY a row was eligible, or to lay the results out on a
+    /// timeline.
     ///
-    /// Sourced from the record's metadata JSON during hydration rather
-    /// than the mirrored `memories.event_time_min`/`event_time_max`
-    /// columns: the two agree by construction on a plain store (every
-    /// writer stamps the columns FROM this JSON via
-    /// [`crate::base::datetext::event_time_bounds`], and the census
-    /// invariant enforces it), but on an ENCRYPTED store the columns
-    /// are NULL by design — metadata is ciphertext at rest — while the
-    /// hydrated JSON is plaintext and still carries the values.
+    /// Host rows carry the `memories.event_time_min`/`event_time_max`
+    /// columns verbatim — the same values the recall prefilter
+    /// range-scans, so a row's reported bounds and its eligibility never
+    /// disagree. That matters on rows whose columns are still NULL while
+    /// their metadata JSON is not (a pre-v48 row not yet rewritten, a
+    /// follower apply that carried a ciphertext payload): the filter
+    /// excludes those, so re-extracting bounds from their JSON would
+    /// claim an eligibility they do not have.
+    ///
+    /// Three paths have no column to read and fall back to
+    /// [`crate::base::datetext::event_time_bounds`] over the plaintext
+    /// metadata, none of them subject to that filter: mounted pack rows
+    /// (a pack sealed before v48 has no such column and can never be
+    /// migrated), link-surfaced neighbors (built from a `Memory`), and
+    /// `recall_as_of` rollback (the restored revision's own JSON is the
+    /// only record of what the bounds were at that point in time — the
+    /// columns describe the live row).
     #[serde(default)]
     pub event_time_min: Option<f64>,
     #[serde(default)]

--- a/crates/yantrikdb-core/src/engine/bitemporal.rs
+++ b/crates/yantrikdb-core/src/engine/bitemporal.rs
@@ -183,6 +183,17 @@ impl YantrikDB {
                 serde_json::from_str(&metadata_plain).unwrap_or(serde_json::Value::Null);
             result.importance = importance;
             result.valence = valence;
+            // #181: re-derive valid time from the metadata just restored.
+            // Recall stamped these from the memories row, which holds the
+            // CURRENT (post-correction) bounds — and correct() re-derives
+            // event time from the new text, so leaving them would pair
+            // yesterday's metadata with today's bounds. The revision's own
+            // JSON is the only record of what the bounds were as of this
+            // point in time; the indexed columns describe the live row.
+            let (event_time_min, event_time_max) =
+                crate::base::datetext::event_time_bounds(&result.metadata);
+            result.event_time_min = event_time_min;
+            result.event_time_max = event_time_max;
             result
                 .why_retrieved
                 .push("as_of: rolled back to pre-correction state".to_string());

--- a/crates/yantrikdb-core/src/engine/bitemporal.rs
+++ b/crates/yantrikdb-core/src/engine/bitemporal.rs
@@ -183,13 +183,10 @@ impl YantrikDB {
                 serde_json::from_str(&metadata_plain).unwrap_or(serde_json::Value::Null);
             result.importance = importance;
             result.valence = valence;
-            // #181: re-derive valid time from the metadata just restored.
-            // Recall stamped these from the memories row, which holds the
-            // CURRENT (post-correction) bounds — and correct() re-derives
-            // event time from the new text, so leaving them would pair
-            // yesterday's metadata with today's bounds. The revision's own
-            // JSON is the only record of what the bounds were as of this
-            // point in time; the indexed columns describe the live row.
+            // #181: recall stamped the bounds from the live row, and
+            // correct() re-derives event time — so without this the result
+            // pairs yesterday's metadata with today's dates. The revision's
+            // own JSON is the only record of the bounds as of `as_of`.
             let (event_time_min, event_time_max) =
                 crate::base::datetext::event_time_bounds(&result.metadata);
             result.event_time_min = event_time_min;

--- a/crates/yantrikdb-core/src/engine/claims_lane.rs
+++ b/crates/yantrikdb-core/src/engine/claims_lane.rs
@@ -743,6 +743,8 @@ impl super::YantrikDB {
                 aged_last_verified: None,
                 best_span: None,
                 pack: None,
+                event_time_min: None,
+                event_time_max: None,
             });
         }
         Ok(())

--- a/crates/yantrikdb-core/src/engine/lexical.rs
+++ b/crates/yantrikdb-core/src/engine/lexical.rs
@@ -255,6 +255,8 @@ mod tests {
             aged_last_verified: None,
             best_span: None,
             pack: None,
+            event_time_min: None,
+            event_time_max: None,
         }
     }
 

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -982,13 +982,9 @@ impl YantrikDB {
                 let nscore = seed_score * pol.neighbor_factor / 4.0;
                 present.insert(l.rid.clone());
                 budget -= 1;
-                // #181: surfaced neighbors are built whole from `mem` and
-                // never reach recall's Step 5 hydration, so the valid-time
-                // pair is read here, before the literal moves
-                // `mem.metadata`. `Memory` carries the decrypted JSON but
-                // not the indexed columns, and link expansion exists to
-                // cross the relevance filters rather than answer to them,
-                // so there is no filter eligibility to stay aligned with.
+                // #181: neighbors never reach Step 5 hydration, and `Memory`
+                // carries the JSON but not the columns — so read the pair
+                // here, before the literal moves `mem.metadata`.
                 let (event_time_min, event_time_max) =
                     crate::base::datetext::event_time_bounds(&mem.metadata);
                 added.push(RecallResult {

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -982,9 +982,13 @@ impl YantrikDB {
                 let nscore = seed_score * pol.neighbor_factor / 4.0;
                 present.insert(l.rid.clone());
                 budget -= 1;
-                // Surfaced neighbors are built whole from `mem` and never
-                // reach recall's Step 5 hydration, so the valid-time pair
-                // is read here, before the literal moves `mem.metadata`.
+                // #181: surfaced neighbors are built whole from `mem` and
+                // never reach recall's Step 5 hydration, so the valid-time
+                // pair is read here, before the literal moves
+                // `mem.metadata`. `Memory` carries the decrypted JSON but
+                // not the indexed columns, and link expansion exists to
+                // cross the relevance filters rather than answer to them,
+                // so there is no filter eligibility to stay aligned with.
                 let (event_time_min, event_time_max) =
                     crate::base::datetext::event_time_bounds(&mem.metadata);
                 added.push(RecallResult {

--- a/crates/yantrikdb-core/src/engine/links.rs
+++ b/crates/yantrikdb-core/src/engine/links.rs
@@ -982,6 +982,11 @@ impl YantrikDB {
                 let nscore = seed_score * pol.neighbor_factor / 4.0;
                 present.insert(l.rid.clone());
                 budget -= 1;
+                // Surfaced neighbors are built whole from `mem` and never
+                // reach recall's Step 5 hydration, so the valid-time pair
+                // is read here, before the literal moves `mem.metadata`.
+                let (event_time_min, event_time_max) =
+                    crate::base::datetext::event_time_bounds(&mem.metadata);
                 added.push(RecallResult {
                     rid: mem.rid,
                     memory_type: mem.memory_type,
@@ -1018,6 +1023,8 @@ impl YantrikDB {
                     aged_last_verified: None,
                     best_span: None,
                     pack: None,
+                    event_time_min,
+                    event_time_max,
                 });
             }
         }

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -433,6 +433,16 @@ pub(crate) struct TextMetadataRow {
     pub rid: String,
     pub text: String,
     pub metadata: String,
+    /// v48 (#149) valid time, read from the indexed columns rather than
+    /// re-extracted from `metadata`. The columns are what the
+    /// `event_after`/`event_before` prefilter range-scans, so reporting
+    /// them keeps a result's stated bounds and its filter eligibility
+    /// answerable from one source. Safe to select unconditionally: this
+    /// query only ever runs against the host database, which is always
+    /// migrated before recall (mounted packs, which can predate a column
+    /// and can never be migrated, go through `fetch_pack_text_metadata`).
+    pub event_time_min: Option<f64>,
+    pub event_time_max: Option<f64>,
 }
 
 /// Embedder a NEW store created via [`YantrikDB::with_default`] uses.

--- a/crates/yantrikdb-core/src/engine/mod.rs
+++ b/crates/yantrikdb-core/src/engine/mod.rs
@@ -433,14 +433,11 @@ pub(crate) struct TextMetadataRow {
     pub rid: String,
     pub text: String,
     pub metadata: String,
-    /// v48 (#149) valid time, read from the indexed columns rather than
-    /// re-extracted from `metadata`. The columns are what the
-    /// `event_after`/`event_before` prefilter range-scans, so reporting
-    /// them keeps a result's stated bounds and its filter eligibility
-    /// answerable from one source. Safe to select unconditionally: this
-    /// query only ever runs against the host database, which is always
-    /// migrated before recall (mounted packs, which can predate a column
-    /// and can never be migrated, go through `fetch_pack_text_metadata`).
+    /// v48 (#149) valid time, from the columns the recall prefilter
+    /// range-scans rather than re-extracted from `metadata`. Selected
+    /// unconditionally because this query only runs against the host
+    /// database, which is always migrated; packs, which can predate the
+    /// column, go through `fetch_pack_text_metadata`.
     pub event_time_min: Option<f64>,
     pub event_time_max: Option<f64>,
 }

--- a/crates/yantrikdb-core/src/engine/pack.rs
+++ b/crates/yantrikdb-core/src/engine/pack.rs
@@ -1821,6 +1821,10 @@ impl YantrikDB {
                             aged_last_verified: None,
                             best_span: None,
                             pack: Some(provenance.clone()),
+                            // Stamped from the pack's metadata JSON in the
+                            // eager hydration loop below.
+                            event_time_min: None,
+                            event_time_max: None,
                         },
                     ));
                 }
@@ -1840,6 +1844,10 @@ impl YantrikDB {
                     result.text = text.clone();
                     result.metadata = serde_json::from_str(meta)
                         .unwrap_or(serde_json::Value::Object(Default::default()));
+                    let (event_time_min, event_time_max) =
+                        crate::base::datetext::event_time_bounds(&result.metadata);
+                    result.event_time_min = event_time_min;
+                    result.event_time_max = event_time_max;
                 }
                 out.push((mount_idx, result));
             }

--- a/crates/yantrikdb-core/src/engine/pack.rs
+++ b/crates/yantrikdb-core/src/engine/pack.rs
@@ -1844,6 +1844,16 @@ impl YantrikDB {
                     result.text = text.clone();
                     result.metadata = serde_json::from_str(meta)
                         .unwrap_or(serde_json::Value::Object(Default::default()));
+                    // #181: pack rows read valid time from the metadata
+                    // JSON, where host rows read the indexed columns. A
+                    // pack carries whatever schema its publisher sealed
+                    // and can never be migrated, so anything published
+                    // before v48 has no such column to select — the same
+                    // trap the v41→v42 synthesis triplet hit. Nothing is
+                    // lost: pack metadata is plaintext (so the JSON is
+                    // exactly what the columns would mirror), and pack
+                    // recall applies no event-time filter, so there is no
+                    // filter source of truth to stay consistent with.
                     let (event_time_min, event_time_max) =
                         crate::base::datetext::event_time_bounds(&result.metadata);
                     result.event_time_min = event_time_min;

--- a/crates/yantrikdb-core/src/engine/pack.rs
+++ b/crates/yantrikdb-core/src/engine/pack.rs
@@ -1821,8 +1821,7 @@ impl YantrikDB {
                             aged_last_verified: None,
                             best_span: None,
                             pack: Some(provenance.clone()),
-                            // Stamped from the pack's metadata JSON in the
-                            // eager hydration loop below.
+                            // Stamped in the hydration loop below.
                             event_time_min: None,
                             event_time_max: None,
                         },
@@ -1844,16 +1843,11 @@ impl YantrikDB {
                     result.text = text.clone();
                     result.metadata = serde_json::from_str(meta)
                         .unwrap_or(serde_json::Value::Object(Default::default()));
-                    // #181: pack rows read valid time from the metadata
-                    // JSON, where host rows read the indexed columns. A
-                    // pack carries whatever schema its publisher sealed
-                    // and can never be migrated, so anything published
-                    // before v48 has no such column to select — the same
-                    // trap the v41→v42 synthesis triplet hit. Nothing is
-                    // lost: pack metadata is plaintext (so the JSON is
-                    // exactly what the columns would mirror), and pack
-                    // recall applies no event-time filter, so there is no
-                    // filter source of truth to stay consistent with.
+                    // #181: JSON here, columns on the host path. A pack
+                    // sealed before v48 has no such column and can never be
+                    // migrated (the v41→v42 synthesis trap). Nothing is
+                    // lost — pack metadata is plaintext, and pack recall
+                    // applies no event-time filter to stay aligned with.
                     let (event_time_min, event_time_max) =
                         crate::base::datetext::event_time_bounds(&result.metadata);
                     result.event_time_min = event_time_min;

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -3632,15 +3632,11 @@ impl YantrikDB {
                 result.text = tm.text.clone();
                 result.metadata = serde_json::from_str(&tm.metadata)
                     .unwrap_or(serde_json::Value::Object(Default::default()));
-                // #181: valid time, from the SAME indexed columns the
-                // event_after/event_before prefilter range-scans — so a
-                // row's reported bounds and the reason it was (or wasn't)
-                // eligible are answerable from one source. Reading the
-                // metadata JSON instead would diverge on rows whose
-                // columns are still NULL (pre-v48 rows not yet rewritten,
-                // ciphertext-payload follower applies): the filter
-                // excludes those, so reporting bounds for them would
-                // describe an eligibility they do not have.
+                // #181: the columns, not a re-extraction from the JSON.
+                // They diverge on rows the prefilter excludes (columns
+                // still NULL, JSON populated — pre-v48 rows, ciphertext
+                // follower applies), where the JSON would report an
+                // eligibility the filter denies.
                 result.event_time_min = tm.event_time_min;
                 result.event_time_max = tm.event_time_max;
             }
@@ -6250,8 +6246,7 @@ impl YantrikDB {
                     result.text = tm.text.clone();
                     result.metadata = serde_json::from_str(&tm.metadata)
                         .unwrap_or(serde_json::Value::Object(Default::default()));
-                    // #181 — mirrors recall() Step 5: the filter's own
-                    // columns, not a re-extraction from the JSON.
+                    // #181 — mirrors recall() Step 5.
                     result.event_time_min = tm.event_time_min;
                     result.event_time_max = tm.event_time_max;
                 }

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -3632,15 +3632,17 @@ impl YantrikDB {
                 result.text = tm.text.clone();
                 result.metadata = serde_json::from_str(&tm.metadata)
                     .unwrap_or(serde_json::Value::Object(Default::default()));
-                // #181: valid time, read off the metadata we just decrypted
-                // rather than the mirrored v48 columns — same values on a
-                // plain store (every writer stamps the columns FROM this
-                // JSON), but the columns are NULL on an encrypted store
-                // where this JSON still carries them. No extra query.
-                let (event_time_min, event_time_max) =
-                    crate::base::datetext::event_time_bounds(&result.metadata);
-                result.event_time_min = event_time_min;
-                result.event_time_max = event_time_max;
+                // #181: valid time, from the SAME indexed columns the
+                // event_after/event_before prefilter range-scans — so a
+                // row's reported bounds and the reason it was (or wasn't)
+                // eligible are answerable from one source. Reading the
+                // metadata JSON instead would diverge on rows whose
+                // columns are still NULL (pre-v48 rows not yet rewritten,
+                // ciphertext-payload follower applies): the filter
+                // excludes those, so reporting bounds for them would
+                // describe an eligibility they do not have.
+                result.event_time_min = tm.event_time_min;
+                result.event_time_max = tm.event_time_max;
             }
         }
 
@@ -6248,11 +6250,10 @@ impl YantrikDB {
                     result.text = tm.text.clone();
                     result.metadata = serde_json::from_str(&tm.metadata)
                         .unwrap_or(serde_json::Value::Object(Default::default()));
-                    // #181 — mirrors recall() Step 5.
-                    let (event_time_min, event_time_max) =
-                        crate::base::datetext::event_time_bounds(&result.metadata);
-                    result.event_time_min = event_time_min;
-                    result.event_time_max = event_time_max;
+                    // #181 — mirrors recall() Step 5: the filter's own
+                    // columns, not a re-extraction from the JSON.
+                    result.event_time_min = tm.event_time_min;
+                    result.event_time_max = tm.event_time_max;
                 }
             }
             // Snippet spans (mirrors recall() Step 5.5).
@@ -6358,8 +6359,10 @@ impl YantrikDB {
             .map(|i| format!("?{}", i + 1))
             .collect::<Vec<_>>()
             .join(",");
-        let sql =
-            format!("SELECT rid, type, text, metadata FROM memories WHERE rid IN ({placeholders})");
+        let sql = format!(
+            "SELECT rid, type, text, metadata, event_time_min, event_time_max \
+             FROM memories WHERE rid IN ({placeholders})"
+        );
         let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
         for r in rids {
             param_values.push(Box::new(r.to_string()));
@@ -6375,6 +6378,8 @@ impl YantrikDB {
                     row.get::<_, String>("rid")?,
                     row.get::<_, String>("text")?,
                     row.get::<_, String>("metadata")?,
+                    row.get::<_, Option<f64>>("event_time_min")?,
+                    row.get::<_, Option<f64>>("event_time_max")?,
                 ))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -6382,7 +6387,7 @@ impl YantrikDB {
         drop(conn);
 
         let mut map = HashMap::new();
-        for (rid, stored_text, stored_meta) in rows {
+        for (rid, stored_text, stored_meta, event_time_min, event_time_max) in rows {
             let text = self.decrypt_text(&stored_text)?;
             let metadata = self.decrypt_text(&stored_meta)?;
             map.insert(
@@ -6391,6 +6396,8 @@ impl YantrikDB {
                     rid,
                     text,
                     metadata,
+                    event_time_min,
+                    event_time_max,
                 },
             );
         }

--- a/crates/yantrikdb-core/src/engine/recall.rs
+++ b/crates/yantrikdb-core/src/engine/recall.rs
@@ -1374,6 +1374,8 @@ impl YantrikDB {
                     aged_last_verified: None,
                     best_span: None,
                     pack: None,
+                    event_time_min: None,
+                    event_time_max: None,
                 });
             }
         } // drop cache borrow
@@ -1492,6 +1494,8 @@ impl YantrikDB {
                         aged_last_verified: None,
                         best_span: None,
                         pack: None,
+                        event_time_min: None,
+                        event_time_max: None,
                     });
                 }
             }
@@ -1625,6 +1629,8 @@ impl YantrikDB {
                         aged_last_verified: None,
                         best_span: None,
                         pack: None,
+                        event_time_min: None,
+                        event_time_max: None,
                     });
                 }
             }
@@ -2266,6 +2272,8 @@ impl YantrikDB {
                                     aged_last_verified: None,
                                     best_span: None,
                                     pack: None,
+                                    event_time_min: None,
+                                    event_time_max: None,
                                 });
                             }
                         }
@@ -2440,6 +2448,8 @@ impl YantrikDB {
                         aged_last_verified: None,
                         best_span: None,
                         pack: None,
+                        event_time_min: None,
+                        event_time_max: None,
                     });
                 }
             }
@@ -2700,6 +2710,8 @@ impl YantrikDB {
                                     aged_last_verified: None,
                                     best_span: None,
                                     pack: None,
+                                    event_time_min: None,
+                                    event_time_max: None,
                                 });
                             }
                         }
@@ -3038,6 +3050,8 @@ impl YantrikDB {
                             aged_last_verified: None,
                             best_span: None,
                             pack: None,
+                            event_time_min: None,
+                            event_time_max: None,
                         });
                     }
                     drop(cache);
@@ -3618,6 +3632,15 @@ impl YantrikDB {
                 result.text = tm.text.clone();
                 result.metadata = serde_json::from_str(&tm.metadata)
                     .unwrap_or(serde_json::Value::Object(Default::default()));
+                // #181: valid time, read off the metadata we just decrypted
+                // rather than the mirrored v48 columns — same values on a
+                // plain store (every writer stamps the columns FROM this
+                // JSON), but the columns are NULL on an encrypted store
+                // where this JSON still carries them. No extra query.
+                let (event_time_min, event_time_max) =
+                    crate::base::datetext::event_time_bounds(&result.metadata);
+                result.event_time_min = event_time_min;
+                result.event_time_max = event_time_max;
             }
         }
 
@@ -4624,6 +4647,8 @@ impl YantrikDB {
                     aged_last_verified: None,
                     best_span: None,
                     pack: None,
+                    event_time_min: None,
+                    event_time_max: None,
                 });
             }
         }
@@ -4735,6 +4760,8 @@ impl YantrikDB {
                         aged_last_verified: None,
                         best_span: None,
                         pack: None,
+                        event_time_min: None,
+                        event_time_max: None,
                     });
                 }
             }
@@ -5305,6 +5332,8 @@ impl YantrikDB {
                                     aged_last_verified: None,
                                     best_span: None,
                                     pack: None,
+                                    event_time_min: None,
+                                    event_time_max: None,
                                 });
                             }
                         }
@@ -5455,6 +5484,8 @@ impl YantrikDB {
                         aged_last_verified: None,
                         best_span: None,
                         pack: None,
+                        event_time_min: None,
+                        event_time_max: None,
                     });
                 }
             }
@@ -5676,6 +5707,8 @@ impl YantrikDB {
                                     aged_last_verified: None,
                                     best_span: None,
                                     pack: None,
+                                    event_time_min: None,
+                                    event_time_max: None,
                                 });
                             }
                         }
@@ -6001,6 +6034,8 @@ impl YantrikDB {
                                 aged_last_verified: None,
                                 best_span: None,
                                 pack: None,
+                                event_time_min: None,
+                                event_time_max: None,
                             });
                         }
                     }
@@ -6213,6 +6248,11 @@ impl YantrikDB {
                     result.text = tm.text.clone();
                     result.metadata = serde_json::from_str(&tm.metadata)
                         .unwrap_or(serde_json::Value::Object(Default::default()));
+                    // #181 — mirrors recall() Step 5.
+                    let (event_time_min, event_time_max) =
+                        crate::base::datetext::event_time_bounds(&result.metadata);
+                    result.event_time_min = event_time_min;
+                    result.event_time_max = event_time_max;
                 }
             }
             // Snippet spans (mirrors recall() Step 5.5).
@@ -6613,6 +6653,8 @@ mod novelty_selection_tests {
             aged_last_verified: None,
             best_span: None,
             pack: None,
+            event_time_min: None,
+            event_time_max: None,
         }
     }
 

--- a/crates/yantrikdb-core/src/engine/snippet.rs
+++ b/crates/yantrikdb-core/src/engine/snippet.rs
@@ -157,6 +157,8 @@ mod tests {
             aged_last_verified: None,
             best_span: None,
             pack: None,
+            event_time_min: None,
+            event_time_max: None,
         }
     }
 

--- a/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
+++ b/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
@@ -496,3 +496,121 @@ fn non_finite_bounds_are_invalid_scalars() {
         );
     }
 }
+
+// ── #181: the values ride out on the result ──────────────────────────
+//
+// Filtering by valid time was only half the surface: a caller who
+// filtered could not see WHY a row was eligible, nor lay the hits on a
+// timeline, because `RecallResult` dropped the values. These three
+// tests pin the read side.
+// =====================================================================
+
+/// The columns for one rid, as the census test reads them — the
+/// `event_time_columns.rs` shape, reused here to prove the hydrated
+/// values agree with the v48 columns rather than merely existing.
+fn columns_for(db: &YantrikDB, rid: &str) -> (Option<f64>, Option<f64>) {
+    db.conn()
+        .query_row(
+            "SELECT event_time_min, event_time_max FROM memories WHERE rid = ?1",
+            [rid],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap()
+}
+
+/// A date-bearing record carries the stamped values out through recall.
+#[test]
+fn recall_result_carries_the_stamped_event_time() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+    let rid = put(
+        &db,
+        "the migration ran that week",
+        &event_meta("2024-03-15", 1_710_460_800.0, 1_710_547_200.0),
+        &decoy_vec(0, 8),
+    );
+
+    let hits = recall_window(&db, &query, 5, None, None, None).unwrap();
+    let hit = hits
+        .iter()
+        .find(|r| r.rid == rid)
+        .expect("the date-bearing record must be recalled");
+
+    assert_eq!(
+        hit.event_time_min,
+        Some(1_710_460_800.0),
+        "event_time_min must reach the caller"
+    );
+    assert_eq!(
+        hit.event_time_max,
+        Some(1_710_547_200.0),
+        "event_time_max must reach the caller"
+    );
+
+    // The load-bearing half: hydrated values are sourced from the
+    // metadata JSON, so this asserts they agree with the mirrored v48
+    // columns — the invariant that makes that sourcing choice safe.
+    assert_eq!(
+        (hit.event_time_min, hit.event_time_max),
+        columns_for(&db, &rid),
+        "hydrated values must equal the v48 columns for the same row"
+    );
+}
+
+/// An undated record carries `None` — absence stays absence, never a
+/// zero or a `created_at` stand-in.
+#[test]
+fn recall_result_event_time_is_none_for_an_undated_record() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+    let rid = put(&db, "no date in this one", &empty_meta(), &decoy_vec(0, 8));
+
+    let hits = recall_window(&db, &query, 5, None, None, None).unwrap();
+    let hit = hits
+        .iter()
+        .find(|r| r.rid == rid)
+        .expect("the undated record must be recalled");
+
+    assert_eq!(hit.event_time_min, None, "undated ⇒ None, not 0.0");
+    assert_eq!(hit.event_time_max, None, "undated ⇒ None, not created_at");
+    assert_eq!(
+        (hit.event_time_min, hit.event_time_max),
+        columns_for(&db, &rid),
+        "both must be NULL in the columns too"
+    );
+}
+
+/// The point of the issue: a caller who FILTERED by valid time can read
+/// back the values that made each row eligible, for every row returned.
+#[test]
+fn filtered_recall_reports_the_bounds_that_made_each_row_eligible() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+    put(
+        &db,
+        "early event",
+        &event_meta("1970-01-01", 1_000.0, 1_000.0),
+        &decoy_vec(0, 8),
+    );
+    let late = put(
+        &db,
+        "late event",
+        &event_meta("1970-01-01", 3_000.0, 3_000.0),
+        &decoy_vec(1, 8),
+    );
+
+    let hits = recall_window(&db, &query, 10, None, Some(2_000.0), None).unwrap();
+    assert_eq!(
+        rid_set(&hits),
+        std::collections::HashSet::from([late]),
+        "only the late record overlaps [2000, ∞)"
+    );
+    let hit = &hits[0];
+    assert_eq!(hit.event_time_min, Some(3_000.0));
+    assert_eq!(hit.event_time_max, Some(3_000.0));
+    assert!(
+        hit.event_time_max.unwrap() >= 2_000.0,
+        "the reported bounds must themselves satisfy the filter that \
+         admitted the row — that is what makes them an explanation"
+    );
+}

--- a/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
+++ b/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
@@ -501,8 +501,15 @@ fn non_finite_bounds_are_invalid_scalars() {
 //
 // Filtering by valid time was only half the surface: a caller who
 // filtered could not see WHY a row was eligible, nor lay the hits on a
-// timeline, because `RecallResult` dropped the values. These three
-// tests pin the read side.
+// timeline, because `RecallResult` dropped the values.
+//
+// Host rows report the v48 COLUMNS — the same values the prefilter
+// range-scans — so that a row's stated bounds and its eligibility can
+// never contradict each other. The last test is the one that pins that
+// choice: it manufactures the divergence (columns NULL, JSON populated)
+// that a pre-v48 row or a ciphertext-payload follower apply leaves
+// behind, and asserts recall reports the column, because reporting the
+// JSON there would advertise an eligibility the filter denies.
 // =====================================================================
 
 /// The columns for one rid, as the census test reads them — the
@@ -612,5 +619,128 @@ fn filtered_recall_reports_the_bounds_that_made_each_row_eligible() {
         hit.event_time_max.unwrap() >= 2_000.0,
         "the reported bounds must themselves satisfy the filter that \
          admitted the row — that is what makes them an explanation"
+    );
+}
+
+/// THE PIN FOR THE SOURCING CHOICE. A row can carry event-time metadata
+/// while its columns are NULL — a pre-v48 row not yet rewritten, or a
+/// follower apply whose payload was ciphertext. The prefilter reads the
+/// COLUMNS, so such a row is excluded from every bounded recall. If
+/// hydration re-extracted the bounds from the JSON instead, an
+/// unfiltered recall would hand back bounds advertising an eligibility
+/// the filter denies — a result that contradicts the engine's own
+/// answer to "show me what happened then".
+#[test]
+fn null_columns_report_none_even_when_the_metadata_json_still_has_bounds() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+    let rid = put(
+        &db,
+        "legacy row written before v48",
+        &event_meta("1970-01-01", 5_000.0, 5_000.0),
+        &decoy_vec(0, 8),
+    );
+
+    // Manufacture the divergence: strip the columns, leave the JSON.
+    db.conn()
+        .execute(
+            "UPDATE memories SET event_time_min = NULL, event_time_max = NULL \
+             WHERE rid = ?1",
+            [&rid],
+        )
+        .unwrap();
+    let stored_meta: String = db
+        .conn()
+        .query_row(
+            "SELECT metadata FROM memories WHERE rid = ?1",
+            [&rid],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let meta: serde_json::Value = serde_json::from_str(&stored_meta).unwrap();
+    assert_eq!(
+        crate::base::datetext::event_time_bounds(&meta),
+        (Some(5_000.0), Some(5_000.0)),
+        "precondition: the JSON must still carry the bounds"
+    );
+
+    // The filter excludes it — this is the eligibility the report must
+    // not contradict.
+    let bounded = recall_window(&db, &query, 10, None, Some(4_000.0), None).unwrap();
+    assert!(
+        !rid_set(&bounded).contains(&rid),
+        "precondition: a NULL-column row is outside the eligible universe"
+    );
+
+    // So an unfiltered recall must report the column (None), not the JSON.
+    let hits = recall_window(&db, &query, 10, None, None, None).unwrap();
+    let hit = hits
+        .iter()
+        .find(|r| r.rid == rid)
+        .expect("unfiltered recall still returns the row");
+    assert_eq!(
+        (hit.event_time_min, hit.event_time_max),
+        (None, None),
+        "reported bounds must match the columns the filter reads, not the \
+         stale JSON — otherwise the result claims an eligibility it lacks"
+    );
+}
+
+/// `recall_as_of` rolls a corrected record back to its pre-correction
+/// text and metadata. The bounds must roll back WITH it: recall stamps
+/// them from the live row, and `correct()` re-derives event time, so a
+/// result left holding the current bounds would pair yesterday's
+/// metadata with today's dates — the row contradicting itself.
+#[test]
+fn as_of_rollback_moves_event_time_back_with_the_metadata() {
+    let db = YantrikDB::new(":memory:", 8).unwrap();
+    let query = axis0(8);
+    let rid = put(
+        &db,
+        "the deadline is in March",
+        &event_meta("2024-03-15", 1_710_460_800.0, 1_710_460_800.0),
+        &decoy_vec(0, 8),
+    );
+
+    let before_correction = crate::engine::now();
+    db.correct(
+        &rid,
+        None,
+        Some(&event_meta("2024-04-20", 1_713_571_200.0, 1_713_571_200.0)),
+        None,
+        None,
+        "deadline moved",
+    )
+    .unwrap();
+
+    // Live recall sees the corrected bounds.
+    let live = recall_window(&db, &query, 5, None, None, None).unwrap();
+    let live_hit = live.iter().find(|r| r.rid == rid).expect("row is live");
+    assert_eq!(
+        live_hit.event_time_min,
+        Some(1_713_571_200.0),
+        "precondition: the correction moved the bounds"
+    );
+
+    // As-of before the correction must report the ORIGINAL bounds.
+    let rolled = db
+        .recall_as_of(&query, 5, before_correction, None, None)
+        .unwrap();
+    let hit = rolled
+        .iter()
+        .find(|r| r.rid == rid)
+        .expect("the row existed before the correction");
+    assert_eq!(
+        hit.event_time_min,
+        Some(1_710_460_800.0),
+        "as_of bounds must roll back with the metadata, not stay live"
+    );
+    assert_eq!(
+        (
+            hit.metadata.get("event_time_min").and_then(|v| v.as_f64()),
+            hit.metadata.get("event_time_max").and_then(|v| v.as_f64()),
+        ),
+        (hit.event_time_min, hit.event_time_max),
+        "the typed fields and the restored metadata must tell one story"
     );
 }

--- a/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
+++ b/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
@@ -497,15 +497,6 @@ fn non_finite_bounds_are_invalid_scalars() {
     }
 }
 
-// ── #181: the values ride out on the result ──────────────────────────
-//
-// Filtering was only half the surface — a caller who filtered could not
-// see WHY a row was eligible. Host rows report the v48 COLUMNS, the same
-// values the prefilter range-scans, so stated bounds and eligibility can
-// never contradict each other. `null_columns_report_none_*` is the test
-// that pins that choice.
-// =====================================================================
-
 /// The `event_time_columns.rs` census shape, reused to prove the
 /// hydrated values match the columns rather than merely existing.
 fn columns_for(db: &YantrikDB, rid: &str) -> (Option<f64>, Option<f64>) {

--- a/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
+++ b/crates/yantrikdb-core/src/engine/tests/event_time_recall.rs
@@ -499,22 +499,15 @@ fn non_finite_bounds_are_invalid_scalars() {
 
 // ── #181: the values ride out on the result ──────────────────────────
 //
-// Filtering by valid time was only half the surface: a caller who
-// filtered could not see WHY a row was eligible, nor lay the hits on a
-// timeline, because `RecallResult` dropped the values.
-//
-// Host rows report the v48 COLUMNS — the same values the prefilter
-// range-scans — so that a row's stated bounds and its eligibility can
-// never contradict each other. The last test is the one that pins that
-// choice: it manufactures the divergence (columns NULL, JSON populated)
-// that a pre-v48 row or a ciphertext-payload follower apply leaves
-// behind, and asserts recall reports the column, because reporting the
-// JSON there would advertise an eligibility the filter denies.
+// Filtering was only half the surface — a caller who filtered could not
+// see WHY a row was eligible. Host rows report the v48 COLUMNS, the same
+// values the prefilter range-scans, so stated bounds and eligibility can
+// never contradict each other. `null_columns_report_none_*` is the test
+// that pins that choice.
 // =====================================================================
 
-/// The columns for one rid, as the census test reads them — the
-/// `event_time_columns.rs` shape, reused here to prove the hydrated
-/// values agree with the v48 columns rather than merely existing.
+/// The `event_time_columns.rs` census shape, reused to prove the
+/// hydrated values match the columns rather than merely existing.
 fn columns_for(db: &YantrikDB, rid: &str) -> (Option<f64>, Option<f64>) {
     db.conn()
         .query_row(
@@ -554,9 +547,6 @@ fn recall_result_carries_the_stamped_event_time() {
         "event_time_max must reach the caller"
     );
 
-    // The load-bearing half: hydrated values are sourced from the
-    // metadata JSON, so this asserts they agree with the mirrored v48
-    // columns — the invariant that makes that sourcing choice safe.
     assert_eq!(
         (hit.event_time_min, hit.event_time_max),
         columns_for(&db, &rid),
@@ -622,14 +612,11 @@ fn filtered_recall_reports_the_bounds_that_made_each_row_eligible() {
     );
 }
 
-/// THE PIN FOR THE SOURCING CHOICE. A row can carry event-time metadata
-/// while its columns are NULL — a pre-v48 row not yet rewritten, or a
-/// follower apply whose payload was ciphertext. The prefilter reads the
-/// COLUMNS, so such a row is excluded from every bounded recall. If
-/// hydration re-extracted the bounds from the JSON instead, an
-/// unfiltered recall would hand back bounds advertising an eligibility
-/// the filter denies — a result that contradicts the engine's own
-/// answer to "show me what happened then".
+/// THE PIN FOR THE SOURCING CHOICE. A pre-v48 row, or a follower apply
+/// with a ciphertext payload, leaves NULL columns beside populated JSON.
+/// The prefilter reads the COLUMNS, so the row is excluded from every
+/// bounded recall — reporting its JSON bounds would advertise an
+/// eligibility the filter denies.
 #[test]
 fn null_columns_report_none_even_when_the_metadata_json_still_has_bounds() {
     let db = YantrikDB::new(":memory:", 8).unwrap();
@@ -686,11 +673,9 @@ fn null_columns_report_none_even_when_the_metadata_json_still_has_bounds() {
     );
 }
 
-/// `recall_as_of` rolls a corrected record back to its pre-correction
-/// text and metadata. The bounds must roll back WITH it: recall stamps
-/// them from the live row, and `correct()` re-derives event time, so a
-/// result left holding the current bounds would pair yesterday's
-/// metadata with today's dates — the row contradicting itself.
+/// The bounds must roll back with the metadata: recall stamps them from
+/// the live row and `correct()` re-derives event time, so leaving them
+/// pairs yesterday's metadata with today's dates.
 #[test]
 fn as_of_rollback_moves_event_time_back_with_the_metadata() {
     let db = YantrikDB::new(":memory:", 8).unwrap();

--- a/crates/yantrikdb-python/src/py_types.rs
+++ b/crates/yantrikdb-python/src/py_types.rs
@@ -105,6 +105,13 @@ pub fn recall_result_to_dict(
         }
         None => dict.set_item("pack", py.None())?,
     }
+    // #181: v48 valid time — when the described events happened, as opposed
+    // to `created_at` (when the row was written). None when the record
+    // carries no event time. Lets a caller who filtered with
+    // event_after/event_before see WHY a row was eligible, or lay the hits
+    // out on a timeline.
+    dict.set_item("event_time_min", r.event_time_min)?;
+    dict.set_item("event_time_max", r.event_time_max)?;
 
     Ok(dict.into())
 }


### PR DESCRIPTION
Closes #181.

This adds `event_time_min: Option<f64>` / `event_time_max: Option<f64>` to `RecallResult`, populated during hydration, and passes them through the Python binding as optional dict fields.

## Tests

Five cases in `engine/tests/event_time_recall.rs`.

## Verification

- `cargo test -p yantrikdb --lib` — **2182 passed, 0 failed** (the issue's acceptance gate)
- `cargo test --workspace --exclude yantrikdb-python` — green
- `cargo check -p yantrikdb --all-features --tests` — covers the feature-gated profiling twin
- `cargo clippy --all-targets --all-features --workspace --exclude yantrikdb-python -- --cap-lints warn` — exit 0
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)